### PR TITLE
feat(offline): enforce the air-gap with --offline / CLAUDETTE_OFFLINE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.8.9] - 2026-06-04
+
 ### Added
 
 - **Enforced offline mode (`--offline` / `CLAUDETTE_OFFLINE=1`).** Turns the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Added
+
+- **Enforced offline mode (`--offline` / `CLAUDETTE_OFFLINE=1`).** Turns the
+  "air-gapped by design" posture into an enforced guarantee: every outbound
+  network call is checked against an allow-list — the configured local model
+  backend (Ollama / LM Studio host, including a LAN box opted into via
+  `CLAUDETTE_ALLOW_REMOTE_OLLAMA`) plus loopback — and anything else is
+  hard-blocked with a single uniform message (`blocked by offline mode
+  (--offline / CLAUDETTE_OFFLINE)…`). Two enforcement layers: an HTTP-layer
+  guard in the reqwest path (blocks `web_search`/`web_fetch`, Gmail/Calendar/
+  Google OAuth, markets/weather/Wikipedia, GitHub, Telegram) and a dispatch
+  layer for tools that reach the network via subprocess (remote `git_push`/
+  `git_clone`, the brownfield `mission_start` clone + `mission_submit` push,
+  and edge-tts TTS). The brain, recall embeddings, and local vision keep
+  working. `--offline` + `--telegram` is refused at startup. `--doctor` gains
+  an **egress / air-gap** section that prints the live allow-list and skips the
+  cloud probes. New module `egress.rs`; host-matching + flag/env parsing are
+  unit-tested. Docs: PRIVACY.md, README, quickstart, configuration.
+
 ## [0.8.8] - 2026-06-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "arboard",

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -15,6 +15,30 @@ If anything here doesn't match what you observe in the wild, that's a bug — pl
 
 ---
 
+## Enforced offline mode (`--offline`)
+
+Everything below this section describes the **default** posture: cloud egress is off until you opt into a specific feature. Offline mode turns that posture into an **enforced guarantee** — the difference between "Claudette is configured not to phone home" and "Claudette *cannot* phone home, by construction."
+
+Run with `--offline` (or set `CLAUDETTE_OFFLINE=1`):
+
+```bash
+claudette --offline "refactor this module"
+claudette --offline --doctor          # prints the egress allow-list
+```
+
+When enabled, **every** outbound network call is checked against a tiny allow-list and anything else is hard-blocked with a single, uniform error (`blocked by offline mode (--offline / CLAUDETTE_OFFLINE)…`):
+
+- **Allowed:** the configured local model backend (the resolved Ollama / LM Studio host) and loopback (`localhost`, `127.0.0.0/8`, `::1`). The brain, recall embeddings, and local vision keep working.
+- **Blocked:** `web_search` / `web_fetch`, Gmail / Calendar / Google OAuth, markets / weather / Wikipedia, GitHub, the Telegram bridge (and its voice in/out), `git_push` / `git_clone` to a remote, the brownfield `mission_start` clone and `mission_submit` push, and the edge-tts TTS subprocess — each refuses with the same message rather than a confusing connection error.
+
+Enforcement is two-layered so nothing slips through: an HTTP-layer guard in the reqwest path (it checks the destination host of every in-process request), plus a dispatch-layer guard for tools that reach the network by spawning a subprocess (`git`, `python -m edge_tts`) where the HTTP guard can't see the destination.
+
+**LAN backends are still your hardware.** If your model runs on another box on your network (`OLLAMA_HOST=http://192.168.1.50:11434`, opted into with `CLAUDETTE_ALLOW_REMOTE_OLLAMA=1`), that host stays on the allow-list. Offline mode blocks the *cloud*, not the model you own.
+
+`--offline` and `--telegram` are mutually exclusive — the Telegram bridge relays through `api.telegram.org`, so Claudette refuses to start the bot under offline mode rather than failing every poll.
+
+---
+
 ## Where your data lives
 
 Everything Claudette stores lives under `~/.claudette/` (or `%USERPROFILE%\.claudette\` on Windows):
@@ -39,7 +63,7 @@ Nothing outside `~/.claudette/` is written without explicit user action (e.g. `w
 
 ## When data leaves your machine
 
-Each outbound connection below is **off by default** until you opt in, and is **gated by a specific feature, env var, or tool group**. Localhost connections (Ollama on `:11434`, LM Studio on `:1234`) are not counted as leaving.
+Each outbound connection below is **off by default** until you opt in, and is **gated by a specific feature, env var, or tool group**. Localhost connections (Ollama on `:11434`, LM Studio on `:1234`) are not counted as leaving. Every host in the tables below is hard-blocked under [`--offline`](#enforced-offline-mode---offline), regardless of how it would otherwise be triggered.
 
 ### Always-off until you opt in
 
@@ -86,10 +110,10 @@ Claudette logs to stdout/stderr. By default, nothing is written to a system log 
 
 These are explicit design intents, not promises:
 
-- **`--offline` hard kill switch.** A single flag that refuses any outbound network call (including the optional ones above) and surfaces an explicit error if a tool needs one. Useful for air-gapped sessions.
 - **Outbound-host audit log.** A `~/.claudette/outbound.log` recording every hostname Claudette touched, with timestamp and triggering tool, for after-the-fact review.
 - **At-rest encryption for `recall.sqlite`.** Pass-phrase-derived key, SQLCipher or equivalent.
-- **`CLAUDETTE_DISALLOW_NETWORK` env var** to forbid network calls for specific environments (CI sandboxes, work laptops).
+
+The `--offline` hard kill switch (formerly listed here) is **shipped** — see [Enforced offline mode](#enforced-offline-mode---offline) above. `CLAUDETTE_OFFLINE=1` is the env-var equivalent.
 
 Track or contribute these at <https://github.com/mrdushidush/claudette/issues>.
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ claudette "what time is it?"
 Most "local AI" tools quietly phone home — telemetry, model downloads, a cloud fallback when the local model struggles. **Claudette has no such path.** There is no cloud-brain code in the binary to begin with.
 
 - **One required dependency:** a model server (Ollama or LM Studio) on `localhost`. That's it.
-- **Every outbound call is opt-in and feature-gated** — voice TTS, Telegram, web search, GitHub, Google Calendar/Gmail. Each one only exists if *you* turn it on with a token. The full inventory of every place a byte could leave your machine is in [`PRIVACY.md`](PRIVACY.md).
+- **`--offline` *enforces* the air-gap.** Run `claudette --offline` (or set `CLAUDETTE_OFFLINE=1`) and every outbound call except the local model backend + loopback is hard-blocked with a clear "blocked by offline mode" error — web search/fetch, Gmail/Calendar, markets/weather/Wikipedia, GitHub, Telegram, and remote `git push`/`clone` all refuse. The brain and recall keep working. `claudette --offline --doctor` prints the exact allow-list. This is the difference between *configured* not to phone home and *can't* phone home.
+- **Every outbound call is opt-in and feature-gated** even without `--offline` — voice TTS, Telegram, web search, GitHub, Google Calendar/Gmail. Each one only exists if *you* turn it on with a token. The full inventory of every place a byte could leave your machine is in [`PRIVACY.md`](PRIVACY.md).
 - **Truly offline:** `CLAUDETTE_SKIP_OLLAMA_PROBE=1` skips even the localhost startup check. Pull your model, disconnect the network, and the entire core works — chat, notes, todos, files, code search, repo editing, and the [Forge](#-forge-mode-an-autonomous-code-change-pipeline) autonomous code-change pipeline.
 - **Nothing is written outside `~/.claudette/`** without an explicit permission prompt.
 
-If you work on a regulated, classified, or simply trust-no-cloud machine, this is the headline feature — not an afterthought. Your code and your conversations never touch someone else's servers.
+If you work on a regulated, classified, or simply trust-no-cloud machine, this is the headline feature — not an afterthought. Your code and your conversations never touch someone else's servers — and with `--offline`, they *can't*.
 
 ---
 
@@ -202,7 +203,7 @@ Claudette has a clear north star: **be the most private, most universally-runnab
 
 ### The vision
 
-- **🔒 Hardened air-gap mode.** A first-class, audited offline profile: a `--air-gapped` flag that hard-disables every network-capable tool, a reproducible offline install bundle (binary + model + Whisper weights), and a documented "regulated-machine" deployment story.
+- **🔒 Hardened air-gap mode.** The enforced egress kill-switch has **shipped** — [`--offline` / `CLAUDETTE_OFFLINE=1`](#-air-gapped-by-design) hard-blocks every network call except the local backend + loopback. Still ahead: a reproducible offline install bundle (binary + model + Whisper weights) and a documented "regulated-machine" deployment story, plus an outbound-host audit log.
 - **🧠 A model-agnostic, curated brain menu.** Not one blessed model — a recommendation for *every* hardware tier, from a 4 GB laptop GPU to a 24 GB workstation, so anyone can run her well on what they already own.
 - **🏅 The Claudette Certified program, expanded.** Keep running the objective [50-task battery](#-claudette-certified--the-local-model-benchmark) on every promising new local model and publish a living, badged recommendation table. The [candidate queue](runs/eval-2026-05-29/battery/CANDIDATES.md) is already scouted — GLM-4.7-Flash, Qwen3-Coder-30B, Granite-4.1-8B, the Mistral/Ministral family, and more.
 

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.8.8"
+version = "0.8.9"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -378,6 +378,40 @@ fn is_compat_value_truthy(value: Option<&str>) -> bool {
 /// arbitrary project `.env` files no longer feed into this path.
 #[must_use]
 pub fn is_local_ollama_url(url: &str) -> bool {
+    let host_lower = host_of_url(url);
+
+    // `0.0.0.0` and `::` are valid BIND addresses (Ollama listens on all
+    // interfaces) but not valid DESTINATION addresses — a TCP connect to
+    // 0.0.0.0 usually routes to the default local interface on Unix and
+    // errors on Windows. Treating them as loopback suppresses the warning
+    // even though OLLAMA_HOST=http://0.0.0.0:11434 does not mean "stay
+    // local". Drop them from the loopback list; a user who really wants
+    // that config can set CLAUDETTE_ALLOW_REMOTE_OLLAMA=1.
+    if host_lower == "localhost" || host_lower == "::1" {
+        return true;
+    }
+    // 127.0.0.0/8 — any loopback IPv4.
+    if let Some(rest) = host_lower.strip_prefix("127.") {
+        return rest.split('.').count() == 3
+            && rest
+                .split('.')
+                .all(|s| !s.is_empty() && s.parse::<u8>().is_ok());
+    }
+    false
+}
+
+/// Parse the lowercased host out of a URL (or a bare `host[:port]`). Strips
+/// the scheme, path, userinfo (`user[:pass]@`), and port, and unwraps an
+/// IPv6 bracket literal (`[::1]:11434` → `::1`). Returns the host verbatim,
+/// lowercased: `localhost`, `127.0.0.1`, `192.168.1.5`, `::1`,
+/// `api.github.com`, … An empty string is returned for input with no host.
+///
+/// Shared by [`is_local_ollama_url`] and the offline egress guard
+/// ([`crate::egress`]) so both judge the same notion of "host" — the loopback
+/// warning and the air-gapped allow-list must never disagree on what host a
+/// URL points at.
+#[must_use]
+pub fn host_of_url(url: &str) -> String {
     // Strip scheme if present, case-insensitively. We only need the host.
     // `str::get(..n)` returns `None` when `n` is out of range *or* not a char
     // boundary, so this never panics on a URL whose first bytes are multibyte
@@ -413,26 +447,7 @@ pub fn is_local_ollama_url(url: &str) -> bool {
     } else {
         host_and_port.split(':').next().unwrap_or(host_and_port)
     };
-    let host_lower = host.to_ascii_lowercase();
-
-    // `0.0.0.0` and `::` are valid BIND addresses (Ollama listens on all
-    // interfaces) but not valid DESTINATION addresses — a TCP connect to
-    // 0.0.0.0 usually routes to the default local interface on Unix and
-    // errors on Windows. Treating them as loopback suppresses the warning
-    // even though OLLAMA_HOST=http://0.0.0.0:11434 does not mean "stay
-    // local". Drop them from the loopback list; a user who really wants
-    // that config can set CLAUDETTE_ALLOW_REMOTE_OLLAMA=1.
-    if host_lower == "localhost" || host_lower == "::1" {
-        return true;
-    }
-    // 127.0.0.0/8 — any loopback IPv4.
-    if let Some(rest) = host_lower.strip_prefix("127.") {
-        return rest.split('.').count() == 3
-            && rest
-                .split('.')
-                .all(|s| !s.is_empty() && s.parse::<u8>().is_ok());
-    }
-    false
+    host.to_ascii_lowercase()
 }
 
 /// Short-timeout GET on the resolved Ollama base URL to verify the daemon

--- a/crates/claudette/src/doctor.rs
+++ b/crates/claudette/src/doctor.rs
@@ -97,6 +97,9 @@ pub fn run() -> i32 {
     print_section("environment");
     bump(probe_env());
 
+    print_section("egress / air-gap");
+    bump(probe_egress());
+
     print_section("local brain");
     bump(probe_brain());
 
@@ -154,6 +157,7 @@ const TRACKED_VARS: &[&str] = &[
     // Backends
     "OLLAMA_HOST",
     "CLAUDETTE_OPENAI_COMPAT",
+    "CLAUDETTE_OFFLINE",
     "CLAUDETTE_ALLOW_REMOTE_OLLAMA",
     "CLAUDETTE_SKIP_OLLAMA_PROBE",
     "CLAUDETTE_SKIP_LM_STUDIO_PROBE",
@@ -556,7 +560,47 @@ fn probe_recall() -> Status {
 
 // ─── Google OAuth ────────────────────────────────────────────────────────
 
+/// Surface the offline-mode posture and, when enforced, the exact egress
+/// allow-list. Purely informational — it never fails the overall run (an
+/// air-gapped box is a healthy box, and "offline off" is the opt-in default,
+/// not a misconfiguration).
+fn probe_egress() -> Status {
+    if crate::egress::is_offline() {
+        print_row(
+            "offline mode",
+            Status::Ok,
+            "ENFORCED — only the hosts below are reachable",
+        );
+        for host in crate::egress::allow_list() {
+            print_row("  allow", Status::Ok, &host);
+        }
+        print_row(
+            "  deny",
+            Status::Ok,
+            "everything else (web_search/web_fetch, gmail/calendar, markets/weather/wikipedia, github, telegram)",
+        );
+    } else {
+        print_row(
+            "offline mode",
+            Status::Ok,
+            "off — run with --offline (or CLAUDETTE_OFFLINE=1) to enforce the air-gap",
+        );
+    }
+    Status::Ok
+}
+
 fn probe_google_oauth() -> Status {
+    // Offline mode blocks every Google API call by design — attempting the
+    // live verify here would just paint the report red. Show it as skipped so
+    // the report stays green-meaningful.
+    if crate::egress::is_offline() {
+        print_row(
+            "google oauth",
+            Status::Ok,
+            "skipped — offline mode blocks Google API access",
+        );
+        return Status::Ok;
+    }
     let mut worst = Status::Ok;
     for ctx in [
         crate::google_auth::AuthContext::Calendar,

--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -1,0 +1,329 @@
+//! Offline mode — the *enforced* backing of claudette's "air-gapped by design"
+//! claim. Until now "air-gapped" was a posture: claudette only talks to a local
+//! model by default, but nothing stopped a tool (or a prompt-injected model)
+//! from reaching the open internet. Offline mode turns that posture into a
+//! guarantee.
+//!
+//! When enabled — `--offline` on the CLI, or `CLAUDETTE_OFFLINE=1` in the
+//! environment — every outbound network call is checked against a tiny
+//! allow-list: the configured local model backend (the resolved Ollama /
+//! LM Studio host, even if it's a LAN box you own) plus loopback. Anything
+//! else is hard-blocked with a single, uniform message so the refusal reads
+//! identically no matter which code path tripped it.
+//!
+//! Two enforcement layers, because not all egress is in-process:
+//!
+//!  1. **HTTP layer** — [`guard`] is called on the resolved destination host
+//!     in the reqwest path of each network-reaching tool, before the request
+//!     leaves the process. Recall embeddings and brain / vision calls to the
+//!     local backend pass the allow-list; `web_search` / `web_fetch` / `gmail`
+//!     / `calendar` / `google_auth` / `tv_get_quote` / `wikipedia` / `weather`
+//!     / Telegram are blocked.
+//!
+//!  2. **Dispatch / subprocess layer** — tools that shell out to the network
+//!     instead of using reqwest can't be seen by the HTTP layer, so they call
+//!     [`guard_subprocess`] up front and refuse with the SAME message: the
+//!     `git_push` / `git_clone` subprocesses, the brownfield `mission_start`
+//!     clone and `mission_submit` push, and the edge-tts TTS subprocess.
+//!
+//! The allow / deny decision is pure host-matching ([`is_allowed_host`]); the
+//! flag/env plumbing ([`is_offline`]) and both message builders are unit-tested
+//! below.
+
+use crate::api::{host_of_url, is_local_ollama_url, resolve_ollama_url};
+
+/// Environment variable that enables offline mode. The `--offline` CLI flag
+/// sets this to `"1"` (see `main.rs`) so the flag and the env var share one
+/// source of truth — and so the setting propagates to any child process
+/// claudette spawns (`gh`, `git`, `python -m edge_tts`, …), which then refuse
+/// network access themselves if they re-enter claudette.
+pub const OFFLINE_ENV: &str = "CLAUDETTE_OFFLINE";
+
+/// Shared prefix on every offline-block message. Centralised so the HTTP-layer
+/// refusal and the subprocess-layer refusal are byte-for-byte recognisable as
+/// "the same block", and so tests can assert on it without pinning the whole
+/// sentence.
+pub const BLOCK_PREFIX: &str = "blocked by offline mode (--offline / CLAUDETTE_OFFLINE)";
+
+/// Returns true when offline mode is enabled. Truthy = set, non-empty, and not
+/// literally `"0"` — matching the convention used by `CLAUDETTE_FACELESS`,
+/// `CLAUDETTE_ALLOW_REMOTE_OLLAMA`, and the skip-probe flags.
+#[must_use]
+pub fn is_offline() -> bool {
+    std::env::var(OFFLINE_ENV)
+        .ok()
+        .is_some_and(|v| !v.is_empty() && v != "0")
+}
+
+/// The allow-list, as host strings, for display in `--doctor`. Order: loopback
+/// names first, then the resolved backend host (de-duplicated if the backend
+/// is itself loopback, which is the common case).
+#[must_use]
+pub fn allow_list() -> Vec<String> {
+    let mut hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.0/8".to_string(),
+        "::1".to_string(),
+    ];
+    let backend = host_of_url(&resolve_ollama_url());
+    if !backend.is_empty() && !is_loopback_host(&backend) {
+        hosts.push(backend);
+    }
+    hosts
+}
+
+/// True when `host` (already a bare lowercased host, as from [`host_of_url`])
+/// is a loopback address. Thin wrapper over [`is_local_ollama_url`] so callers
+/// holding a host rather than a URL don't have to re-synthesise a URL.
+#[must_use]
+fn is_loopback_host(host: &str) -> bool {
+    // `is_local_ollama_url` parses a URL; feed it a bare host (no scheme),
+    // which `host_of_url` passes through unchanged.
+    is_local_ollama_url(host)
+}
+
+/// Core policy: is a request to `url` permitted under offline mode? Pure,
+/// side-effect-free, and independent of whether offline mode is actually on —
+/// so it can be unit-tested directly. Allowed iff the host is loopback OR the
+/// configured backend host.
+///
+/// The backend host is matched at the *host* level, not host+port: a LAN
+/// backend like `http://192.168.1.50:11434` means "that box is my hardware",
+/// so other ports on the same box are allowed too. This is intentional and
+/// documented (`CLAUDETTE_ALLOW_REMOTE_OLLAMA` is the knob that legitimised a
+/// LAN backend in the first place).
+#[must_use]
+pub fn is_allowed_host(url: &str) -> bool {
+    if is_local_ollama_url(url) {
+        return true;
+    }
+    let host = host_of_url(url);
+    if host.is_empty() {
+        return false;
+    }
+    let backend = host_of_url(&resolve_ollama_url());
+    !backend.is_empty() && host.eq_ignore_ascii_case(&backend)
+}
+
+/// HTTP-layer guard. Call with the destination URL (or bare host) immediately
+/// before a reqwest `.send()`. A no-op when offline mode is off; otherwise
+/// returns `Ok(())` for allow-listed hosts and a [`BLOCK_PREFIX`]-prefixed
+/// `Err` for everything else.
+///
+/// # Errors
+/// Returns the uniform offline-block message when offline mode is on and `url`
+/// is not on the allow-list.
+pub fn guard(url: &str) -> Result<(), String> {
+    if !is_offline() || is_allowed_host(url) {
+        return Ok(());
+    }
+    let host = host_of_url(url);
+    let host = if host.is_empty() { url } else { &host };
+    Err(format!(
+        "{BLOCK_PREFIX}: outbound connection to '{host}' is not allowed. Only the local \
+         model backend ({}) and loopback are reachable. Disable offline mode to use this.",
+        resolve_ollama_url()
+    ))
+}
+
+/// Dispatch / subprocess-layer guard. Call at the top of a tool that reaches
+/// the network by spawning a subprocess (`git`, `gh`, `python -m edge_tts`)
+/// rather than through reqwest, where [`guard`] can't see the destination.
+/// `action` is a short human phrase naming what was attempted, e.g.
+/// `"git_push (push to the remote repository)"`.
+///
+/// A no-op when offline mode is off.
+///
+/// # Errors
+/// Returns the uniform offline-block message when offline mode is on.
+pub fn guard_subprocess(action: &str) -> Result<(), String> {
+    if !is_offline() {
+        return Ok(());
+    }
+    Err(format!(
+        "{BLOCK_PREFIX}: {action} requires network access, which is disabled. Only the local \
+         model backend ({}) and loopback are reachable. Disable offline mode to use this.",
+        resolve_ollama_url()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialise env-mutating tests: `OLLAMA_HOST` / `CLAUDETTE_OFFLINE` are
+    /// process-global, so parallel tests would race. Each test takes this lock
+    /// and restores the prior values on the way out.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        offline: Option<String>,
+        ollama: Option<String>,
+    }
+    impl EnvGuard {
+        fn capture() -> Self {
+            Self {
+                offline: std::env::var(OFFLINE_ENV).ok(),
+                ollama: std::env::var("OLLAMA_HOST").ok(),
+            }
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            restore(OFFLINE_ENV, self.offline.as_deref());
+            restore("OLLAMA_HOST", self.ollama.as_deref());
+        }
+    }
+    fn restore(key: &str, val: Option<&str>) {
+        match val {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn is_offline_reads_truthy_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+
+        std::env::remove_var(OFFLINE_ENV);
+        assert!(!is_offline(), "unset → off");
+
+        std::env::set_var(OFFLINE_ENV, "");
+        assert!(!is_offline(), "empty → off");
+
+        std::env::set_var(OFFLINE_ENV, "0");
+        assert!(!is_offline(), "literal 0 → off");
+
+        std::env::set_var(OFFLINE_ENV, "1");
+        assert!(is_offline(), "1 → on");
+
+        std::env::set_var(OFFLINE_ENV, "true");
+        assert!(is_offline(), "any other non-empty → on");
+    }
+
+    #[test]
+    fn loopback_hosts_always_allowed() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+
+        for url in [
+            "http://localhost:11434/api/chat",
+            "http://127.0.0.1:1234/v1/chat/completions",
+            "http://127.255.255.255:11434",
+            "https://[::1]:443/x",
+            "localhost:11434",
+        ] {
+            assert!(is_allowed_host(url), "{url} should be allowed (loopback)");
+        }
+    }
+
+    #[test]
+    fn cloud_hosts_denied() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+
+        for url in [
+            "https://api.github.com/user",
+            "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+            "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+            "https://oauth2.googleapis.com/token",
+            "https://api.search.brave.com/res/v1/web/search",
+            "https://en.wikipedia.org/w/api.php",
+            "https://api.open-meteo.com/v1/forecast",
+            "https://scanner.tradingview.com/america/scan",
+            "https://api.telegram.org/bot123/getUpdates",
+            "https://localhost.evil.com/x",
+            "http://user:pass@evil.com/path",
+        ] {
+            assert!(!is_allowed_host(url), "{url} should be denied (cloud)");
+        }
+    }
+
+    #[test]
+    fn configured_lan_backend_allowed_other_cloud_still_denied() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        // A remote-but-LAN backend the user opted into — "your hardware".
+        std::env::set_var("OLLAMA_HOST", "http://192.168.1.50:11434");
+
+        assert!(
+            is_allowed_host("http://192.168.1.50:11434/api/chat"),
+            "the configured backend host is allowed"
+        );
+        // Same box, different port — still your hardware, host-level match.
+        assert!(
+            is_allowed_host("http://192.168.1.50:8080/anything"),
+            "other ports on the backend box are allowed (host-level match)"
+        );
+        // A different LAN box is NOT the backend → denied.
+        assert!(
+            !is_allowed_host("http://192.168.1.99:11434/api/chat"),
+            "a different LAN host is not the backend"
+        );
+        // Cloud is still denied even with a LAN backend.
+        assert!(!is_allowed_host("https://api.github.com/user"));
+    }
+
+    #[test]
+    fn guard_is_noop_when_offline_off() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        std::env::remove_var(OFFLINE_ENV);
+        // Even an obvious cloud host passes when offline mode is off.
+        assert!(guard("https://api.github.com/user").is_ok());
+        assert!(guard_subprocess("git_push").is_ok());
+    }
+
+    #[test]
+    fn guard_blocks_cloud_and_allows_backend_when_offline_on() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+        std::env::set_var(OFFLINE_ENV, "1");
+
+        // Backend / loopback pass — recall embeddings stay allowed.
+        assert!(guard("http://localhost:11434/api/embeddings").is_ok());
+
+        // Cloud is blocked with the uniform, recognisable message.
+        let err = guard("https://api.github.com/user").unwrap_err();
+        assert!(
+            err.starts_with(BLOCK_PREFIX),
+            "uses the shared prefix: {err}"
+        );
+        assert!(
+            err.contains("api.github.com"),
+            "names the blocked host: {err}"
+        );
+
+        // Subprocess refusal shares the same prefix.
+        let sub = guard_subprocess("git_clone (clone a remote repository)").unwrap_err();
+        assert!(
+            sub.starts_with(BLOCK_PREFIX),
+            "subprocess shares the prefix: {sub}"
+        );
+        assert!(sub.contains("git_clone"), "names the action: {sub}");
+    }
+
+    #[test]
+    fn allow_list_includes_loopback_and_lan_backend() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+        let local = allow_list();
+        assert!(local.iter().any(|h| h == "localhost"));
+        assert!(local.iter().any(|h| h == "127.0.0.0/8"));
+        // Loopback backend isn't repeated as a separate host.
+        assert!(!local.iter().any(|h| h == "11434"));
+
+        std::env::set_var("OLLAMA_HOST", "http://192.168.1.50:11434");
+        let lan = allow_list();
+        assert!(
+            lan.iter().any(|h| h == "192.168.1.50"),
+            "LAN backend host listed: {lan:?}"
+        );
+    }
+}

--- a/crates/claudette/src/google_auth.rs
+++ b/crates/claudette/src/google_auth.rs
@@ -235,6 +235,7 @@ pub fn access_token(ctx: AuthContext) -> Result<String, String> {
 /// messages can name the right scope; `None` falls back to a generic
 /// "<scope>" placeholder.
 fn refresh_tokens(tokens: &mut GoogleTokens, ctx: Option<AuthContext>) -> Result<(), String> {
+    crate::egress::guard(TOKEN_URL)?;
     let creds = load_client_creds()?;
     let client = http_client()?;
     let params = [
@@ -335,6 +336,7 @@ fn classify_refresh_failure(
 /// confirmation) and `claudette --doctor` (token-staleness probe), so the
 /// two callers stay in lockstep on what "access works" means.
 pub fn verify_scope_live(ctx: AuthContext, token: &str) -> Result<String, String> {
+    crate::egress::guard("https://www.googleapis.com")?;
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
@@ -379,6 +381,7 @@ pub fn verify_scope_live(ctx: AuthContext, token: &str) -> Result<String, String
 /// Revoke the stored refresh token for `ctx` with Google and delete the
 /// corresponding local file. Used by `claudette --auth-google [scope] --revoke`.
 pub fn revoke(ctx: AuthContext) -> Result<(), String> {
+    crate::egress::guard(REVOKE_URL)?;
     let tokens = load_tokens(ctx)?;
     let client = http_client()?;
     let resp = client
@@ -405,6 +408,10 @@ pub fn revoke(ctx: AuthContext) -> Result<(), String> {
 /// listener, opens the browser, captures the `code`, exchanges it for
 /// tokens, saves to the context-specific file.
 pub fn run_auth_flow(ctx: AuthContext) -> Result<(), String> {
+    // The OAuth consent + token exchange talk to accounts.google.com /
+    // oauth2.googleapis.com — refuse early under offline mode rather than
+    // opening a browser the flow can never complete.
+    crate::egress::guard("https://accounts.google.com")?;
     let creds = load_client_creds()?;
 
     // Bind first so we know which port to put in the redirect URI.

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -46,6 +46,7 @@ pub mod codet;
 pub mod commands;
 pub mod cto;
 pub mod doctor;
+pub mod egress;
 pub mod executor;
 pub mod forge;
 pub mod google_auth;

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -131,6 +131,12 @@ ONE-SHOT SETUP COMMANDS (each exits after doing its one job):
                          'daily', or a single weekday name ('monday', etc).
 
 MISC:
+    --offline            Enforce the air-gap: hard-block every outbound network
+                         call except the local model backend + loopback. Same
+                         as CLAUDETTE_OFFLINE=1. Blocks web_search/web_fetch,
+                         Gmail/Calendar, markets/weather/wikipedia, GitHub, and
+                         the Telegram bridge; the local brain + recall still
+                         work. See `--offline` in --doctor for the allow-list.
     --help, -h           Show this help and exit.
     --version, -V        Show the claudette version and exit.
 
@@ -140,6 +146,7 @@ ENVIRONMENT:
       CLAUDETTE_MODEL          Override the brain model.
       CLAUDETTE_CODER_MODEL    Override the Codet coder model.
       CLAUDETTE_SESSION        Override the session-file path.
+      CLAUDETTE_OFFLINE        Set to 1 to enforce the air-gap (see --offline).
       TELEGRAM_BOT_TOKEN       Required for --telegram.
 
 EXAMPLES:
@@ -226,6 +233,21 @@ fn main() -> ExitCode {
         doctor,
         cto,
     } = args;
+
+    // ── Offline-mode banner ───────────────────────────────────────────
+    // Loud, one-line confirmation that the air-gap is enforced this run.
+    // `--doctor` prints its own dedicated offline section, so skip it here
+    // to avoid saying it twice.
+    if claudette::egress::is_offline() && !doctor {
+        eprintln!(
+            "{} {}",
+            theme::accent("🔒 offline mode"),
+            theme::dim(&format!(
+                "only the local backend ({}) + loopback are reachable; all other egress is blocked",
+                claudette::api::resolve_ollama_url()
+            ))
+        );
+    }
 
     // ── --doctor: full diagnostic probe ──────────────────────────────
     // Runs before every other branch because it's the command the user
@@ -402,6 +424,22 @@ fn main() -> ExitCode {
 
     // ── Telegram bot mode ──────────────────────────────────────────────
     if telegram {
+        // The Telegram bridge is a cloud service (api.telegram.org); it is
+        // fundamentally incompatible with an enforced air-gap. Refuse up front
+        // with the same vocabulary the egress guard uses, rather than letting
+        // the bot start and then fail every poll.
+        if claudette::egress::is_offline() {
+            eprintln!(
+                "{} {}",
+                theme::error(theme::ERR_GLYPH),
+                theme::error(
+                    "offline mode (--offline) blocks the Telegram bridge — it relays through \
+                     api.telegram.org (cloud). Drop --offline to run the bot, or drop --telegram \
+                     to stay air-gapped."
+                )
+            );
+            return ExitCode::FAILURE;
+        }
         // Merge persisted chat IDs (from previous runs) with CLI flags.
         for id in secrets::load_chat_ids() {
             if !chat_ids.contains(&id) {
@@ -568,6 +606,12 @@ fn parse_args(args: &[String]) -> CliArgs {
                 // builder picks it up — same surface as
                 // `CLAUDETTE_FACELESS=1`.
                 std::env::set_var("CLAUDETTE_FACELESS", "1");
+            }
+            "--offline" => {
+                // Enforced air-gap. Set the env var so the egress guard (and
+                // any subprocess we spawn) sees it — same surface as
+                // `CLAUDETTE_OFFLINE=1`. See `egress.rs`.
+                std::env::set_var(claudette::egress::OFFLINE_ENV, "1");
             }
             _ => out.prompt_words.push(arg.clone()),
         }
@@ -777,6 +821,27 @@ mod tests {
         let a = parse_args(&["--telegram".into()]);
         assert!(a.telegram);
         assert!(a.prompt_words.is_empty());
+    }
+
+    #[test]
+    fn parse_args_offline_sets_env_and_is_not_a_prompt_word() {
+        let _g = lock_env();
+        let prev = std::env::var(claudette::egress::OFFLINE_ENV).ok();
+        std::env::remove_var(claudette::egress::OFFLINE_ENV);
+
+        // The flag is consumed (not echoed into the prompt) and flips the env
+        // var the egress guard reads — same mechanism as --faceless.
+        let a = parse_args(&["--offline".into(), "fix".into(), "bug".into()]);
+        assert!(
+            claudette::egress::is_offline(),
+            "--offline enables offline mode"
+        );
+        assert_eq!(a.prompt_words, vec!["fix".to_string(), "bug".to_string()]);
+
+        match prev {
+            Some(v) => std::env::set_var(claudette::egress::OFFLINE_ENV, v),
+            None => std::env::remove_var(claudette::egress::OFFLINE_ENV),
+        }
     }
 
     #[test]

--- a/crates/claudette/src/telegram_mode.rs
+++ b/crates/claudette/src/telegram_mode.rs
@@ -111,6 +111,11 @@ pub fn run_telegram_bot(
     let token = read_secret("telegram").map_err(|e| anyhow::anyhow!(e))?;
     let base_url = format!("https://api.telegram.org/bot{token}");
 
+    // Defense-in-depth: `main.rs` already refuses `--offline --telegram` at
+    // startup, but guard the transport too so no code path can poll the cloud
+    // Bot API while air-gapped.
+    crate::egress::guard(&base_url).map_err(|e| anyhow::anyhow!(e))?;
+
     // Verify the token works.
     let http = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(30))

--- a/crates/claudette/src/tools/calendar.rs
+++ b/crates/claudette/src/tools/calendar.rs
@@ -97,14 +97,19 @@ pub(super) fn schemas() -> Vec<Value> {
 }
 
 pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>> {
-    let result = match name {
-        "calendar_list_events" => run_list_events(input),
-        "calendar_create_event" => run_create_event(input),
-        "calendar_update_event" => run_update_event(input),
-        "calendar_delete_event" => run_delete_event(input),
+    // Resolve the handler before running it so the offline egress guard can
+    // refuse before any request hits the Google Calendar API.
+    let handler: fn(&str) -> Result<String, String> = match name {
+        "calendar_list_events" => run_list_events,
+        "calendar_create_event" => run_create_event,
+        "calendar_update_event" => run_update_event,
+        "calendar_delete_event" => run_delete_event,
         _ => return None,
     };
-    Some(result)
+    if let Err(e) = crate::egress::guard("https://www.googleapis.com") {
+        return Some(Err(e));
+    }
+    Some(handler(input))
 }
 
 /// Percent-encode a path segment (calendar ID can contain `@` and `.`).

--- a/crates/claudette/src/tools/facts.rs
+++ b/crates/claudette/src/tools/facts.rs
@@ -62,6 +62,7 @@ pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>
 ///   - `search`: `query` is search terms, returns top 5 title matches
 ///     with HTML-stripped snippets via the MediaWiki search API.
 fn run_wikipedia(input: &str) -> Result<String, String> {
+    crate::egress::guard("https://en.wikipedia.org")?;
     let v = parse_json_input(input, "wikipedia")?;
     let query = extract_str(&v, "query", "wikipedia")?.to_string();
     let mode = v
@@ -318,6 +319,8 @@ fn wmo_label(code: i64) -> &'static str {
 /// current conditions; `days=1..7` is a daily forecast. Values outside
 /// the range clamp; non-numeric `days` is treated as 0.
 fn run_weather(input: &str) -> Result<String, String> {
+    // Geocoding + forecast both hit *.open-meteo.com (cloud).
+    crate::egress::guard("https://api.open-meteo.com")?;
     let v = parse_json_input(input, "weather")?;
     let location = extract_str(&v, "location", "weather")?.to_string();
     let days = v.get("days").and_then(Value::as_i64).unwrap_or(0);

--- a/crates/claudette/src/tools/git.rs
+++ b/crates/claudette/src/tools/git.rs
@@ -546,6 +546,9 @@ fn run_git_clone(input: &str) -> Result<String, String> {
     let depth = v.get("depth").and_then(Value::as_u64);
 
     validate_clone_url(url)?;
+    // Cloning a remote is network egress (a loopback URL would still be
+    // allowed); refuse cloud clones under offline mode with the uniform msg.
+    crate::egress::guard(url)?;
     let dest = validate_dest_slug(dest_raw)?;
 
     let root = missions_root();
@@ -611,6 +614,10 @@ fn run_git_clone(input: &str) -> Result<String, String> {
 }
 
 fn run_git_push() -> Result<String, String> {
+    // Pushing reaches the configured remote (cloud); refuse under offline mode
+    // before spawning git, so the user sees the uniform air-gap message rather
+    // than a git transport error.
+    crate::egress::guard_subprocess("git_push (push to the remote repository)")?;
     // Gate enforcement lives at the policy layer: `git_push` is registered
     // as `DangerFullAccess` in `run.rs::build_permission_policy` and in
     // `agents.rs`, so every call path either (a) already runs under

--- a/crates/claudette/src/tools/github.rs
+++ b/crates/claudette/src/tools/github.rs
@@ -211,21 +211,27 @@ pub(super) fn schemas() -> Vec<Value> {
 }
 
 pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>> {
-    let result = match name {
-        "gh_inbox" => run_gh_inbox(input),
-        "gh_get_issue" => run_gh_get_issue(input),
-        "gh_create_issue" => run_gh_create_issue(input),
-        "gh_comment_issue" => run_gh_comment_issue(input),
-        "gh_search_code" => run_gh_search_code(input),
-        "gh_list_repo_issues" => run_gh_list_repo_issues(input),
-        "gh_pr_status" => run_gh_pr_status(input),
-        "gh_pr_view" => run_gh_pr_view(input),
-        "gh_workflow_logs" => run_gh_workflow_logs(input),
-        "gh_fork" => run_gh_fork(input),
-        "gh_create_pr" => run_gh_create_pr(input),
+    // Resolve the handler first (so ownership of `name` is decided) but DON'T
+    // run it yet — every gh_* tool reaches api.github.com, so the offline
+    // egress guard gets to refuse before any request leaves the process.
+    let handler: fn(&str) -> Result<String, String> = match name {
+        "gh_inbox" => run_gh_inbox,
+        "gh_get_issue" => run_gh_get_issue,
+        "gh_create_issue" => run_gh_create_issue,
+        "gh_comment_issue" => run_gh_comment_issue,
+        "gh_search_code" => run_gh_search_code,
+        "gh_list_repo_issues" => run_gh_list_repo_issues,
+        "gh_pr_status" => run_gh_pr_status,
+        "gh_pr_view" => run_gh_pr_view,
+        "gh_workflow_logs" => run_gh_workflow_logs,
+        "gh_fork" => run_gh_fork,
+        "gh_create_pr" => run_gh_create_pr,
         _ => return None,
     };
-    Some(result)
+    if let Err(e) = crate::egress::guard("https://api.github.com") {
+        return Some(Err(e));
+    }
+    Some(handler(input))
 }
 
 /// `gh_inbox(scope, owner?, repo?)` — polymorphic GitHub inbox. Routes to

--- a/crates/claudette/src/tools/gmail.rs
+++ b/crates/claudette/src/tools/gmail.rs
@@ -85,14 +85,19 @@ pub(super) fn schemas() -> Vec<Value> {
 }
 
 pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>> {
-    let result = match name {
-        "gmail_list" => run_gmail_list(input),
-        "gmail_search" => run_gmail_search(input),
-        "gmail_read" => run_gmail_read(input),
-        "gmail_list_labels" => run_gmail_list_labels(),
+    // Resolve the handler before running it so the offline egress guard can
+    // refuse before any request hits gmail.googleapis.com.
+    let handler: fn(&str) -> Result<String, String> = match name {
+        "gmail_list" => run_gmail_list,
+        "gmail_search" => run_gmail_search,
+        "gmail_read" => run_gmail_read,
+        "gmail_list_labels" => |_| run_gmail_list_labels(),
         _ => return None,
     };
-    Some(result)
+    if let Err(e) = crate::egress::guard("https://gmail.googleapis.com") {
+        return Some(Err(e));
+    }
+    Some(handler(input))
 }
 
 fn auth_header(

--- a/crates/claudette/src/tools/markets.rs
+++ b/crates/claudette/src/tools/markets.rs
@@ -41,11 +41,15 @@ pub(super) fn schemas() -> Vec<Value> {
 }
 
 pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>> {
-    let result = match name {
-        "tv_get_quote" => run_tv_get_quote(input),
-        _ => return None,
-    };
-    Some(result)
+    if name != "tv_get_quote" {
+        return None;
+    }
+    // tv_get_quote reaches scanner.tradingview.com (cloud); block under
+    // offline mode before any request leaves the process.
+    if let Err(e) = crate::egress::guard("https://scanner.tradingview.com") {
+        return Some(Err(e));
+    }
+    Some(run_tv_get_quote(input))
 }
 
 // ────── TradingView helpers ──────────────────────────────────────────────

--- a/crates/claudette/src/tools/mission.rs
+++ b/crates/claudette/src/tools/mission.rs
@@ -211,6 +211,10 @@ fn run_mission_start(input: &str) -> Result<String, String> {
     }
 
     let parsed = parse_target(target)?;
+    // Brownfield missions clone a remote over the network (a loopback URL
+    // would still be allowed). Refuse cloud clones under offline mode here —
+    // local/ephemeral forge work needs no clone and is unaffected.
+    crate::egress::guard(&parsed.clone_url)?;
     let dest_raw = v
         .get("dest")
         .and_then(Value::as_str)
@@ -398,6 +402,10 @@ fn run_mission_attach(input: &str) -> Result<String, String> {
 // ─── mission_submit (capstone) ───────────────────────────────────────────
 
 fn run_mission_submit(input: &str) -> Result<String, String> {
+    // Submitting pushes to origin and opens a PR via the GitHub API — both
+    // are network egress. Refuse up front under offline mode rather than doing
+    // local git work that can't be shipped.
+    crate::egress::guard_subprocess("mission_submit (push branch + open a pull request)")?;
     let v = parse_json_input(input, "mission_submit")?;
     let title = extract_str(&v, "title", "mission_submit")?;
     let body_in = v.get("body").and_then(Value::as_str).unwrap_or("");

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -362,6 +362,9 @@ fn run_web_fetch(input: &str) -> Result<String, String> {
         ));
     }
     validate_fetch_target(url)?;
+    // Offline mode: the SSRF guard above already rejects loopback/private
+    // targets, so any URL that reaches here is public — block it.
+    crate::egress::guard(url)?;
 
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(WEB_FETCH_TIMEOUT_SECS))

--- a/crates/claudette/src/tools/telegram.rs
+++ b/crates/claudette/src/tools/telegram.rs
@@ -41,11 +41,15 @@ pub(super) fn schemas() -> Vec<Value> {
 }
 
 pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>> {
-    let result = match name {
-        "tg_send" => run_tg_send(input),
-        _ => return None,
-    };
-    Some(result)
+    if name != "tg_send" {
+        return None;
+    }
+    // tg_send relays through api.telegram.org (cloud); block under offline
+    // mode before any request leaves the process.
+    if let Err(e) = crate::egress::guard("https://api.telegram.org") {
+        return Some(Err(e));
+    }
+    Some(run_tg_send(input))
 }
 
 /// Resolve the Telegram Bot API token via the unified secret store.

--- a/crates/claudette/src/tools/web_search.rs
+++ b/crates/claudette/src/tools/web_search.rs
@@ -40,6 +40,7 @@ pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>
 }
 
 fn run_web_search(input: &str) -> Result<String, String> {
+    crate::egress::guard("https://api.search.brave.com")?;
     let v: Value = serde_json::from_str(input)
         .map_err(|e| format!("web_search: invalid JSON ({e}): {input}"))?;
     let query = v

--- a/crates/claudette/src/tts.rs
+++ b/crates/claudette/src/tts.rs
@@ -35,6 +35,12 @@ pub fn voice_for_lang(lang: &str) -> &'static str {
 ///
 /// Returns the path to the generated MP3. Caller is responsible for cleanup.
 fn synthesize_to_mp3(text: &str, lang: &str, out_path: &Path) -> Result<(), String> {
+    // edge-tts streams from Microsoft's cloud neural-voice endpoint. Refuse
+    // under offline mode with the uniform air-gap message instead of letting
+    // the python subprocess fail with an opaque connection error.
+    crate::egress::guard_subprocess(
+        "text-to-speech (edge-tts streams from a Microsoft cloud endpoint)",
+    )?;
     let voice = match lang {
         "he" => std::env::var("CLAUDETTE_TTS_VOICE_HE")
             .unwrap_or_else(|_| "he-IL-HilaNeural".to_string()),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ Claudette intentionally does **not** auto-load `.env` from the current working d
 |----------|---------|---------|
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API endpoint. Honoured exactly like Ollama itself. |
 | `CLAUDETTE_ALLOW_REMOTE_OLLAMA` | unset | Set to `1` to silence the startup warning when `OLLAMA_HOST` is non-loopback. Default posture is local-only. |
+| `CLAUDETTE_OFFLINE` | unset | Set to `1` (or pass `--offline`) to **enforce the air-gap**: hard-block every outbound network call except the local model backend + loopback. See [Enforced offline mode](#enforced-offline-mode---offline) below. |
 | `CLAUDETTE_MODEL` | `qwen3.5:4b` (Auto preset) | Brain model override. |
 | `CLAUDETTE_NUM_CTX` | `16384` | Brain context window in tokens. |
 | `CLAUDETTE_NUM_PREDICT` | `6144` | Max output tokens per request. |
@@ -32,6 +33,18 @@ LM Studio exposes models with a `@<quant>` suffix in `/v1/models` — for exampl
 ### Backend quirks: brain and embeddings share `OLLAMA_HOST`
 
 Both the brain (`/v1/chat/completions`) and recall (`/v1/embeddings`) resolve to the same `OLLAMA_HOST`. There is no separate `CLAUDETTE_RECALL_HOST` knob. If you run a chat-only server (e.g. an MTP llama-server with no `--embeddings`) you'll see `recall: /v1/embeddings HTTP 501 Not Implemented` from `--doctor` and from `/recall`. Either (a) set `CLAUDETTE_RECALL_DISABLE=1`, or (b) load the embedding model on the same endpoint as the brain (LM Studio supports loading both simultaneously if VRAM allows).
+
+### Enforced offline mode (`--offline` / `CLAUDETTE_OFFLINE`)
+
+`--offline` (or `CLAUDETTE_OFFLINE=1`) turns claudette's local-first *posture* into an *enforced* air-gap. With it on, every outbound network call is checked against an allow-list and anything not on it is hard-blocked with a uniform error — `blocked by offline mode (--offline / CLAUDETTE_OFFLINE)…` — whether the call would have been made via reqwest or by spawning a subprocess.
+
+- **Allowed:** the resolved model backend host (`OLLAMA_HOST`, even a LAN box you opted into with `CLAUDETTE_ALLOW_REMOTE_OLLAMA=1` — matched at the host level, so any port on that box is reachable) and loopback (`localhost`, `127.0.0.0/8`, `::1`). The brain, recall embeddings, and local vision keep working.
+- **Blocked:** `web_search` / `web_fetch`, `gmail_*` / `calendar_*` / `--auth-google`, `tv_get_quote`, `wikipedia`, `weather`, the `gh_*` GitHub tools, `tg_send`, remote `git_push` / `git_clone`, the brownfield `mission_start` clone and `mission_submit` push, and text-to-speech (edge-tts).
+- **`--offline` + `--telegram`** is refused at startup — the Telegram bridge is a cloud relay (`api.telegram.org`) and can't run air-gapped.
+
+Inspect the live allow-list with `claudette --offline --doctor` — the **egress / air-gap** section prints exactly what's reachable and notes that the Google-OAuth live probe is skipped (it can't run offline).
+
+Two layers enforce it: an HTTP-layer guard in the reqwest path checks the destination host of every in-process request, and a dispatch-layer guard refuses tools that reach the network through a subprocess where the HTTP guard can't see the destination. The host-matching logic lives in [`src/egress.rs`](../crates/claudette/src/egress.rs).
 
 ## Codet (code-generation sidecar)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,7 +47,14 @@ claudette --tui                      # fullscreen TUI
 claudette "your prompt here"         # one-shot, prints reply and exits
 claudette --telegram --chat any      # Telegram bot
 claudette --resume                   # resume last session
+claudette --offline "..."            # enforced air-gap: block all cloud egress
 ```
+
+Add `--offline` (or set `CLAUDETTE_OFFLINE=1`) to any of these to **enforce**
+the air-gap — every outbound call except the local model backend + loopback is
+hard-blocked, so the brain and recall keep working but web search, mail, GitHub,
+Telegram, and remote git all refuse. `claudette --offline --doctor` prints the
+exact allow-list. See [Air-gapped by design](../README.md#-air-gapped-by-design).
 
 ## The TUI in 60 seconds
 


### PR DESCRIPTION
## What

Makes claudette's **"air-gapped by design"** claim *enforceable*, not just documented. Adds an offline mode — a `--offline` flag and `CLAUDETTE_OFFLINE=1` — that **hard-blocks every outbound network call** except the configured local model backend (the resolved Ollama / LM Studio host) and loopback.

> The difference between *configured* not to phone home and *can't* phone home.

## How — two enforcement layers

Not all egress is in-process, so a single hook isn't enough:

1. **HTTP layer** — a centralized host allow-list guard (`egress::guard`) wired into the reqwest path of every cloud-reaching tool: `web_search`/`web_fetch`, `gmail`/`calendar`/`google_auth`, markets/weather/wikipedia, `github`, telegram. Recall embeddings, the brain, and local vision pass the allow-list (backend host), so they keep working.
2. **Dispatch / subprocess layer** — `egress::guard_subprocess` for tools that reach the network by spawning a subprocess where the HTTP guard can't see the destination: remote `git_push`/`git_clone`, the brownfield `mission_start` clone + `mission_submit` push, and the edge-tts TTS subprocess.

Both layers emit the **same** uniform message — `blocked by offline mode (--offline / CLAUDETTE_OFFLINE)…` — so a refusal reads identically no matter where it tripped, never a confusing connection/subprocess error.

### Allow-list
`{ resolved backend host } ∪ { localhost, 127.0.0.0/8, ::1 }`. A LAN backend opted into via `CLAUDETTE_ALLOW_REMOTE_OLLAMA` stays allowed (host-level match) — *that's still your hardware*; all true cloud is blocked.

## Surfacing
- **Startup banner** confirms the enforced air-gap (stderr, so scriptable stdout stays clean).
- **`--offline` + `--telegram`** is refused at startup (the bridge relays through `api.telegram.org`).
- **`claudette --offline --doctor`** gains an *egress / air-gap* section that prints the live allow-list and **skips** the Google-OAuth cloud probe (so the report stays green-meaningful).

## Notes / accuracy
- The GitHub tools use the **REST API via reqwest** (not the `gh` CLI), so they're caught by the HTTP layer.
- Voice transcription has **no** auto huggingface download — the whisper model is user-placed — so there's nothing to block there. Voice is fully local; only TTS (edge-tts) and the Telegram file fetch are cloud, and both are covered.
- Factored a shared `api::host_of_url` out of `is_local_ollama_url` so the loopback warning and the allow-list judge hosts identically.

## Tests
- New `egress.rs` unit tests: loopback always allowed, cloud denied, LAN-backend allowed (host-level) while other LAN/cloud denied, guard is a no-op when off, uniform block message + prefix, allow-list contents.
- New `main.rs` test: `--offline` flips the env var and isn't echoed as a prompt word.
- Full gate green locally: `cargo fmt --all --check`, `cargo clippy --all-targets --no-deps -- -D warnings`, `cargo test --lib --bins` (1022 lib + 25 bin).

## Docs
PRIVACY.md (new *Enforced offline mode* section; `--offline` moved from "Future" to shipped), README (*Air-gapped by design* + roadmap), `docs/quickstart.md`, `docs/configuration.md`.

Depth over breadth: one hardening feature, no new product surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)