### PR TITLE
Steer exhaustive enumeration — close the model-bound search gap (I-series 2/6→6/6)

### DIFF
--- a/crates/claudette/src/prompt.rs
+++ b/crates/claudette/src/prompt.rs
@@ -98,8 +98,10 @@ pub fn secretary_system_prompt_with_memory(memory: Option<&str>, concise: bool) 
          over answering from memory for prices, weather, news, or any current facts. \
          To localize code, call repo_map(query) FIRST — it returns the matching \
          files + symbols + the defining line (often with the value); then read_file \
-         that line. Use grep_search (regex) for exact strings or to enumerate all \
-         matches. Do not read whole large files or re-run the same search. Confirm \
+         that line. Use grep_search (regex) for exact strings or to enumerate. To \
+         list ALL of something, run ONE grep_search for the shared prefix/pattern \
+         and report EVERY distinct match across ALL files — never stop at the first \
+         file or conclude early. Do not read whole large files or re-run the same search. Confirm \
          code facts (a default value, a signature, a constant) from the defining \
          source line, not from docs or CHANGELOG, which can be stale. \
          When asked to edit, fix, or create a file, immediately CALL the edit tool \


### PR DESCRIPTION
## Summary

Closes the documented **model-bound search gap** — the battery's I-series ("list ALL X" enumeration + deep-locate of an authoritative value in a big repo with conflicting docs) — that was the ~20% kept for Claude Code.

One targeted line added to the base secretary prompt: *for "list ALL of something", run ONE `grep_search` for the shared prefix and report EVERY distinct match across ALL files — never stop at the first file or conclude early.*

## Live validation (qwen3.6-35b-a3b@q3_k_xl daily-driver brain)

Re-ran the affected battery tasks (`runs/eval-2026-05-29/battery`) before → after:

| Task | Type | Before | After |
|---|---|---|---|
| I1 | enumerate `CLAUDETTE_FORGE_*` | **2/6 FAIL** | **6/6 PASS** |
| I2 | enumerate forge roles | weak | **8/8 PASS** |
| I6 | enumerate CLI modes | weak | **7/7 PASS** |
| I3 | locate `DEFAULT_MAX_FIX_ROUNDS` | **TIMEOUT FAIL** | **PASS** (resisted the stale-doc value-2 trap) |
| I5 | locate | weak | **PASS** |
| C4 | create-file (regression guard) | PASS | **PASS** (no regression) |

The improvement generalises across 5 distinct enumerate/locate prompts (not q3 variance). Verified the bigrepo fixture contains all 6 ground-truth vars, so this was genuine under-searching, not a stale fixture.

1024 lib + 24 bin tests green · clippy `-D warnings` · rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
