### PR TITLE
chore(release): v0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.8.8] - 2026-06-03
+
 ### Added
 
 - **Forge human-review gate.** Before the Submitter opens a PR, forge now prints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release prep for **v0.8.8** — ships the Forge trust + onboarding work from #37.

- Bumps `crates/claudette/Cargo.toml` 0.8.7 → 0.8.8 (+ `Cargo.lock`).
- Moves the CHANGELOG `[Unreleased]` entries under `[0.8.8]`.

After this merges to `main`, pushing the `v0.8.8` tag triggers `release.yml`: crates.io publish (OIDC) + 5-target binaries + GitHub Release with sha256.

### What's in 0.8.8 (from #37)
- **Forge human-review gate** before `mission_submit` — plan + full diff, requires explicit `y`, fail-closed.
- **Verifier builds + tests for real** each round (`cargo check`/`cargo test`, `go`/`pytest`/`npm`); build break or failing test is a hard fail fed back to the Coder.
- **`claudette --doctor`** build-toolchains section + copy-paste `↳ fix:` on every red/yellow row.
- Sub-5-minute **quickstart** (TUI + forge) and de-staled `docs/forge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)