### PR TITLE
feat(tui): prompt for DangerFullAccess tools instead of silently denying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Added
+
+- **The TUI now prompts for `DangerFullAccess` tools instead of silently
+  denying them.** Previously the fullscreen TUI had no permission prompter, so
+  `bash`, `edit_file`, `git add/commit/push`, and every other dangerous tool
+  was auto-denied — the headline coding surface couldn't edit a file or run a
+  command. A confirmation modal now shows the tool name and its **full** input
+  (wrapped + scrollable, never truncated); `y` allows, `n`/`Esc`/`Enter`
+  denies. Any way the TUI exits while a prompt is pending — quit, crash, error
+  — resolves the pending tool as denied, never hung.
+
 ### Changed
 
 - **The OpenAI-compat (LM Studio / vLLM / llama.cpp) path now streams.** It

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -14,7 +14,7 @@
 //! Sprint G adds the `TuiPrompter` for `DangerFullAccess` confirmation modals.
 
 use std::path::PathBuf;
-use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError};
 use std::time::{Duration, Instant};
 
 use crate::Session;
@@ -184,6 +184,22 @@ impl Default for NotesState {
     }
 }
 
+/// A pending `DangerFullAccess` permission prompt (Sprint G / PR5). The
+/// worker thread is parked inside `PermissionPrompter::decide()` until the
+/// user answers over `resp_tx` — or until this struct drops (any render-loop
+/// exit path), which the worker reads as a deny.
+struct PermissionPrompt {
+    tool_name: String,
+    /// Full tool input — display-side wrap + scroll, never truncated.
+    input: String,
+    /// e.g. "danger-full-access".
+    required_mode: String,
+    /// Vertical scroll offset for long inputs (↑/↓).
+    scroll: u16,
+    /// Rendezvous answer channel: `true` → allow, `false` → deny.
+    resp_tx: SyncSender<bool>,
+}
+
 /// All mutable TUI state — owned entirely by the render loop thread.
 struct App {
     // ── Conversation ──────────────────────────────────────────────────────
@@ -207,6 +223,11 @@ struct App {
     /// Space Invaders modal. `Some` while the game is being played; `None`
     /// otherwise. Toggled via Ctrl+G.
     space_game: Option<space::SpaceGame>,
+
+    // ── Permissions ───────────────────────────────────────────────────────
+    /// Pending DangerFullAccess confirmation modal. Outranks every other
+    /// input mode while `Some` — the worker thread is blocked on the answer.
+    permission_prompt: Option<PermissionPrompt>,
 
     // ── Tool log ──────────────────────────────────────────────────────────
     all_tool_records: Vec<ToolRecord>,
@@ -244,6 +265,7 @@ impl Default for App {
             paste_file: paste::PasteFile::new(),
             working: false,
             space_game: None,
+            permission_prompt: None,
             all_tool_records: Vec::new(),
             notes: NotesState::default(),
             todos: TodosState::default(),
@@ -263,6 +285,27 @@ impl App {
     fn handle_tui_event(&mut self, event: TuiEvent) {
         match event {
             TuiEvent::Token(delta) => self.streaming_text.push_str(&delta),
+
+            TuiEvent::PermissionRequest {
+                tool_name,
+                input,
+                required_mode,
+                resp_tx,
+            } => {
+                // A permission question outranks the easter egg and any
+                // pane edit mode — force-close them so their input branches
+                // can't starve the modal (the worker is blocked until the
+                // user answers).
+                self.space_game = None;
+                self.notes.filter_editing = false;
+                self.permission_prompt = Some(PermissionPrompt {
+                    tool_name,
+                    input,
+                    required_mode,
+                    scroll: 0,
+                    resp_tx,
+                });
+            }
 
             TuiEvent::TurnComplete { text, .. } => {
                 self.history.push(Message {
@@ -736,6 +779,68 @@ fn run_loop(
                     app.hw.last_error = Some(e);
                 }
             }
+        }
+
+        // Permission modal — highest-priority input mode; owns its own
+        // draw + poll, then loops. Must come BEFORE the Space Invaders
+        // branch (whose `continue` would otherwise starve it) — and the
+        // event handler force-closes the game/filter modes on arrival.
+        // The worker thread is parked in `decide()` until we answer via
+        // `resp_tx`; every exit path that drops the prompt instead (quit,
+        // `?` error) reads as a deny on the worker side.
+        if app.permission_prompt.is_some() {
+            terminal.draw(|f| render::render(f, &app))?;
+            if event::poll(Duration::from_millis(50))? {
+                if let Event::Key(k) = event::read()? {
+                    // Windows fires Press + Release — Press only.
+                    if k.kind == KeyEventKind::Press {
+                        match (k.code, k.modifiers) {
+                            // Quit: deny first so the worker unblocks
+                            // promptly, then shut down as usual.
+                            (KeyCode::Char('c' | 'd'), KeyModifiers::CONTROL) => {
+                                if let Some(p) = app.permission_prompt.take() {
+                                    let _ = p.resp_tx.send(false);
+                                }
+                                let _ = user_tx.send(UserInput::Quit);
+                                return Ok(());
+                            }
+                            (
+                                KeyCode::Char('y' | 'Y'),
+                                KeyModifiers::NONE | KeyModifiers::SHIFT,
+                            ) => {
+                                if let Some(p) = app.permission_prompt.take() {
+                                    let _ = p.resp_tx.send(true);
+                                }
+                            }
+                            // Default-deny, matching CliPrompter's
+                            // anything-but-y semantics on Enter.
+                            (
+                                KeyCode::Char('n' | 'N'),
+                                KeyModifiers::NONE | KeyModifiers::SHIFT,
+                            )
+                            | (KeyCode::Esc | KeyCode::Enter, _) => {
+                                if let Some(p) = app.permission_prompt.take() {
+                                    let _ = p.resp_tx.send(false);
+                                }
+                            }
+                            // Long inputs scroll; everything else is
+                            // swallowed while the modal is up.
+                            (KeyCode::Up, _) => {
+                                if let Some(p) = app.permission_prompt.as_mut() {
+                                    p.scroll = p.scroll.saturating_sub(1);
+                                }
+                            }
+                            (KeyCode::Down, _) => {
+                                if let Some(p) = app.permission_prompt.as_mut() {
+                                    p.scroll = p.scroll.saturating_add(1);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            continue;
         }
 
         // Space Invaders modal — own its own input + tick loop, then loop.

--- a/crates/claudette/src/tui/render.rs
+++ b/crates/claudette/src/tui/render.rs
@@ -15,7 +15,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
     Frame,
 };
 
@@ -58,6 +58,96 @@ pub(super) fn render(f: &mut Frame, app: &App) {
     if let Some(game) = app.space_game.as_ref() {
         game.draw(f, area);
     }
+
+    // Permission confirmation modal — drawn last so it sits above
+    // everything, including the easter-egg overlay. The worker thread is
+    // blocked until the user answers.
+    if let Some(prompt) = app.permission_prompt.as_ref() {
+        render_permission_modal(f, prompt, area);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Permission modal (Sprint G / PR5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Centred confirmation overlay for a pending `DangerFullAccess` tool call.
+///
+/// Shows the **full** input — long bodies wrap and scroll (↑/↓) rather than
+/// truncate, so an adversarial payload can't hide past a preview edge (same
+/// rationale as `CliPrompter`). The char count in the title makes a body
+/// that scrolls below the fold detectable at a glance.
+fn render_permission_modal(f: &mut Frame, prompt: &super::PermissionPrompt, area: Rect) {
+    // ~70% × ~60%, centred — same overlay shape as the Space Invaders modal.
+    let ow = (area.width.saturating_mul(7) / 10).clamp(24.min(area.width), area.width);
+    let oh = (area.height.saturating_mul(6) / 10).clamp(6.min(area.height), area.height);
+    let ox = area.x + area.width.saturating_sub(ow) / 2;
+    let oy = area.y + area.height.saturating_sub(oh) / 2;
+    let overlay = Rect::new(ox, oy, ow, oh);
+
+    f.render_widget(Clear, overlay);
+
+    let chars = prompt.input.chars().count();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(
+            " ⚠ {} wants to run ({chars} chars, {}) ",
+            prompt.tool_name, prompt.required_mode
+        ))
+        .style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(overlay);
+    f.render_widget(block, overlay);
+
+    // Body (scrollable) above a fixed one-line footer that never scrolls
+    // out of view.
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let body_lines: Vec<Line> = if prompt.input.is_empty() {
+        vec![Line::from(Span::styled(
+            "(empty input)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        prompt
+            .input
+            .lines()
+            .map(|l| Line::from(l.to_string()))
+            .collect()
+    };
+    // Clamp the scroll offset to the wrapped row count. ratatui's Wrap
+    // render path draws an EMPTY paragraph when `scroll.y` exceeds the
+    // content (the line composer exhausts and returns early) — without
+    // this clamp, holding ↓ would scroll the payload fully off-screen and
+    // let the user approve a blank modal, defeating the modal's anti-hide
+    // purpose. Same render-time clamp the chat pane uses.
+    let total = wrapped_row_count(&body_lines, rows[0].width);
+    let max_scroll = total.saturating_sub(rows[0].height);
+    let scroll = prompt.scroll.min(max_scroll);
+
+    let body = Paragraph::new(body_lines)
+        .style(Style::default().fg(Color::White))
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
+    f.render_widget(body, rows[0]);
+
+    // "(end)" only when there IS hidden content to scroll through and the
+    // user has reached its bottom — tells them nothing more is below.
+    let footer_text = if max_scroll > 0 && scroll == max_scroll {
+        " Allow? [y/N] · Esc denies · ↑↓ scroll · (end) "
+    } else {
+        " Allow? [y/N] · Esc denies · ↑↓ scroll "
+    };
+    let footer = Paragraph::new(Line::from(Span::styled(
+        footer_text,
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )));
+    f.render_widget(footer, rows[1]);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/claudette/src/tui_events.rs
+++ b/crates/claudette/src/tui_events.rs
@@ -37,6 +37,28 @@ pub enum TuiEvent {
     /// Informational text from a slash command (e.g. /help, /status, /tools).
     /// Rendered as a non-error system message in the chat history.
     Info(String),
+    /// The worker thread is blocked inside a permission prompt for a
+    /// `DangerFullAccess` tool. The render loop must show the confirmation
+    /// modal and answer over `resp_tx` — NOT over `UserInput`, because the
+    /// worker owns that receiver and cannot read it while parked inside
+    /// `run_turn`.
+    ///
+    /// Each request carries its own rendezvous channel, so a buffered or
+    /// stale answer from an earlier prompt can never satisfy a later one,
+    /// and any render-loop exit path that drops the prompt automatically
+    /// denies it (the worker's `recv()` sees `Disconnected`).
+    PermissionRequest {
+        tool_name: String,
+        /// The tool's full input — never truncated here. The render side
+        /// owns presentation (wrap + scroll), so no payload can hide past
+        /// a preview edge (same rationale as `CliPrompter`).
+        input: String,
+        /// Display string of the tier the tool requires
+        /// (e.g. "danger-full-access").
+        required_mode: String,
+        /// Answer channel: `true` → allow, `false` → deny.
+        resp_tx: std::sync::mpsc::SyncSender<bool>,
+    },
 }
 
 /// One image attached to a user turn — base64-encoded payload paired with

--- a/crates/claudette/src/tui_worker.rs
+++ b/crates/claudette/src/tui_worker.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{
     compact_session, estimate_session_tokens, CompactionConfig, ContentBlock, ConversationRuntime,
-    Session,
+    PermissionPromptDecision, PermissionPrompter, PermissionRequest, Session,
 };
 
 use crate::api::{tui_text_callback, OllamaApiClient};
@@ -41,8 +41,8 @@ type TuiRuntime = ConversationRuntime<OllamaApiClient, TuiToolExecutor>;
 /// pushed the per-turn payload to ~2,500 tokens. Now ~200.
 ///
 /// Uses the same per-tool permission policy as the REPL so `ReadOnly` +
-/// `WorkspaceWrite` tools pass through. `DangerFullAccess` tools are denied
-/// (no prompter yet). Sprint G will add `TuiPrompter` for confirmation modals.
+/// `WorkspaceWrite` tools pass through. `DangerFullAccess` tools prompt the
+/// user via [`TuiPrompter`] (a confirmation modal in the render loop).
 fn build_tui_runtime(session: Session, tui_tx: SyncSender<TuiEvent>) -> TuiRuntime {
     let reg = ToolRegistry::new();
     let registry = Arc::new(Mutex::new(reg));
@@ -75,6 +75,64 @@ fn build_tui_runtime(session: Session, tui_tx: SyncSender<TuiEvent>) -> TuiRunti
             reg.group_tool_names(group)
         })
     })
+}
+
+/// TUI analogue of [`crate::run::CliPrompter`] — the permission prompter
+/// for `DangerFullAccess` tools (bash, edit_file, git mutations, …).
+///
+/// Runs on the worker thread, which is parked inside `run_turn` while a
+/// decision is pending, so the answer cannot arrive over the regular
+/// `UserInput` channel (the worker owns that receiver but is not reading
+/// it mid-turn). Instead, each `decide()` creates a fresh rendezvous
+/// channel and ships its sender to the render loop inside
+/// [`TuiEvent::PermissionRequest`]:
+///
+/// - per-request channel ⇒ a stale/buffered answer from an earlier prompt
+///   can never satisfy a later one, by construction;
+/// - every render-loop exit path (quit, error `?`, panic) drops the sender
+///   ⇒ `recv()` returns `Disconnected` ⇒ the tool is denied, never hung.
+pub struct TuiPrompter {
+    tui_tx: SyncSender<TuiEvent>,
+}
+
+impl TuiPrompter {
+    pub fn new(tui_tx: SyncSender<TuiEvent>) -> Self {
+        Self { tui_tx }
+    }
+}
+
+impl PermissionPrompter for TuiPrompter {
+    fn decide(&mut self, request: &PermissionRequest) -> PermissionPromptDecision {
+        // Rendezvous (capacity 0): the render loop's send completes only
+        // when this thread is at `recv()` — which it is, nanoseconds after
+        // the event send below. FIFO ordering on `tui_tx` guarantees the
+        // render loop sees the request before any answer is expected.
+        let (resp_tx, resp_rx) = std::sync::mpsc::sync_channel::<bool>(0);
+
+        let sent = self.tui_tx.send(TuiEvent::PermissionRequest {
+            tool_name: request.tool_name.clone(),
+            input: request.input.clone(),
+            required_mode: request.required_mode.as_str().to_string(),
+            resp_tx,
+        });
+        if sent.is_err() {
+            // Render loop is gone — fail closed, same reason CliPrompter
+            // uses when it cannot read an answer.
+            return PermissionPromptDecision::Deny {
+                reason: "could not read user input".to_string(),
+            };
+        }
+
+        match resp_rx.recv() {
+            Ok(true) => PermissionPromptDecision::Allow,
+            Ok(false) => PermissionPromptDecision::Deny {
+                reason: "user denied permission".to_string(),
+            },
+            Err(_) => PermissionPromptDecision::Deny {
+                reason: "could not read user input".to_string(),
+            },
+        }
+    }
 }
 
 /// Run a slash command typed in the TUI through the shared dispatcher.
@@ -216,6 +274,7 @@ pub fn spawn_worker(
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut runtime = build_tui_runtime(session, tui_tx.clone());
+        let mut prompter = TuiPrompter::new(tui_tx.clone());
 
         // Pre-flight the recall embedder so a missing embed model surfaces
         // a clear warn line before the first turn instead of as per-turn
@@ -253,9 +312,9 @@ pub fn spawn_worker(
                         .map(|att| (att.media_type, att.data_b64))
                         .collect();
                     let turn_result = if image_pairs.is_empty() {
-                        runtime.run_turn(&text, None)
+                        runtime.run_turn(&text, Some(&mut prompter))
                     } else {
-                        runtime.run_turn_with_images(&text, image_pairs, None)
+                        runtime.run_turn_with_images(&text, image_pairs, Some(&mut prompter))
                     };
                     match turn_result {
                         Ok(summary) => {
@@ -327,7 +386,138 @@ pub fn spawn_worker(
 
 #[cfg(test)]
 mod tests {
-    use super::strip_ansi_escapes;
+    use super::{strip_ansi_escapes, TuiPrompter};
+    use crate::tui_events::TuiEvent;
+    use crate::{
+        PermissionMode, PermissionOutcome, PermissionPolicy, PermissionPromptDecision,
+        PermissionPrompter, PermissionRequest,
+    };
+    use std::sync::mpsc;
+
+    fn danger_request(input: &str) -> PermissionRequest {
+        PermissionRequest {
+            tool_name: "bash".to_string(),
+            input: input.to_string(),
+            current_mode: PermissionMode::WorkspaceWrite,
+            required_mode: PermissionMode::DangerFullAccess,
+        }
+    }
+
+    /// Pretend to be the render loop: receive one PermissionRequest event
+    /// and answer it (or drop the channel when `answer` is None).
+    fn spawn_render_stub(
+        tui_rx: mpsc::Receiver<TuiEvent>,
+        answer: Option<bool>,
+    ) -> std::thread::JoinHandle<(String, String, String)> {
+        std::thread::spawn(move || match tui_rx.recv().expect("no event") {
+            TuiEvent::PermissionRequest {
+                tool_name,
+                input,
+                required_mode,
+                resp_tx,
+            } => {
+                if let Some(ans) = answer {
+                    resp_tx.send(ans).expect("worker hung up");
+                }
+                // None → resp_tx drops here, simulating a render-loop exit.
+                (tool_name, input, required_mode)
+            }
+            other => panic!("unexpected event: {other:?}"),
+        })
+    }
+
+    #[test]
+    fn tui_prompter_allows_on_true_and_ships_full_input() {
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        let stub = spawn_render_stub(tui_rx, Some(true));
+        let mut p = TuiPrompter::new(tui_tx);
+
+        let decision = p.decide(&danger_request("rm -rf ./target && echo done"));
+        assert_eq!(decision, PermissionPromptDecision::Allow);
+
+        let (tool, input, mode) = stub.join().unwrap();
+        assert_eq!(tool, "bash");
+        // Full input — no truncation anywhere on the prompt path.
+        assert_eq!(input, "rm -rf ./target && echo done");
+        assert_eq!(mode, "danger-full-access");
+    }
+
+    #[test]
+    fn tui_prompter_denies_on_false_with_cli_parity_reason() {
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        let stub = spawn_render_stub(tui_rx, Some(false));
+        let mut p = TuiPrompter::new(tui_tx);
+
+        let decision = p.decide(&danger_request("git push --force"));
+        assert_eq!(
+            decision,
+            PermissionPromptDecision::Deny {
+                reason: "user denied permission".to_string(),
+            }
+        );
+        stub.join().unwrap();
+    }
+
+    #[test]
+    fn tui_prompter_denies_when_render_loop_drops_the_answer() {
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        // Render stub receives the request but exits without answering —
+        // the per-request sender drops, which must read as a deny.
+        let stub = spawn_render_stub(tui_rx, None);
+        let mut p = TuiPrompter::new(tui_tx);
+
+        let decision = p.decide(&danger_request("bash payload"));
+        assert_eq!(
+            decision,
+            PermissionPromptDecision::Deny {
+                reason: "could not read user input".to_string(),
+            }
+        );
+        stub.join().unwrap();
+    }
+
+    #[test]
+    fn tui_prompter_denies_when_render_loop_is_gone_entirely() {
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        drop(tui_rx); // no render loop at all
+        let mut p = TuiPrompter::new(tui_tx);
+
+        let decision = p.decide(&danger_request("anything"));
+        assert_eq!(
+            decision,
+            PermissionPromptDecision::Deny {
+                reason: "could not read user input".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_consults_tui_prompter_for_danger_tools() {
+        // End-to-end through the real policy: a DangerFullAccess tool under
+        // a WorkspaceWrite active mode is no longer hard-denied — it asks
+        // the prompter, and the user's modal answer decides.
+        let policy = PermissionPolicy::new(PermissionMode::WorkspaceWrite)
+            .with_tool_requirement("bash", PermissionMode::DangerFullAccess);
+
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        let stub = spawn_render_stub(tui_rx, Some(true));
+        let mut p = TuiPrompter::new(tui_tx);
+        let outcome = policy.authorize("bash", "cargo test", Some(&mut p));
+        assert_eq!(outcome, PermissionOutcome::Allow);
+        stub.join().unwrap();
+
+        let (tui_tx, tui_rx) = mpsc::sync_channel(8);
+        let stub = spawn_render_stub(tui_rx, Some(false));
+        let mut p = TuiPrompter::new(tui_tx);
+        let outcome = policy.authorize("bash", "cargo test", Some(&mut p));
+        assert_eq!(
+            outcome,
+            PermissionOutcome::Deny {
+                reason: "user denied permission".to_string(),
+            }
+        );
+        stub.join().unwrap();
+    }
 
     #[test]
     fn strip_ansi_passthrough_when_no_escapes() {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,7 +68,7 @@ Three additional commands are **Telegram-only** (they have no effect in the REPL
 | **WorkspaceWrite** | Auto-allowed | note_create, note_update, todo_add, web_search, generate_code, github comment |
 | **DangerFullAccess** | Prompts `[y/N]` every time | bash, edit_file, git add/commit/push/checkout, cross-org PRs |
 
-The REPL prompter is interactive. The TUI renders the permission dialog in its tool pane. Telegram bot denies DangerFullAccess by default (no TTY to confirm with).
+The REPL prompter is interactive. The TUI shows a confirmation modal over the chat — `y` allows; `n`, `Esc`, or `Enter` denies (deny is the default); long inputs scroll with `↑`/`↓` and are never truncated. Telegram bot denies DangerFullAccess by default (no TTY to confirm with).
 
 ## Sessions and auto-compaction
 


### PR DESCRIPTION
## Summary

PR5 of the Tier-1+2 roadmap (`plans/tier12-2026-06-04/PR5-tui-prompter.md`): the TUI now **prompts** for `DangerFullAccess` tools instead of silently denying them. Previously the fullscreen TUI passed `prompter=None` into `run_turn`, so `bash`, `edit_file`, and git mutations were auto-denied — the headline coding surface couldn't edit a file or run a command — while `docs/usage.md` claimed a permission dialog existed. Both fixed.

## Design (panel-reviewed before implementation)

**Per-request rendezvous channel**: `TuiPrompter::decide()` creates a fresh `sync_channel::<bool>(0)` and ships the sender *inside* `TuiEvent::PermissionRequest`. Properties by construction:
- a stale/buffered answer from an earlier prompt can never satisfy a later one (each request owns its channel)
- every render-loop exit path — quit, `?` error, crash — drops the sender, so the worker's `recv()` sees `Disconnected` and resolves the tool as **denied, never hung**
- FIFO on the event channel guarantees the request is visible before any answer is expected
- zero signature changes through `run_tui`/`spawn_worker`

## What changed

- `tui_events.rs`: `TuiEvent::PermissionRequest { tool_name, input (FULL, untruncated), required_mode, resp_tx }`
- `tui_worker.rs`: `TuiPrompter` + both `run_turn` call sites now pass `Some(&mut prompter)`; CliPrompter parity on deny-reason strings
- `tui.rs`: modal input branch outranks Space Invaders / notes-filter (force-closed on arrival); `y` allows, `n`/`Esc`/`Enter` denies (default deny); `Ctrl+C/D` denies first, then quits; `↑↓` scroll
- `tui/render.rs`: centered modal — full wrapped input, char count in title, fixed `[y/N]` footer; **scroll clamped at render time** to the wrapped row count
- `docs/usage.md` permission line is now true; CHANGELOG updated

## Review

4-lens adversarial workflow (deadlock/threading, parity+payload-hiding, scope/regressions, Windows/UX) + synthesis judge: **fix-then-ship → fixed → ship.** The judge caught a real one: both reviewers assumed ratatui clamps over-scroll; the judge read ratatui-widgets 0.3.0 source and proved over-scroll renders an **empty** paragraph — a user could scroll the payload fully off-screen and approve a blank modal. Fixed with the same render-time clamp the chat pane uses, plus an `(end)` footer hint.

Out of scope per spec: routing the forge review gate through the modal (TODO), permission-tier changes, TUI redesign.

## Test plan

- [x] 5 new tests: decision mapping (allow/deny exact reasons), dropped-sender → deny, dead-render-loop → deny, full-input delivery, policy-level `authorize()` round-trip through the prompter
- [x] `cargo test -p claudette --lib --bins`: 1041 + 25 passed, 0 failed
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean; `cargo fmt --all` no-op
- [x] REPL `CliPrompter` path untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)