### PR TITLE
docs: publish 50-task local-model benchmark + recommendation table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Until we tag `1.0.0`, minor-version bumps may contain breaking changes; patch
 bumps are non-breaking bugfixes only.
 
+## [0.8.2] - 2026-05-31
+
+### Documentation — local-model benchmark & recommendations
+
+Published a benchmark table in the README, backed by the objective 50-task
+daily-driver battery run across the local-model lineup at 24k context /
+`--parallel 1` on a 16 GB GPU (RTX 5060 Ti). No code changes — this republishes
+the README on crates.io with the recommendation table.
+
+- **Benchmark table** under `## Recommended models`: `qwen3.6-35b-a3b@q3_k_xl`
+  92% (best accuracy / default), `qwen3.5-4b` 90% in 8 min (best value, fits
+  8 GB), `qwen3.5-9b` 88%, `gpt-oss-20b` 86% (fastest, MXFP4-resident),
+  `granite-4.1-8b` 78%. The dense `qwen3.6-27b` is the slow "precision" tier.
+- **16 GB pin corrected** from `q4_k_xl` to `q3_k_xl` — q3 fits VRAM and finishes
+  more tasks within the per-task timeout, while q4 spills to RAM and loses tasks.
+- **Template-compatibility note** — `gemma-4-26b` / `qwen3-coder-30b` stock GGUFs
+  fail tool-calling in LM Studio (HTTP 400); use `lmstudio-community` repacks.
+- Full per-model rows, Findings, and a scouted "Claudette Certified" candidate
+  queue land under `runs/eval-2026-05-29/battery/` (`MODEL-COMPARISON.md`,
+  `CANDIDATES.md`) along with the reusable per-model eval driver.
+
 ## [0.8.1] - 2026-05-30
 
 ### Fixed — daily-driver tool actuation on the local q3 brain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/README.md
+++ b/README.md
@@ -121,7 +121,27 @@ The defaults (`qwen3.5:4b` brain / `qwen3-coder:30b` coder) are tuned for **broa
 | 16 GB VRAM / 32 GB RAM | **`qwen3.6-35b-a3b`** | Best overall by a wide margin. MoE — 35 B total / ~3 B active per token, needs CPU-MoE offload. ~24 t/s baseline / ~43 t/s with MTP on RTX 5060 Ti. |
 | 24 GB+ VRAM | **`qwen3.6-35b-a3b`** (full GPU) | Top quality, full GPU residency. |
 
-`qwen3.6-35b-a3b` is currently distributed via [LM Studio](https://lmstudio.ai/) (Unsloth GGUF) rather than packaged on Ollama. Flip the backend with `CLAUDETTE_OPENAI_COMPAT=1` — see [`docs/power-user.md`](docs/power-user.md#lm-studio-or-any-openai-compatible-server). When multiple quants are on disk, pin one explicitly (`CLAUDETTE_MODEL=qwen3.6-35b-a3b@q4_k_xl`) — LM Studio picks the smallest match otherwise.
+`qwen3.6-35b-a3b` is currently distributed via [LM Studio](https://lmstudio.ai/) (Unsloth GGUF) rather than packaged on Ollama. Flip the backend with `CLAUDETTE_OPENAI_COMPAT=1` — see [`docs/power-user.md`](docs/power-user.md#lm-studio-or-any-openai-compatible-server). When multiple quants are on disk, pin one explicitly (`CLAUDETTE_MODEL=qwen3.6-35b-a3b@q3_k_xl`) — LM Studio picks the smallest match otherwise. On 16 GB, prefer **`q3_k_xl`** over `q4_k_xl`: the benchmark below shows q3 fits VRAM and finishes more tasks, while q4 spills to RAM and *loses* tasks to timeouts.
+
+### Benchmark — 50-task daily-driver battery
+
+Every brain runs the *same* objective 50-task battery — 11 languages/surfaces (Rust, Python, JS, TS, Go, shell, HTML, CSS, SQL, a large real repo, git) × 12 task types (bugfix, add-feature, multi-file, refactor, create-file, explain, locate, enumerate, run-tests, debug-error, git-workflow, answer-from-codebase) — through claudette's real tool loop, then an automated verifier (build/test passes, the file is correct, or ground-truth tokens appear in the transcript). **No self-grading.** All runs: **24k context, `--parallel 1`, RTX 5060 Ti 16 GB** (2026-05-30).
+
+| Brain | Quant | VRAM | Pass @ 50 | Wall | Best for |
+|-------|-------|------|-----------|------|----------|
+| **`qwen3.6-35b-a3b`** | `q3_k_xl` | 16 GB (MoE offload) | **92%** | 38 min | **Best accuracy** — the daily-driver default |
+| `qwen3.5-4b` | Q4–Q8 | **8 GB** | 90% | **8 min** | **Best value** — runs on almost any GPU |
+| `qwen3.5-9b` | Q4 | 11 GB | 88% | 16 min | Solid mid-tier |
+| `qwen3.6-35b-a3b` | `q4_k_xl` | 24 GB (spills at 16) | 88% | 48 min | More precision, but RAM-bound on 16 GB → timeouts |
+| `gpt-oss-20b` | MXFP4 | 13 GB (resident) | 86% | **5 min** | **Fastest** — fully in-VRAM, coolest |
+| `granite-4.1-8b` | Q4–Q6 | 9 GB | 78% | 17 min | Reliable tool-calling, weaker raw coder |
+| `qwen3.6-27b` (dense) | Q3 | 14 GB | ≈86% \* | ~67 s/task | **Precision tier** — accurate but slow; not interactive |
+
+<sub>\* `qwen3.6-27b` stopped at 37/50 (86% of scored). Dense → every parameter active per token → ~67 s/task and it loses generation-heavy tasks to the timeout, so it's a one-shot/batch "precision" pick, not an interactive driver.</sub>
+
+**Reading the table:** *fitting in VRAM matters more than parameter count.* `q3_k_xl` (fits 16 GB) beats `q4_k_xl` (spills to RAM → ~20% slower → loses tasks to timeouts) despite lower precision — so `q3_k_xl` is the 16 GB pick. The small models punch far above their weight: a 4 B model hits 90% in 8 minutes. MoE brains keep the GPU cool (~55 °C); the dense `qwen3.6-27b` is the slow precision tier, not for interactive use.
+
+> **Didn't make the table — config/fit issues, *not* quality:** `nemotron-3-nano-omni-30b` (reasoning MoE) loads and reasons well but runs ~73 s/task at 16 GB (RAM spill + thinking blocks) — too slow. `glm-4.7-flash` is promising (SWE-bench 59.2) but its stock GGUF didn't emit tool calls in our LM Studio runtime — needs a post-2026-01 quant + corrected template. `gemma-4-26b` and `qwen3-coder-30b` stock GGUFs return HTTP 400 on tool calls in LM Studio's template engine. **Lesson: pull `lmstudio-community`/`unsloth` GGUFs and validate one real tool call before trusting a model — chat-template compatibility is the #1 local-model failure mode.** Full per-task data + reasoning notes: [`runs/eval-2026-05-29/battery/MODEL-COMPARISON.md`](runs/eval-2026-05-29/battery/MODEL-COMPARISON.md).
 
 ### Codet sidecar coder
 

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/runs/eval-2026-05-29/battery/CANDIDATES.md
+++ b/runs/eval-2026-05-29/battery/CANDIDATES.md
@@ -1,0 +1,125 @@
+# Claudette-Certified — candidate models to battery-test (scouted 2026-05-30)
+
+Sourced from 7 parallel web-research agents. Selection priorities: strong coding,
+**reliable tool/function-calling**, **MoE preferred** (cooler GPU per
+[thermal standard] — dense mid/large models run hot), GGUF with a **working LM Studio
+chat template** (broken jinja `| safe` / tool-role templates silently kill the tool loop),
+fits ~16 GB VRAM @ 24k ctx (also note other tiers). Recency favored (2025–2026).
+
+> Status: collecting agent results. Synthesize + dedupe + rank when all 7 are in.
+
+---
+
+## Mistral family  *(agent 4 — done)*
+**Caveat:** every Mistral model that fits 16 GB is **DENSE → thermally hot**; the MoE
+Mistrals (Small 4 119B, Large 3 675B) are far too big for 16 GB. So the MoE/cool
+preference can't be met in this family at this tier.
+
+| Model | Arch | Fit @16GB/24k | Coding | Tool-calling | Template risk | Verdict |
+|---|---|---|---|---|---|---|
+| **Devstral Small 2** (24B-2512) | dense 24B | tight — IQ3 only (quant-sensitive; cliff <2.3bpw) | **68% SWE-bench** (best 24B agentic) | purpose-built code-agent (powers Vibe CLI) | ⚠ **stock GGUF template broken for tool-calls** (role-alternation errors; needs unsloth fix / pinned `--chat-template`, disable `--jinja`) | top capability, but dense+template risk; certify at IQ3 + fixed template |
+| **Mistral Small 3.2** (24B-2506) | dense 24B | best fit — Q3_K_XL clean | all-rounder (no headline SWE) | **most proven/stable tool-caller** in family | early GGUFs buggy; unsloth/bartowski builds fixed | safest reliable default baseline |
+| **Ministral 3 14B** (2512) | dense 14B | **comfortable Q4_K_M + 24k headroom** | mid (reasoning variant exists) | native FC + JSON | verify Mistral-3 tool-role template | best clean 16GB fit; pragmatic pick |
+| Codestral 2 (22B, Apr 2026, Apache-2.0) | dense 22B | IQ3/Q3 | elite **FIM/completion** (~95% FIM, 86% HumanEval) | ⚠ **completion tool, NOT agentic** | n/a | mismatch — use as autocomplete sidecar, not the loop |
+| Ministral 3 8B (2512) | dense 8B | trivial (~12GB) | modest (8B) | native FC + JSON | Mistral-3 template caveat | budget/router tier, fast smoke model |
+
+**Disqualified for 16GB:** Mistral Small 4 (119B MoE, 6.5–22B active — needs ≥48GB; IQ2 = 31GB), Devstral 2 Large (123B dense, 72.2% SWE-bench).
+**Universal Mistral gotcha:** Tekken-tokenizer + Jinja templates repeatedly ship broken tool-call round-trips in 3rd-party GGUF converts → always pull unsloth/bartowski/official tool-fixed builds and validate one full tool-call→result→assistant turn before certifying.
+**Top Mistral picks for our battery:** Devstral Small 2 (max capability, dense/hot), Mistral Small 3.2 (safest), Ministral 3 14B (best fit). All dense → flag thermal.
+
+---
+
+## Recent MoE coders  *(agent 1 — done)*
+> Note: 30B-total MoEs need llama.cpp expert-offload (`-ncmoe` / `--override-tensor experts=CPU`) to fit Q4+24k on 16 GB; only gpt-oss-20b is truly resident.
+
+| Model | Arch (MoE) | Fit @16GB/24k | Coding | Tool-calling | Template | Verdict |
+|---|---|---|---|---|---|---|
+| **GLM-4.7-Flash** (Z.ai, Jan 2026) | 30B / ~3B act | Q3/Q4_K_XL + offload (Q4_K_M ~10GB per agent 6) | **SWE 59.2**, τ² 79.5 (multi-step tools) | tuned for agents (Cline/Goose/Zed) | ⚠ pre-21-Jan quants loop/break tools; **use post-21-Jan + `--jinja`** | freshest small-MoE agentic coder; top pick |
+| **gpt-oss-20b** (OpenAI, Aug 2025) | 21B / 3.6B act, MXFP4 | **~12GB, RESIDENT on 16GB** (best fit, coolest) | LCB v6 **70** | native FC, TauBench-trained | ⚠ **Harmony format**; LM Studio has no jinja editor for it; use unsloth fixed GGUF, low/med effort | cleanest resident MoE — **testing now** |
+| **Qwen3-Coder-30B-A3B** (Jul 2025) | 30B / 3.3B act | Q3_K_M 14.7 / Q4_K_XL 17.7 + offload | **SWE 51.6** | purpose-built agentic; XML tool format | ⚠ the canonical `\| safe` offender — **FIXED in post-Aug-2025 unsloth/v16 template** + `--jinja` | the model we skipped IS usable with a fixed GGUF — retry candidate |
+| Qwen3.6-35B-A3B (Apr 2026) | 35B / 3B act | Q3/IQ + offload | vendor 73.4 SWE / repro ~53/100 | `qwen3_coder` parser | Qwen `\|safe` lineage; current GGUF + `--jinja` | our in-house default; repro SWE trails Qwen3-Coder-30B & 3.5 |
+| Qwen3-Coder-Next 80B-A3B (2026) | 80B / 3B act | ❌ ~49.6GB — needs 48GB+ | **>70 SWE**, best per active-param | trained for tool use + error recovery | Qwen `\|safe` lineage | ceiling brain for 32GB+/workstation only |
+
+**Excluded (too big for ≤32GB local):** GLM-4.5-Air 106B, DeepSeek V3.2/V4, Kimi-K2.x (1T), Ring 2.6 (1T), GLM-4.7 full 355B.
+
+---
+
+## Phi / Granite / Gemma  *(agent 5 — done)*
+**Verdict: IBM Granite is the category winner** (only family purpose-built for tool calls w/ native llama.cpp-parsed templates). Phi-4 14B does NOT support function calling (only Phi-4-mini). Gemma 3/4 tool-calling is broken in stock GGUF runtimes.
+
+| Model | Arch | Fit @16GB/24k | Coding | Tool-calling | Template | Verdict |
+|---|---|---|---|---|---|---|
+| **Granite 4.1-8B-Instruct** (IBM, Apr 2026) | dense 8B | **easy — Q4 ~5GB, huge headroom** | strong for 8B (30B sib HumanEval ~89) | **BFCL v3 68.3** (best in cat) | native tool tokens, clean LM Studio/Ollama | **category pick** — dense, Apache-2.0, reliable tools, low VRAM |
+| Granite 4.0-H-Tiny (7B-A1B MoE) | hybrid Mamba MoE | roomy | lower (1B active) | "fast function calling" building block | ⚠ hybrid-Mamba needs recent llama.cpp build | best cool/low-VRAM MoE for high-volume simple loops |
+| Granite 4.0-H-Small (32B-A9B MoE) | hybrid Mamba MoE | tight/marginal (~18-19GB) → 24GB tier | workhorse | BFCL 64.7 | hybrid-Mamba runtime caveat | true MoE for 24GB tier |
+| Phi-4-mini-instruct (3.8B, Feb 2025) | dense 3.8B | trivial (~2.2GB Q4) | HumanEval 74 | only Phi w/ FC; **shaky w/ many tools** | `\|tool\|` JSON in system prompt; needs recent llama.cpp | tiny fallback, not primary |
+| Gemma 4 26B-A4B (Google, Apr 2026) | MoE 26B / 3.8B act | marginal (26B wts) → 24GB | competitive general; not code-specialized | ⚠ **broken in stock Ollama/GGUF** (calls leak to content) | needs **patched llama.cpp** (PR #21326/#21343) | what we run — keep only on patched build; weak as pure agent brain |
+
+**DQ:** Phi-4 14B (no FC, 16K ctx), no Phi-5 exists, Granite-Code superseded by 4.x.
+
+---
+
+## GLM / Llama / Cohere / Kimi / MiniMax / Nemotron  *(agent 6 — done)*
+**Headline: GLM-4.7-Flash is the only model here that's both top-tier agentic AND fits 16GB.** (Corroborates agent 1.)
+
+| Model | Arch | Fit @16GB/24k | Coding | Tool-calling | Verdict |
+|---|---|---|---|---|---|
+| **GLM-4.7-Flash** (Jan 2026) | 30B/3B MoE | **Q4_K_M ~10GB, comfortable** | **SWE 59.2**, LCB 84.9 | **τ² 79.5**, Claude-Code/Cline-validated | category + overall pick; post-21-Jan quant + `--jinja` + sigmoid-fixed build |
+| Nemotron-Nano-12B-v2 (NVIDIA) | hybrid Mamba dense ~12B | easy Q4/Q5 | solid mid-tier | supported (vLLM parser proven) | lightweight non-MoE fallback; confirm `nemotron_h` runtime support |
+| MiniMax-M2.7 | 230B/10B MoE | ❌ 24GB+ w/ offload | top agentic coder | native in LM Studio ≥0.3.31 | 24GB+ tier |
+| GLM-4.5-Air | 106B/12B MoE | ❌ 24GB+ | ~59.8 | agentic | superseded by 4.7-Flash for 16GB |
+| Llama 3.3 70B | dense 70B | ❌ 48GB+ | strong | mature JSON FC, best-supported | great brain if ≥48GB |
+
+**DQ:** Kimi-K2.6 (1T, datacenter), Cohere Command-A 111B (thin GGUF), Seed-Coder-8B (SWE only 19.2, not agentic), Llama 4 Scout 109B (24GB+, weaker coder).
+
+---
+
+## Small dense ≤14B (fast/low-VRAM tier)  *(agent 2 — done)*
+**Winner: the Qwen3.5 small dense series** (Mar 2026) — exactly our reference family.
+
+| Model | Arch | Fit | Coding | Tool-calling | Verdict |
+|---|---|---|---|---|---|
+| **Qwen3.5-9B** | dense 9B | Q4_K_XL ~6GB (10-12GB comfy) | **LCB 82.7** | **BFCL-v4 66, τ² 79.1** | top pick — beats Qwen3-Next-80B on FC; **we ran it: 88%** |
+| **Qwen3.5-4B** | dense 4B | Q4 2.7GB / Q8 4.3GB (8GB!) | IFEval ~90 | best 4B caller | fast/8GB pick — **we're running it now** |
+| Ministral 3 8B (Dec 2025) | dense 8B | ~5GB Q4 | LCB ~62 | native FC+JSON | non-Qwen control |
+| Phi-4 14B | dense 14B | ~9GB Q4 (tight) | HumanEval 83 | only mini has FC; shaky | reasoner not tool-caller |
+| Granite 4.1/3.3 8B | dense 8B | ~5GB | mid | BFCL 68 | enterprise-clean fallback |
+> **Critical for whole Qwen3.5/3.6 gen:** stock GGUF templates broken under LM Studio (`\|safe`/`\|items`/"Unknown test: sequence") — **use `lmstudio-community` repack or froggeric patched template; needs LM Studio ≥0.4.7.**
+
+## Qwen + DeepSeek ecosystems  *(agent 3 — done)*
+**Bottom line: our incumbent Qwen3.6-35B-A3B is still the strongest 16GB-class brain; new releases sit beside it, not above.**
+| Model | Arch | Fit @16GB | Coding | Notes |
+|---|---|---|---|---|
+| Qwen3.6-35B-A3B (incumbent) | 35B/3B MoE | Q3 13-16GB | **SWE 73.4, LCB 80.4** | keep as primary; thinking-mode ON by default (set `enable_thinking:false`) |
+| **Qwen3-Coder-30B-A3B** | 30B/3.3B MoE | Q3_K_M ~14.7GB | SWE 51.6 | **`\|safe` bug FIXED post-Aug-2025** unsloth/lmstudio-community + `--jinja`; pilot as coding specialist. ⚠ also a missing-`properties` 500-crash — ensure tool schemas emit `properties:{}` |
+| DeepSeek-R1-0528-Qwen3-8B | dense 8B | ~5GB (trivial) | reasoning SOTA-8B | **BFCL 93** caller; `<think>` overhead; low-VRAM fallback |
+| Qwen3.6-27B (dense) | dense 27B | Q3_K_M ~13.6GB | **SWE 77.2** | hotter (dense); we partial-tested it |
+| DeepSeek-Coder-V2-Lite | 16B/2.4B MoE | easy | HumanEval 90 | cool but weak tool format; Chinese-drift; flash-attn OFF |
+> Ruled out (too big): Qwen3-Coder-Next 80B (~21GB+), DeepSeek-V3.2/V4 (datacenter), QwQ-32B (loops — superseded).
+
+## Tool-calling reliability + template playbook  *(agent 7 — done; the make-or-break axis)*
+**Real-world multi-tool eval (jdhodges 2026, 13 models):** Qwen3.5-4B **97.5%** (best!), GLM-4.7-Flash 95%, Nemotron-Nano-4B 95%, Mistral-Nemo-12B 92.5%. **BFCL-v3 leader: GLM-4.5 ~77%** (note: old v1/v2 90%+ scores are NOT comparable to v3 multi-turn).
+- **The `\|safe` fix is a 30-second LM Studio edit:** Prompt Template editor → delete ` \| safe` (2 spots in Qwen3-Coder). Or just pull a fixed publisher.
+- **Publisher order for tool templates: `lmstudio-community` → `unsloth` → `bartowski` → froggeric-rescue.** Avoid stock Mistral/Step/KAT GGUFs for tools (no native jinja / broken). xLAM & Hammer ship their own tool-ready GGUFs.
+- **llama.cpp escape hatch:** `--jinja --chat-template-file <fixed.jinja>`. **Keep quant ≥Q5 for small dense FC models** (JSON-arg fidelity degrades faster than prose; don't push MoE below ~IQ3).
+- Specialized tool-routers: Salesforce **xLAM-2-3b/8b-fc-r**, MadeAgents **Hammer2.1-7b** (vendor GGUFs, narrow schemas).
+
+---
+
+# 🏁 CERTIFICATION QUEUE — next models to run on the 50-task battery
+All confirmed to fit 16 GB @ 24k with a known working-template path. Priority order:
+
+| Pri | Model | Why | Template action |
+|---|---|---|---|
+| 1 | **gpt-oss-20b** | MoE, only fully-resident 16GB fit, coolest, LCB 70 | use `lms get openai/gpt-oss-20b`; verify Harmony parse — **running now** |
+| 2 | **GLM-4.7-Flash** | strongest new agentic coder, MoE/cool ~10GB, SWE 59.2/τ² 79.5, 95% real-world | post-21-Jan quant + `--jinja` + sigmoid-fixed build |
+| 3 | **Qwen3-Coder-30B-A3B** | resolves our earlier SKIP — coding specialist, MoE | lmstudio-community GGUF (or delete `\|safe`) + `--jinja`; emit `properties:{}` |
+| 4 | **Granite 4.1-8B** | best small dense tool-caller, BFCL 68, clean templates, tiny VRAM | native — low risk |
+| 5 | **Nemotron-Nano-12B-v2** | reliable hybrid-dense, 95% real-world FC | confirm `nemotron_h` runtime support |
+| 6 | **Ministral 3 8B** or **Mistral-Nemo-12B** | non-Qwen control; Nemo = best multi-turn sequencer | **unsloth** GGUF only (never stock Mistral) |
+| 7 | **DeepSeek-R1-0528-Qwen3-8B** | low-VRAM reasoning fallback, BFCL 93 | unsloth post-Jun-2025 + `--jinja` |
+
+**Already battery-tested this sweep:** qwen3.6-35b-a3b q3 **92%** / q4 88%, qwen3.6-27b dense (partial, thermal), qwen3.5-9b **88%**, qwen3.5-4b (in progress). Big-tier (24GB+) watch list: MiniMax-M2.7, GLM-4.5-Air, Qwen3-Coder-Next 80B, Llama 3.3 70B, Kimi-K2.6.
+
+**MoE/thermal note** (per thermal standard): GLM-4.7-Flash, gpt-oss-20b, Qwen3-Coder-30B, Granite-4.0-H, DeepSeek-Coder-V2-Lite are MoE → cool. Devstral/Mistral-Small/Ministral/Qwen3.6-27B are dense → run hotter; Granite-4.1-8B & Nemotron-12B are small-dense (mild).
+

--- a/runs/eval-2026-05-29/battery/MODEL-COMPARISON.md
+++ b/runs/eval-2026-05-29/battery/MODEL-COMPARISON.md
@@ -1,0 +1,149 @@
+# Claudette local-model comparison — 50-task daily-driver battery
+
+**Goal:** measure how well different local models drive claudette as a coding agent,
+on the *same* objective 50-task battery, so we can recommend models to users and
+show the project is rigorously benchmarked.
+
+**Harness:** claudette **v0.8.1** (the cargo-installed binary on PATH — see WDAC note
+below), daily-driver config (`CLAUDETTE_AUTO_APPROVE=1`, per-task
+`CLAUDETTE_WORKSPACE`, OpenAI-compat → LM Studio @ `localhost:1234`). Every task runs
+the real one-shot tool loop against a fresh fixture copy, then an **objective**
+verifier (build/test passes, file exists with correct behavior, or transcript
+contains ground-truth tokens). No self-grading.
+
+**Hardware:** RTX 5060 Ti 16 GB (models > 16 GB spill to system RAM).
+
+**LM Studio load settings (held constant):** **context = 24 576 (24k)** and
+**`--parallel 1`** for every model. `--parallel 1` is essential — with N>1,
+llama.cpp/LM Studio splits the context window into N slots (parallel 4 @ 24k ≈ 6k
+usable per request), which silently starves the long-context bigrepo tasks. All
+models are loaded identically for a fair comparison.
+
+**Coverage:** 11 languages/surfaces (Rust, Python, JS, TS, Go, shell, HTML, CSS,
+SQL, a large real-repo = claudette's own `src`+`docs`, git) × 12 task types
+(bugfix, add-feature, multi-file, refactor, create-file, explain, locate,
+enumerate, run-tests, debug-error, git-workflow, answer-from-codebase).
+
+**Reasoning capture:** each model's run is recorded with
+`lms log stream --source model --stats` → `~/claudette-eval-captures/<id>.stream.log`,
+so we can inspect *which models reason correctly* vs. flail, not just the score.
+
+Reproduce one model:
+```
+bash runs/eval-2026-05-29/battery/run_model_eval.sh <model-key> <identifier> 24576
+```
+
+---
+
+## Lineup (from `lms ls`)
+
+| # | Model (identifier) | LM Studio key | Params | Arch | Size | Status |
+|---|---|---|---|---|---|---|
+| 0 | q3-35b *(reference)* | `qwen3.6-35b-a3b@q3_k_xl` | 35B-A3B MoE | qwen35moe | 18.6 GB | baseline @24k p1 |
+| 1 | q4-35b | `qwen3.6-35b-a3b@q4_k_xl` | 35B-A3B MoE | qwen35moe | 24.2 GB | pending |
+| 2 | qwen3.6-27b (dense) | `qwen3.6-27b` | 27B dense | qwen35 | 14.2 GB | pending |
+| 3 | qwen3.5-9b | `qwen3.5-9b` | 9B dense | qwen35 | 11.4 GB | pending |
+| 4 | qwen3.5-4b | `qwen3.5-4b` | 4B dense | qwen35 | 7.3 GB | pending |
+| — | ~~coder-30b~~ | `qwen3-coder-30b-a3b-instruct` | 30B-A3B MoE | qwen3moe | 17.7 GB | **SKIPPED** (broken template) |
+| 5 | gpt-oss-20b | `openai/gpt-oss-20b` | 20B | gpt-oss | 12.1 GB | pending |
+| 6 | nemotron-omni-reasoning | `nvidia-nemotron-3-nano-omni-30b-a3b-reasoning` | 30B-A3B MoE | nemotron_h_moe | 24.9 GB | pending |
+| 7 | gemma-4-26b | `gemma-4-26b-a4b-it` | 26B-A4B | gemma4 | 19.2 GB | pending (crash risk) |
+
+---
+
+## Results
+
+| Model | ctx | parallel | PASS/50 | % | total wall | slowest task | notes |
+|---|---|---|---|---|---|---|---|
+| q3-35b *(ref, 2026-05-29)* | 32k | 1 | 44/50 | **88.0%** | ~41 min | I3 240s (timeout) | the daily-driver baseline |
+| q3-35b *(re-baseline)* | 24k | 1 | 46/50 | **92.0%** | 37.9 min | I3 191s (FAIL) | ✓ ≥88% ref — 24k holds. Crisp, correct diagnoses; follows repo_map→grep→read→run_tests workflow; verifies via tests. Fails: A4 incomplete refactor (missed a call site — under-enumeration, not bad logic), I1/I3 bigrepo enumerate+deep-locate weak spots, C4 correct-but-timed-out (EC=124) |
+| q4-35b | 24k | 1 | 44/50 | **88.0%** | 48.3 min | I3 240s (timeout) | Reasoning quality ≈ q3, but **24.2 GB spills to RAM on the 16 GB GPU → ~20% slower → timeouts**. create-file only 1/4: B4 artifacts-correct-but-timed-out, C4+F2 didn't finish in time. Real miss: A5 (applied edit, skipped `cargo test` verify). I1/I3 bigrepo weak spots persist. **Takeaway: higher precision doesn't help here — q3 (fits VRAM, faster) completes more within the timeout.** |
+| qwen3.6-27b (dense) | 24k | 1 | *32/37* **(86% of scored, stopped at 37/50)** | — | ~67 s/task | A4 151s | **Precision tier, not interactive.** Re-run to near-completion after the thermal concern was walked back (inference airflow keeps the coupled NVMe cool — only idle-GPU+download spikes it). **Accurate on what it finishes — bugfix 6/6, refactor 4/4, multi-file 4/4, rust 7/7, locate 2/2** — but **dense → ~67 s/task** (4–8× the A3B MoE) and **create-file 1/4**: loses generation-heavy tasks to the 150s wall (B4/C4/H2 timeouts, F2 correct-but-timed-out) + one real miss (C7). Highest SWE-bench in the Qwen line per scouts (77.2). **Use where correctness-per-attempt > speed (one-shot hard problems, batch jobs); not an interactive daily driver.** |
+| qwen3.5-9b | 24k | 1 | 44/50 | **88.0%** | **15.7 min** | I3 108s | **Fastest by far — 2.4× q3, ZERO timeouts**, fits 11.4 GB VRAM, runs cool (GPU ~60°C). Excellent for a 9B. Failure mode is the inverse of the big models — *no throughput misses, pure correctness misses* on the hardest tasks: enumerate 1/3 (under-counts — I6 0/7 CLI modes, I1 2/6 vars), + two real logic errors (E1 left the buggy line; H4 wrong SQL column). **Best "fast / low-VRAM" pick.** |
+| qwen3.5-4b | 24k | 1 | 45/50 | **90.0%** | **7.9 min** | C4 22s | **Astonishing for a 4B / 7.3 GB** — beats the 9b & q4, nearly matches the q3 champ, at **4.8× q3 speed**, ZERO timeouts, **create-file 4/4** (fast enough to finish what bigger models time out on). Fits **8 GB VRAM**. Real misses only on the hardest tasks: C1 (js bugfix), D4 (ts multi-file — missed a field), I1/I3/I8 (bigrepo enumerate/locate/answer). **The universal-access pick — runs on almost any GPU.** |
+| gpt-oss-20b | 24k | 1 | 43/50 | **86.0%** | **5.3 min** | B4 29s | **Fastest run of the whole sweep** — MoE/MXFP4, fits **16 GB RESIDENT**, coolest load. **Harmony tool-calling works fine via LM Studio** (the scout caveat only bites raw llama.cpp). ZERO timeouts. Weakest on the long-context bigrepo set (4/8: I1/I3/I6/I7) + a SQL-dialect slip (H3: MySQL `AUTO_INCREMENT` in SQLite). Solid on standard single-file tasks (py 7/7, rust 7/7). **Best speed/efficiency pick.** |
+| nemotron-omni-r (MoE, reasoning) | 24k | 1 | **n/a — too slow** | — | ~73 s/task | A2 145s | **Reasons correctly (3/3 PASS at stop) but impractical at 24k on 16 GB.** 24.9 GB spills to RAM → prompt-processing dominates each turn, and reasoning thinking-blocks compound it → **~73 s/task avg** (A2 hit 145s, a hair under the 150s wall) vs 9–30 s for the fast models. Projected ~60–80 min with heavy timeouts on the long-context tasks. Stopped at 3/50 after re-running with the user's adjusted load config (still too slow). MoE, so the GPU stays cool — the bottleneck is **RAM-spill + reasoning latency, not heat**. **Verdict: needs a smaller quant or lower context to be a viable daily driver here.** |
+| gemma-4-26b (MoE) | 24k | 1 | **TEMPLATE-BLOCKED** | — | — | — | **Loaded fine** (19.2 GB, 24k/p1) but **stock GGUF chat template can't render tool requests in LM Studio** → HTTP 400 `"Cannot call something that is not a function: got UndefinedValue"`. Smoke-gated out before the full run (same class as coder-30b, different jinja bug). **Not a quality result.** Fix = `lmstudio-community` GGUF (LM Studio's own error message suggests this). MoE, so would run cool if templated correctly. |
+| granite-4.1-8b (dense) | 24k | 1 | 39/50 | **78.0%** | 17.2 min | B2 161s | **Tool-calls reliably** (clean native templates — the scout's selling point holds: git/multi-file/refactor all 4/4) but a **weaker coder**: bugfix 2/6, debug-error 2/4, sql 1/3. Misses are genuine code-quality errors (A1 over-eager signature change, D1 duplicate decl, F1 shell syntax, H4 wrong column), not tool failures. 9.35 GB, fast + cool. **Good for tool-heavy/agentic orchestration; below the qwen small models for raw bugfixing.** |
+| glm-4.7-flash (MoE) | 24k | 1 | **n/a — tool calls not rendering** | — | — | — | Loaded fine (13.78 GB resident, MoE/cool) but **narrates fixes in prose instead of emitting tool calls** → smoke A1 FAIL 102s (claudette loop-breaker fired). Tool schemas *were* sent (581 refs in capture), so it's a rendering/template issue: needs LM Studio runtime update + a post-21-Jan-2026 quant + corrected/`--jinja` template (sigmoid `scoring_func` fix). **Config issue, not a quality result** — to re-bench after fix. Scouts rate it highly (SWE 59.2, τ²-bench 79.5) when templated right. |
+
+---
+
+## Findings
+
+### Windows Application Control (WDAC) blocks the freshly-built binary
+On this machine, the locally-compiled `target/release/claudette.exe` is blocked by
+**Windows Application Control** ("An Application Control policy has blocked this
+file"), which pops a per-launch dialog and makes unattended runs fail in 0 s with
+`exit 126` (permission denied). The **cargo-installed `~/.cargo/bin/claudette.exe`**
+(same v0.8.1) is already approved and runs fine, so the harness defaults to the PATH
+binary (override via `CLAUDETTE_BIN`). It deliberately does **not** probe
+`target/release` (the probe itself triggers the popup). This is an environment quirk,
+not a claudette issue — but it's exactly what an end-user compiling from source on a
+locked-down Windows box would hit, so worth a docs note.
+
+### Chat-template compatibility is a hard gate (independent of model quality)
+**Two of the eight models never ran a single task** because their stock GGUF chat
+templates can't render tool schemas in LM Studio's (C++ minja) engine — HTTP 400
+before the model is even invoked:
+- **`qwen3-coder-30b-a3b-instruct`** → `Unknown StringValue filter: safe` (a Jinja
+  `| safe` filter minja doesn't implement). *(pre-skipped)*
+- **`gemma-4-26b-a4b-it`** → `Cannot call something that is not a function: got
+  UndefinedValue`. Loaded fine (19.2 GB, 24k/p1) — purely a template-render failure.
+Neither is a claudette bug or a model-quality result. **Both are fixable** via the
+`lmstudio-community` re-published GGUF (fixed templates) or a 30-second template
+override; LM Studio's own 400 message even points you to lmstudio-community. **This is
+the #1 local-model failure mode** — always pull `lmstudio-community → unsloth →
+bartowski` GGUFs and validate one real tool-call round-trip before trusting a model.
+(See `CANDIDATES.md` for the full template playbook + the froggeric rescue templates.)
+
+### `--parallel 1` matters
+Loading at the LM Studio default (`--parallel 4`) divides the 24k context into ~6k
+per slot, starving the long-context tasks. Always load with `--parallel 1` for
+single-agent use.
+
+### Heat is driven by dense-vs-MoE, NOT model size
+Sustained GPU temperature tracks **active parameters**, not file size: the A3B/A4B
+**MoE** models (q3/q4-35b-a3b, gpt-oss-20b, gemma-4-26b-a4b) run the GPU cool (~55 °C)
+even at 19–25 GB, while the **dense** qwen3.6-27b pins it at 96 %/72 °C — which is why
+that one run was halted for thermal management. Practical rule: prefer MoE for
+sustained local use; a big MoE is cooler than a mid-size dense model.
+
+### VRAM/offload at 24k decides throughput — and throughput decides the score
+On a 16 GB card, models >16 GB spill to system RAM at 24k and run ~20 % slower. That
+slowdown, not reasoning, is what cost the bigger models points: **q4-35b (24 GB) lost
+4 tasks purely to create-file/`generate_code` timeouts** that the same-family q3 (fits
+VRAM) finished. The single best predictor of "fits in the 150 s task budget" was **does
+it fit in VRAM**, not parameter count. gpt-oss-20b (MXFP4, ~13 GB, fully resident) was
+the fastest of all at 5.3 min.
+
+### Two distinct failure modes — and small models flip which one dominates
+- **Big models fail by timeout** (correct work that doesn't finish): q4 B4/C4/F2,
+  qwen3.6-27b B4/C4 — all create-file/generate_code that timed out, artifacts often
+  correct.
+- **Small models fail by correctness** (fast but wrong): qwen3.5-9b/4b and gpt-oss-20b
+  produced *zero* timeouts but made outright errors on the hardest tasks (E1 left a bug
+  in, H4/H3 SQL slips, D4 missed a field).
+- **Model-bound weak spots persist across the whole lineup:** the bigrepo
+  **enumerate** (I1/I6 — under-counting) and **deep-locate-with-conflicting-docs** (I3 —
+  trusting stale docs over source) tasks failed for nearly every model. These are the
+  real frontier, independent of size/speed.
+
+### The surprise: small models are the value play
+A 4B model (qwen3.5-4b, 7.3 GB) scored **90 % in 7.9 min** — beating the 9B and the
+q4-35b, nearly matching the q3-35b champ (92 %), and finishing **4.8× faster** with
+zero timeouts. For an air-gapped assistant meant to run on *anyone's* hardware, the
+fast small models (qwen3.5-4b/9b, gpt-oss-20b) are the headline: ~86–90 % at a fraction
+of the VRAM and wall-time of the 35B.
+
+### Recommendation tiers (for the README)
+- **Best accuracy:** `qwen3.6-35b-a3b @ q3_k_xl` — 92 %, fits 16 GB, MoE/cool; the
+  daily-driver default. (q4_k_xl spills to RAM and scores *lower* via timeouts — skip it.)
+- **Best all-round / value:** `qwen3.5-4b` — 90 % at 8 GB and 8 min; runs on almost
+  anything.
+- **Fastest / lowest overhead:** `gpt-oss-20b` — 86 %, fully VRAM-resident at ~13 GB,
+  5 min, coolest.
+- **Solid mid:** `qwen3.5-9b` — 88 %, 11 GB.
+- **Avoid for now:** q4_k_xl (RAM-bound), dense qwen3.6-27b (hot/slow), and any
+  stock-template model that 400s (gemma-4, coder-30b) until repacked.
+- **Pending:** nemotron-omni-r (reasoning MoE) — to be re-run after reconfiguration.

--- a/runs/eval-2026-05-29/battery/SCORES-gpt-oss-20b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-gpt-oss-20b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	5s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	10s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	3s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	9s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	5s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	5s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	4s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	4s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	6s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	5s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	29s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	4s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	5s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	5s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	FAIL	3s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	PASS	7s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	4s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS	9s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	6s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	6s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	4s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	4s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	2s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	7s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	5s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	4s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	FAIL	6s	EC=0	recall=na	FAIL — old name 'GetUserName' still present:\n/d/dev/claudette/runs/eval-2026-05-29/battery/work/E2/user.go:11:// GetUserName returns the user's full display name.
+E3	go	locate	PASS	2s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	8s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	4s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	8s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	6s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	5s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	6s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	7s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	6s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	FAIL	7s	EC=0	recall=na	FAIL — schema.sql invalid or products table not as required: ERR: OperationalError: near "AUTO_INCREMENT": syntax error 
+H4	sql	debug-error	PASS	6s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=3)
+I1	bigrepo	enumerate	FAIL	9s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	10s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	7s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	11s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	8s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	FAIL	21s	EC=0	recall=2/7	FAIL — only 2/7 CLI modes (need >=6; enumeration weak spot)
+I7	bigrepo	answer-codebase	FAIL	3s	EC=0	recall=na	FAIL — did not establish the no-telemetry / local-first answer
+I8	bigrepo	answer-codebase	PASS	5s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	5s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-granite41-8b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-granite41-8b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	FAIL	24s	EC=0	recall=na	FAIL — cargo test failed:\nerror[E0308]: mismatched types
+A2	rust	add-feature	PASS	30s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	9s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	121s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	40s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	35s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	FAIL	43s	EC=0	recall=na	FAIL — cargo build still failing:\nerror[E0425]: cannot find value `count` in this scope
+B1	python	bugfix	PASS	34s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	FAIL(TIMEOUT)	161s	EC=124	recall=na	FAIL — variance test failing (rc=1): Ran 1 test in 0.000s  FAILED (errors=1) 
+B3	python	multi-file	PASS	8s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	18s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	9s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	6s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	7s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	FAIL	12s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	PASS	22s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	6s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	FAIL	29s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`slugify('Hello World!') expected 'hello-world' but got '${a}'`);
+C5	js	multi-file	PASS	12s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	23s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	15s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	FAIL	17s	EC=0	recall=na	FAIL — node test.ts exited 1: SyntaxError: Identifier 'isValidEmail' has already been declared
+D2	ts	locate	PASS	4s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	20s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	6s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	8s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	12s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	4s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	21s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	FAIL	9s	EC=0	recall=na	FAIL — greet.sh exited 2: greet.sh: line 9: syntax error near unexpected token `do'
+F2	shell	create-file	PASS	13s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	16s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	11s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	16s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	10s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	FAIL	7s	EC=0	recall=na	FAIL — top_customer.sql did not produce a usable result: ERR: query returned no rows 
+H3	sql	create-file	PASS	13s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	FAIL	10s	EC=0	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.order_amount 
+I1	bigrepo	enumerate	FAIL	5s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	21s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	17s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	20s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	16s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	37s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	9s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	20s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	7s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	7s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	6s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	7s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-q3-35b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-q3-35b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	25s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	41s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	9s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	FAIL	49s	EC=0	recall=na	FAIL — an 'add(' call site still remains in src/lib.rs
+A5	rust	multi-file	PASS	54s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	40s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	23s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	41s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	25s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	52s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	131s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	29s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: defaultdict(<class 'int'>, {'h': 1, 'e': 1, 'l': 2, 'o': 1})
+B7	python	run-tests	PASS	15s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	21s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	26s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	32s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	14s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	33s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	26s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	20s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	59s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	10s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	47s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	33s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	27s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	33s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	11s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	22s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	22s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	67s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	24s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	51s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	17s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	59s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	67s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	70s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	36s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=3)
+I1	bigrepo	enumerate	FAIL	95s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	67s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	191s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	17s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	60s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	61s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	40s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	144s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	17s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	32s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	10s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	30s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-q4-35b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-q4-35b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	33s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	34s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	9s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	84s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	FAIL	32s	EC=0	recall=na	FAIL — cargo test failed:\n
+A6	rust	explain	PASS	32s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	48s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	74s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	37s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	47s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	40s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	28s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	42s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	43s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	66s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	14s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	FAIL(TIMEOUT)	151s	EC=124	recall=na	FAIL — slug.js was not created
+C5	js	multi-file	PASS	37s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	22s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	32s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	49s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	8s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	77s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	27s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	33s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	48s	EC=1	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	10s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	22s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	23s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	FAIL(TIMEOUT)	120s	EC=124	recall=na	FAIL — count.sh was not created in workdir
+F3	shell	explain	PASS	21s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	54s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	20s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	89s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	133s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	101s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	61s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=3)
+I1	bigrepo	enumerate	FAIL	91s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	97s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL(TIMEOUT)	240s	EC=124	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	21s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	94s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	143s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	46s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	121s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	37s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	21s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	11s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	25s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-4b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-4b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	11s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	15s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	2s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	14s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	7s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	8s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	13s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	19s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	17s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	8s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	19s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	7s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	6s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	6s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	FAIL	8s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	PASS	14s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	6s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS	22s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	5s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	9s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	6s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	11s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	3s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	FAIL	11s	EC=0	recall=na	FAIL — src/types.ts does not declare a 'role' field on User
+D6	ts	run-tests	PASS	7s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	7s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	12s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	2s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	7s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	7s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	10s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	5s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	13s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	6s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	14s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	13s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	11s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	11s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=2)
+I1	bigrepo	enumerate	FAIL	15s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	14s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	11s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	6s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	14s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	17s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	8s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	FAIL	5s	EC=0	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-9b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-9b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	12s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	14s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	3s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	19s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	13s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	9s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	7s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	12s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	8s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	12s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	36s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	17s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	8s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	6s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	23s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	21s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	6s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	FAIL	15s	EC=0	recall=na	FAIL — slug.js was not created
+C5	js	multi-file	PASS	5s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	9s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	11s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	22s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	4s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	15s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	10s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	FAIL	65s	EC=1	recall=na	FAIL — buggy line still present: 'if a < b { return a' (returns the smaller value)
+E2	go	refactor	PASS	17s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	6s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	11s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	17s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	12s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	10s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	26s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	7s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	11s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	13s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	15s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	FAIL	91s	EC=1	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.total 
+I1	bigrepo	enumerate	FAIL	32s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	25s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	108s	EC=1	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	16s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	21s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	FAIL	88s	EC=1	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I7	bigrepo	answer-codebase	PASS	12s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	12s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	2s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	2s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	2s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/analyze.sh
+++ b/runs/eval-2026-05-29/battery/analyze.sh
@@ -2,8 +2,9 @@
 # Summarize SCORES.tsv: aggregate + by-type + by-lang + failure list.
 set -u
 BAT="/d/dev/claudette/runs/eval-2026-05-29/battery"
-S="$BAT/SCORES.tsv"
-[ -f "$S" ] || { echo "no SCORES.tsv yet"; exit 0; }
+# Accepts an explicit scores file as $1, else honors BATTERY_TAG, else the default.
+S="${1:-$BAT/SCORES${BATTERY_TAG:+-$BATTERY_TAG}.tsv}"
+[ -f "$S" ] || { echo "no scores file: $S"; exit 0; }
 
 total=$(wc -l < "$S")
 pass=$(awk -F'\t' '$4=="PASS"{n++}END{print n+0}' "$S")
@@ -22,4 +23,4 @@ echo "==================== NON-PASS ====================="
 awk -F'\t' '$4!="PASS"{printf "%-4s %-8s %-16s %-14s %s  %s\n",$1,$2,$3,$4,$5,$8}' "$S"
 echo
 echo "==================== TIMING ======================="
-awk -F'\t' '{gsub(/s/,"",$5); s+=$5; if($5>mx){mx=$5;mxid=$1}} END{printf "total model wall: %ds (%.1f min)  slowest: %s @ %ds\n", s, s/60, mxid, mx}' "$S"
+awk -F'\t' '{e=$5; gsub(/s/,"",e); e+=0; s+=e; if(e>mx){mx=e;mxid=$1}} END{printf "total model wall: %ds (%.1f min)  slowest: %s @ %ds\n", s, s/60, mxid, mx}' "$S"

--- a/runs/eval-2026-05-29/battery/run_battery.sh
+++ b/runs/eval-2026-05-29/battery/run_battery.sh
@@ -5,19 +5,33 @@
 # usage: bash run_battery.sh [id-prefix]   (e.g. "A", "I", "B3" — empty = all)
 set -u
 BAT="/d/dev/claudette/runs/eval-2026-05-29/battery"
-BIN="/d/dev/claudette/target/release/claudette.exe"
-export CLAUDETTE_MODEL=qwen3.6-35b-a3b@q3_k_xl
-export CLAUDETTE_CODER_MODEL=qwen3.6-35b-a3b@q3_k_xl
+# Binary: default to the cargo-installed claudette on PATH. The freshly-built
+# target/release exe is blocked by Windows Application Control (WDAC) on this box
+# and pops a per-launch dialog; the PATH binary is already approved and is the
+# same v0.8.1 (it's what users `cargo install`). Override with CLAUDETTE_BIN.
+# NOTE: we deliberately do NOT probe target/release here — probing it triggers
+# the WDAC popup. Set CLAUDETTE_BIN explicitly if you want a specific build.
+BIN="${CLAUDETTE_BIN:-$(command -v claudette)}"
+# Model + context are overridable from the environment so the SAME battery can be
+# run across many models for a comparison. Defaults reproduce the q3 baseline.
+: "${CLAUDETTE_MODEL:=qwen3.6-35b-a3b@q3_k_xl}"
+: "${CLAUDETTE_CODER_MODEL:=$CLAUDETTE_MODEL}"
+: "${CLAUDETTE_NUM_CTX:=32768}"
+: "${CLAUDETTE_CODER_NUM_CTX:=$CLAUDETTE_NUM_CTX}"
+export CLAUDETTE_MODEL CLAUDETTE_CODER_MODEL CLAUDETTE_NUM_CTX CLAUDETTE_CODER_NUM_CTX
 export CLAUDETTE_OPENAI_COMPAT=1
 export OLLAMA_HOST=http://localhost:1234
 export CLAUDETTE_SKIP_OLLAMA_PROBE=1
-export CLAUDETTE_NUM_CTX=32768
-export CLAUDETTE_CODER_NUM_CTX=32768
 export CLAUDETTE_AUTO_APPROVE=1
+# BATTERY_TAG suffixes the scores file + logs dir so models don't clobber each other.
+TAG="${BATTERY_TAG:-}"
 
 filter="${1:-}"
-SCORES="$BAT/SCORES.tsv"
+SCORES="$BAT/SCORES${TAG:+-$TAG}.tsv"
+LOGDIR="$BAT/logs${TAG:+-$TAG}"
+mkdir -p "$LOGDIR"
 [ -z "$filter" ] && : > "$SCORES"   # full run resets; filtered run appends
+echo "[battery] model=$CLAUDETTE_MODEL  ctx=$CLAUDETTE_NUM_CTX  tag='${TAG:-<none>}'  scores=$(basename "$SCORES")"
 
 # The "bigrepo" fixture (I1-I8) is a copy of claudette's own src+docs — the
 # large-repo-with-conflicting-docs stressor. It's gitignored (it's a dup of the
@@ -37,7 +51,7 @@ while IFS=$'\t' read -r id lang type fixture timeout; do
   case "$id" in \#*) continue;; esac
   if [ -n "$filter" ]; then case "$id" in $filter*) ;; *) continue;; esac; fi
 
-  work="$BAT/work/$id"; log="$BAT/logs/$id.log"
+  work="$BAT/work/$id"; log="$LOGDIR/$id.log"
   rm -rf "$work"
   cp -r "$BAT/fixtures/$fixture" "$work"
   [ -f "$BAT/setup/$id.sh" ] && bash "$BAT/setup/$id.sh" "$work" >/dev/null 2>&1

--- a/runs/eval-2026-05-29/battery/run_model_eval.sh
+++ b/runs/eval-2026-05-29/battery/run_model_eval.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Per-model eval driver for the multi-model comparison.
+#   usage: bash run_model_eval.sh <model-key> <identifier> [ctx] [filter]
+# Steps: unload -> load@ctx (--parallel 1 ALWAYS) -> A1 smoke (abort if the
+# model's chat template is incompatible / 400s) -> start reasoning capture
+# (lms log stream) -> full battery (tagged, non-clobbering) -> stop capture ->
+# analyze.
+set -u
+BAT="/d/dev/claudette/runs/eval-2026-05-29/battery"
+LMS="/c/Users/david/.lmstudio/bin/lms"
+CAPDIR="$HOME/claudette-eval-captures"
+mkdir -p "$CAPDIR"
+
+KEY="${1:?model-key required}"
+ID="${2:?identifier required}"
+CTX="${3:-24576}"
+FILTER="${4:-}"
+
+echo "================================================================"
+echo "[driver] model-key=$KEY  id=$ID  ctx=$CTX  parallel=1  $(date '+%F %T')"
+echo "================================================================"
+
+"$LMS" unload --all >/dev/null 2>&1
+echo "[driver] loading $KEY @ ${CTX} (parallel 1) ..."
+if ! "$LMS" load "$KEY" -c "$CTX" --parallel 1 --identifier "$ID" -y 2>&1 | tail -1; then
+  echo "[driver] LOAD FAILED for $KEY"; exit 5
+fi
+# show what actually loaded (CONTEXT + PARALLEL columns must read $CTX / 1)
+"$LMS" ps 2>&1 | grep -iE "IDENTIFIER|$ID" || true
+
+# Constant per-run env: export once so child run_battery.sh inherits it.
+export CLAUDETTE_MODEL="$ID" CLAUDETTE_CODER_MODEL="$ID"
+export CLAUDETTE_NUM_CTX="$CTX" CLAUDETTE_CODER_NUM_CTX="$CTX"
+
+# ---- smoke A1 (template / connectivity gate) ----
+echo "[driver] smoke A1 ..."
+# run_battery.sh appends for filtered runs, so clear any stale smoke scores first
+# (else the gate's NR==1 read picks up a leftover row from a prior session).
+rm -f "$BAT/SCORES-smoke-$ID.tsv"
+BATTERY_TAG="smoke-$ID" bash "$BAT/run_battery.sh" A1 >/dev/null 2>&1 || true
+SLOG="$BAT/logs-smoke-$ID/A1.log"
+if grep -qiE "jinja template|Unknown StringValue filter|HTTP 400 Bad Request" "$SLOG" 2>/dev/null; then
+  echo "[driver] TEMPLATE_INCOMPATIBLE: $ID  (LM Studio cannot render this model's chat template)"
+  grep -iE "error\":" "$SLOG" 2>/dev/null | head -1
+  exit 7
+fi
+SS=$(awk -F'\t' 'NR==1{print $4" "$5}' "$BAT/SCORES-smoke-$ID.tsv" 2>/dev/null)
+echo "[driver] smoke A1 = ${SS:-<no result>}  -> proceeding to full battery"
+
+# ---- reasoning capture ----
+CAP="$CAPDIR/${ID}.stream.log"
+echo "[driver] reasoning capture -> $CAP"
+"$LMS" log stream --source model --stats > "$CAP" 2>&1 &
+CAPPID=$!
+sleep 1
+
+# ---- full battery ----
+BATTERY_TAG="$ID" bash "$BAT/run_battery.sh" "$FILTER"
+EC=$?
+
+kill "$CAPPID" 2>/dev/null || true
+
+echo "================================================================"
+echo "[driver] ANALYZE $ID"
+bash "$BAT/analyze.sh" "$BAT/SCORES-$ID.tsv"
+echo "[driver] DONE $ID (battery ec=$EC, capture=$CAP)"


### PR DESCRIPTION
## What

Publishes a **Benchmark** subsection under README's *Recommended models*, backed by an objective 50-task daily-driver battery run across the local-model lineup, plus the full results doc, a scouted certification queue, and the reusable harness.

All runs: **24k context, `--parallel 1`, RTX 5060 Ti 16 GB.** Each model drives claudette's real tool loop; an automated verifier scores PASS (build/test passes, file correct, or ground-truth tokens) — no self-grading.

## Results (Pass@50)

| Brain | Pass | Wall | Best for |
|---|---|---|---|
| qwen3.6-35b-a3b `q3_k_xl` | **92%** | 38 min | best accuracy — default |
| qwen3.5-4b | **90%** | 8 min | best value, fits 8 GB |
| qwen3.5-9b | 88% | 16 min | solid mid |
| qwen3.6-35b-a3b `q4_k_xl` | 88% | 48 min | RAM-bound on 16 GB → timeouts |
| gpt-oss-20b | 86% | 5 min | fastest, MXFP4 resident |
| granite-4.1-8b | 78% | 17 min | reliable tools, weaker coder |
| qwen3.6-27b (dense) | ≈86%* | ~67 s/task | precision tier, not interactive |

\* stopped at 37/50; dense → slow, loses generation-heavy tasks to timeouts.

**Not viable as shipped** (config/template, not quality): `gemma-4-26b` + `qwen3-coder-30b` (stock-GGUF jinja → HTTP 400 on tool calls), `glm-4.7-flash` (tool calls don't render in our LM Studio runtime — needs a post-Jan-2026 quant + corrected template), `nemotron-omni` (too slow at 24k).

## Key findings
- **VRAM-fit > parameter count** — q3 (fits) beats q4 (spills → timeouts); this corrects the README's 16 GB pin from `q4_k_xl` to `q3_k_xl`.
- **Small models punch up** — a 4B hits 90% in 8 min.
- **Chat-template compatibility is the #1 local-model failure mode** — always pull `lmstudio-community`/`unsloth` GGUFs and validate one real tool call.

## Files
- `README.md` — benchmark table + findings; q4→q3 16 GB correction
- `runs/eval-2026-05-29/battery/MODEL-COMPARISON.md` — full per-model rows + Findings
- `runs/eval-2026-05-29/battery/CANDIDATES.md` — scouted certification queue (future rounds)
- harness: `run_model_eval.sh` (new) + parametrized `run_battery.sh`/`analyze.sh`
- raw `SCORES-*.tsv` for the 6 clean full runs

No Rust changed — docs + shell + data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)