### PR TITLE
Revert #34 enumeration nudge (no battery benefit; keep base prompt lean)

### DIFF
--- a/crates/claudette/src/prompt.rs
+++ b/crates/claudette/src/prompt.rs
@@ -98,10 +98,8 @@ pub fn secretary_system_prompt_with_memory(memory: Option<&str>, concise: bool) 
          over answering from memory for prices, weather, news, or any current facts. \
          To localize code, call repo_map(query) FIRST — it returns the matching \
          files + symbols + the defining line (often with the value); then read_file \
-         that line. Use grep_search (regex) for exact strings or to enumerate. To \
-         list ALL of something, run ONE grep_search for the shared prefix/pattern \
-         and report EVERY distinct match across ALL files — never stop at the first \
-         file or conclude early. Do not read whole large files or re-run the same search. Confirm \
+         that line. Use grep_search (regex) for exact strings or to enumerate all \
+         matches. Do not read whole large files or re-run the same search. Confirm \
          code facts (a default value, a signature, a constant) from the defining \
          source line, not from docs or CHANGELOG, which can be stale. \
          When asked to edit, fix, or create a file, immediately CALL the edit tool \


### PR DESCRIPTION
## Summary

Reverts #34 (the exhaustive-enumeration prompt nudge).

The full 50-task battery on `qwen3.6-35b-a3b@q3_k_xl` (48/50 = 96%) showed the nudge does **not** reliably fix the I-series enumerate/locate gap it targeted: I1 came back to **2/6 FAIL** and I3 to **FAIL(TIMEOUT)**, identical to the pre-nudge baseline. The earlier "I1 2/6→6/6" result was q3 run-to-run variance from an isolated re-run, not a fix (I2/I5/I6 pass with or without it — they passed in the baseline too).

With no demonstrated benefit and a real cost — it lengthens the base prompt, which `prompt.rs` documents as tool-call-suppression-sensitive on smaller brains (4b/9b) and was only validated on 35b — the lean prompt is the safer default. I1/I3 (exhaustive enumeration + deep-locate against conflicting docs) remain genuinely model-bound; keep Claude Code for that class.

No behaviour change for the shipped fixes in #33; this only restores the base prompt to its pre-#34 wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
