### PR TITLE
feat(egress): prove the air-gap in CI + close web_fetch redirect SSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Security
+
+- **`web_fetch` now re-validates every HTTP redirect target.** Previously the
+  SSRF guard checked only the *initial* URL, then reqwest silently followed up
+  to 10 redirects — so a public page returning `301 → http://169.254.169.254/`
+  (cloud metadata) or `→ http://192.168.0.1/` could pivot the fetch onto a
+  loopback/private/link-local host. The client now carries a custom redirect
+  policy that re-runs the loopback/private/metadata check on each hop and
+  refuses any disallowed target.
+
+### Added
+
+- **CI-proven air-gap.** A new integration test (`tests/offline_egress.rs`)
+  drives every network-reaching tool through the real `dispatch_tool` path
+  under `CLAUDETTE_OFFLINE=1` and asserts each one refuses (with the uniform
+  offline-block message) before any request leaves the process — turning the
+  enforced offline guarantee into a build-gating test rather than a documented
+  promise. Backed by a canonical `egress::NET_TOOLS` registry with a regression
+  guard that catches a new always-network tool (`gh_*`/`gmail_*`/`calendar_*`/
+  `tg_*`) added without its egress guard.
+
 ## [0.8.9] - 2026-06-04
 
 ### Added

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -33,6 +33,8 @@ When enabled, **every** outbound network call is checked against a tiny allow-li
 
 Enforcement is two-layered so nothing slips through: an HTTP-layer guard in the reqwest path (it checks the destination host of every in-process request), plus a dispatch-layer guard for tools that reach the network by spawning a subprocess (`git`, `python -m edge_tts`) where the HTTP guard can't see the destination.
 
+This is **CI-proven, not just asserted in prose.** An integration test (`tests/offline_egress.rs`) drives every network-reaching tool through the real dispatch path under `CLAUDETTE_OFFLINE=1` and fails the build if any one of them connects out instead of refusing. Separately — even with offline mode *off* — `web_fetch` re-validates the target of **every HTTP redirect**, so a public page that answers `301 → http://169.254.169.254/` (the cloud-metadata address) or `→ http://192.168.0.1/` can't smuggle the fetch onto your LAN or a metadata service (SSRF).
+
 **LAN backends are still your hardware.** If your model runs on another box on your network (`OLLAMA_HOST=http://192.168.1.50:11434`, opted into with `CLAUDETTE_ALLOW_REMOTE_OLLAMA=1`), that host stays on the allow-list. Offline mode blocks the *cloud*, not the model you own.
 
 `--offline` and `--telegram` are mutually exclusive — the Telegram bridge relays through `api.telegram.org`, so Claudette refuses to start the bot under offline mode rather than failing every poll.

--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -45,6 +45,60 @@ pub const OFFLINE_ENV: &str = "CLAUDETTE_OFFLINE";
 /// sentence.
 pub const BLOCK_PREFIX: &str = "blocked by offline mode (--offline / CLAUDETTE_OFFLINE)";
 
+/// Canonical registry of every tool whose normal operation reaches the network
+/// and is therefore gated by [`guard`] / [`guard_subprocess`] under offline
+/// mode. This is the single source of truth the no-egress integration test
+/// (`tests/offline_egress.rs`) iterates: it drives each tool through
+/// `dispatch_tool` with `CLAUDETTE_OFFLINE=1` and asserts every one refuses
+/// with a [`BLOCK_PREFIX`] message — turning the air-gap from a documented
+/// posture into a CI-proven guarantee.
+///
+/// MAINTENANCE CONTRACT: when you add a tool that performs network egress, add
+/// its name here *and* wire its `egress::guard*` call. The integration test
+/// fails if a tool listed here is not actually guarded; the registry test
+/// (`net_tools_registry_covers_network_named_tools`) fails if a tool in an
+/// always-network family (`gh_`, `gmail_`, `calendar_`, `tg_`) is missing from
+/// this list — so a forgotten guard on those families is caught automatically.
+/// Tools in mixed families (`git_*`, `mission_*` have local siblings) must be
+/// added here by hand.
+pub const NET_TOOLS: &[&str] = &[
+    // Search / fetch
+    "web_search",
+    "web_fetch",
+    // GitHub (REST via reqwest → api.github.com)
+    "gh_inbox",
+    "gh_get_issue",
+    "gh_create_issue",
+    "gh_comment_issue",
+    "gh_search_code",
+    "gh_list_repo_issues",
+    "gh_pr_status",
+    "gh_pr_view",
+    "gh_workflow_logs",
+    "gh_fork",
+    "gh_create_pr",
+    // Google (Gmail + Calendar)
+    "gmail_list",
+    "gmail_search",
+    "gmail_read",
+    "gmail_list_labels",
+    "calendar_list_events",
+    "calendar_create_event",
+    "calendar_update_event",
+    "calendar_delete_event",
+    // Keyless facts / markets
+    "tv_get_quote",
+    "wikipedia",
+    "weather",
+    // Telegram bridge
+    "tg_send",
+    // Network-reaching git + brownfield-mission subprocesses
+    "git_push",
+    "git_clone",
+    "mission_start",
+    "mission_submit",
+];
+
 /// Returns true when offline mode is enabled. Truthy = set, non-empty, and not
 /// literally `"0"` — matching the convention used by `CLAUDETTE_FACELESS`,
 /// `CLAUDETTE_ALLOW_REMOTE_OLLAMA`, and the skip-probe flags.

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -366,10 +366,7 @@ fn run_web_fetch(input: &str) -> Result<String, String> {
     // targets, so any URL that reaches here is public — block it.
     crate::egress::guard(url)?;
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(WEB_FETCH_TIMEOUT_SECS))
-        .build()
-        .map_err(|e| format!("web_fetch: build http client: {e}"))?;
+    let client = web_fetch_client()?;
 
     let resp = client
         .get(url)
@@ -408,6 +405,33 @@ fn run_web_fetch(input: &str) -> Result<String, String> {
         "text": wrapped,
     })
     .to_string())
+}
+
+/// Build the blocking HTTP client `web_fetch` uses, carrying a **custom
+/// redirect policy** that re-runs [`validate_fetch_target`] on every redirect
+/// hop. Without this, `validate_fetch_target(url)?` only checks the *initial*
+/// URL while reqwest then silently follows up to 10 redirects — so a public
+/// page returning `301 → http://169.254.169.254/` (cloud metadata) or
+/// `→ http://192.168.0.1/` would bypass the SSRF guard. The policy refuses any
+/// redirect target the guard rejects, and caps the chain at 10 hops (matching
+/// reqwest's default) so a redirect loop can't spin forever.
+fn web_fetch_client() -> Result<reqwest::blocking::Client, String> {
+    let policy = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error(std::io::Error::other("web_fetch: too many redirects"));
+        }
+        match validate_fetch_target(attempt.url().as_str()) {
+            Ok(()) => attempt.follow(),
+            // The SSRF guard rejected this redirect target — turn it into a
+            // hard error so the chain stops here instead of being followed.
+            Err(msg) => attempt.error(std::io::Error::other(msg)),
+        }
+    });
+    reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(WEB_FETCH_TIMEOUT_SECS))
+        .redirect(policy)
+        .build()
+        .map_err(|e| format!("web_fetch: build http client: {e}"))
 }
 
 /// SSRF guard for `web_fetch`. Refuses URLs whose host is loopback, private
@@ -535,6 +559,44 @@ mod tests {
         }
         // A normal public IP literal is allowed.
         assert!(validate_fetch_target("https://1.1.1.1/").is_ok());
+    }
+
+    #[test]
+    fn web_fetch_client_refuses_redirect_to_internal_host() {
+        // Proves the redirect policy is actually wired into the web_fetch
+        // client (not just that validate_fetch_target works in isolation). A
+        // loopback server answers 301 → http://169.254.169.254/ (cloud
+        // metadata). The client must refuse to follow it: send() returns Err.
+        //
+        // We drive the client directly with a loopback *initial* URL — the
+        // policy only runs on the redirect hop, so the initial loopback
+        // address is reached, and the 169.254 redirect target is what the
+        // policy rejects. (run_web_fetch additionally blocks loopback initial
+        // URLs up front; that path is covered by the SSRF test above.)
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf); // drain the request line
+                let resp = "HTTP/1.1 301 Moved Permanently\r\n\
+                            Location: http://169.254.169.254/\r\n\
+                            Content-Length: 0\r\n\r\n";
+                let _ = stream.write_all(resp.as_bytes());
+            }
+        });
+
+        let client = web_fetch_client().expect("build client");
+        let result = client.get(format!("http://{addr}/")).send();
+        let _ = server.join();
+
+        assert!(
+            result.is_err(),
+            "redirect to the 169.254.169.254 metadata host must be refused"
+        );
     }
 
     #[test]

--- a/crates/claudette/tests/offline_egress.rs
+++ b/crates/claudette/tests/offline_egress.rs
@@ -1,0 +1,155 @@
+//! Proves the air-gap end-to-end.
+//!
+//! v0.8.9 shipped enforced offline mode, but until now it was tested only at
+//! the *policy-function* level (`egress::is_allowed_host`). Nothing proved that
+//! the actual tool-dispatch path — the thing the model drives — makes zero
+//! cloud connections under `--offline`. This integration test closes that gap:
+//! with `CLAUDETTE_OFFLINE=1`, it drives every network-reaching tool through
+//! the real [`dispatch_tool`] entry point and asserts each one refuses with the
+//! uniform [`egress::BLOCK_PREFIX`] message *before* any request leaves the
+//! process. The air-gap is now a CI-proven guarantee, not just a posture.
+//!
+//! Approach: dispatch-level assertion (no sockets). Every guard fires before
+//! the tool opens a connection, so a refusal at the dispatch layer is proof of
+//! zero egress. We point `OLLAMA_HOST` at loopback so the backend stays
+//! allow-listed (the brain/recall path must keep working under offline mode).
+
+use claudette::egress::{self, BLOCK_PREFIX, NET_TOOLS};
+use claudette::secretary_tools_json;
+use claudette::tools::dispatch_tool;
+
+/// Serialises the env-mutating tests: `CLAUDETTE_OFFLINE` / `OLLAMA_HOST` are
+/// process-global, so parallel tests in this binary would otherwise race.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Enables offline mode + a loopback backend for a test's duration and restores
+/// the prior environment on drop (mirrors the env-guard in `egress.rs`'s unit
+/// tests). Declare it *after* the `ENV_LOCK` guard so it drops first — env is
+/// restored while the lock is still held.
+struct OfflineEnv {
+    offline: Option<String>,
+    ollama: Option<String>,
+}
+
+impl OfflineEnv {
+    fn set() -> Self {
+        let prev = Self {
+            offline: std::env::var(egress::OFFLINE_ENV).ok(),
+            ollama: std::env::var("OLLAMA_HOST").ok(),
+        };
+        std::env::set_var(egress::OFFLINE_ENV, "1");
+        std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
+        prev
+    }
+}
+
+impl Drop for OfflineEnv {
+    fn drop(&mut self) {
+        restore(egress::OFFLINE_ENV, self.offline.as_deref());
+        restore("OLLAMA_HOST", self.ollama.as_deref());
+    }
+}
+
+fn restore(key: &str, val: Option<&str>) {
+    match val {
+        Some(v) => std::env::set_var(key, v),
+        None => std::env::remove_var(key),
+    }
+}
+
+/// The minimal input each tool needs to *reach* its egress guard. Most tools
+/// guard at the dispatch/group level (or the first line of their handler)
+/// before touching their input, so `{}` is enough. Three parse input first:
+/// `web_fetch` needs a public URL that clears the SSRF check, and
+/// `git_clone` / `mission_start` need a remote target — each then hits the
+/// guard before any side effect (network *or* filesystem).
+fn offline_probe_input(tool: &str) -> &'static str {
+    match tool {
+        "web_fetch" => r#"{"url":"https://1.1.1.1/"}"#,
+        "git_clone" => {
+            r#"{"url":"https://github.com/octocat/Hello-World.git","dest":"claudette-offline-probe"}"#
+        }
+        "mission_start" => r#"{"target":"octocat/Hello-World"}"#,
+        _ => "{}",
+    }
+}
+
+#[test]
+fn every_net_tool_refuses_under_offline() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _env = OfflineEnv::set();
+
+    for &tool in NET_TOOLS {
+        match dispatch_tool(tool, offline_probe_input(tool)) {
+            Ok(out) => panic!("{tool} reached the network under offline mode (returned Ok): {out}"),
+            Err(err) => assert!(
+                err.starts_with(BLOCK_PREFIX),
+                "{tool} must refuse with the uniform air-gap message, got: {err}"
+            ),
+        }
+    }
+}
+
+#[test]
+fn backend_and_loopback_stay_allowed_under_offline() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _env = OfflineEnv::set();
+
+    // The backend / recall-embeddings path is on the allow-list — offline mode
+    // must NOT block it, or the local model itself would stop working. This is
+    // the positive control for the blocks above.
+    assert!(
+        egress::guard("http://localhost:11434/api/embeddings").is_ok(),
+        "loopback backend must stay reachable under offline mode"
+    );
+    assert!(
+        egress::guard("http://127.0.0.1:1234/v1/chat/completions").is_ok(),
+        "LM Studio loopback must stay reachable under offline mode"
+    );
+}
+
+#[test]
+fn net_tools_registry_is_consistent_and_covers_network_families() {
+    use std::collections::HashSet;
+
+    // (a) No duplicate entries in the registry.
+    let mut seen = HashSet::new();
+    for &t in NET_TOOLS {
+        assert!(seen.insert(t), "duplicate entry in NET_TOOLS: {t}");
+    }
+
+    // (b) Every registered net tool is a real, dispatchable tool that appears
+    // in the advertised schema (catches a rename/removal that would silently
+    // drop a tool from coverage).
+    let schema = secretary_tools_json();
+    let schema_names: HashSet<String> = schema
+        .as_array()
+        .expect("tool schema is a JSON array")
+        .iter()
+        .filter_map(|t| t.pointer("/function/name").and_then(|v| v.as_str()))
+        .map(str::to_string)
+        .collect();
+    for &t in NET_TOOLS {
+        assert!(
+            schema_names.contains(t),
+            "NET_TOOLS lists '{t}' but it is not in the tool schema (renamed or removed?)"
+        );
+    }
+
+    // (c) Forgotten-guard regression guard: every tool in an *always-network*
+    // family must be listed. Add a new `gh_*` (etc.) tool but forget the guard
+    // + registry entry and this fails loudly. `git_*` / `mission_*` have local
+    // siblings, so they can't be swept by prefix and are maintained by hand in
+    // egress::NET_TOOLS.
+    const ALWAYS_NET_PREFIXES: &[&str] = &["gh_", "gmail_", "calendar_", "tg_"];
+    let registry: HashSet<&str> = NET_TOOLS.iter().copied().collect();
+    for name in &schema_names {
+        if ALWAYS_NET_PREFIXES.iter().any(|p| name.starts_with(p)) {
+            assert!(
+                registry.contains(name.as_str()),
+                "tool '{name}' is in an always-network family but missing from \
+                 egress::NET_TOOLS — add it there and wire its egress::guard call"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

PR1 of the Tier-1+2 roadmap. Two independent hardenings of the enforced-offline guarantee shipped in v0.8.9 — the claim the upcoming Show HN launch leads on.

### A — CI-proven air-gap (the headline)
- New integration test `crates/claudette/tests/offline_egress.rs` drives **every** network-reaching tool through the real `dispatch_tool` path under `CLAUDETTE_OFFLINE=1` and asserts each one refuses (uniform `egress::BLOCK_PREFIX`) **before any request leaves the process**. Until now offline mode was tested only at the policy-function level (`is_allowed_host`); nothing proved the whole dispatch path makes zero cloud connections.
- Positive control: the loopback backend / recall-embeddings path stays allowed under offline.
- Backed by a canonical `egress::NET_TOOLS` registry (single source of truth) + a regression-guard test that fails if a new always-network tool (`gh_`/`gmail_`/`calendar_`/`tg_`) is added without its guard.

### B — close the `web_fetch` redirect-SSRF gap
- `validate_fetch_target` previously checked only the **initial** URL, then reqwest followed up to 10 redirects unchecked → a `301 → http://169.254.169.254/` (cloud metadata) or `→ http://192.168.x.x/` bypassed the SSRF guard.
- The `web_fetch` client now carries a custom `reqwest::redirect::Policy` that re-runs the loopback/private/metadata check on **every** hop and caps the chain at 10. New unit test spins a loopback server that 301s to `169.254.169.254` and asserts the client refuses to follow — proving the policy is actually wired into the client, not just that the check function works in isolation.

### Part C (centralization) — evaluated, skipped
`external_http_client` is shared by tools with differing redirect needs and `web_fetch` builds its own client, so folding them behind one factory isn't a clean refactor. The per-call `egress::guard()` sites are correct defense-in-depth and stay. Spec marks Part C optional.

## Why
Protects the exact claim we're about to launch on, and closes an independent SSRF hole.

## Tests / gate
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --no-deps -- -D warnings` ✅
- `cargo test --lib --bins` ✅ (1023 + 25 passed, 0 failed)
- `cargo test --test offline_egress` ✅ (3 passed)

## Out of scope
No change to what offline allows/denies (already shipped). No new product surface. No version bump (the roadmap bumps once at the end of the PR series).

Spec: `plans/tier12-2026-06-04/PR1-egress-chokepoint.md` (local working note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)