### PR TITLE
feat(repo_map): add mode=refs - exhaustive deduped reference scan

### DIFF
--- a/crates/claudette/src/tools/repomap.rs
+++ b/crates/claudette/src/tools/repomap.rs
@@ -347,22 +347,34 @@ fn run_repo_refs(root: &Path, needle: &str) -> Result<String, String> {
             // Enumeration answer: every full identifier on this line that
             // contains the needle. Computed for ALL hits (before the cap).
             for m in ident_re.find_iter(line) {
-                if m.as_str().contains(needle) && distinct.len() < MAX_DISTINCT_NAMES {
-                    distinct.insert(m.as_str().to_string());
+                if m.as_str().contains(needle) {
+                    if distinct.len() < MAX_DISTINCT_NAMES {
+                        distinct.insert(m.as_str().to_string());
+                    } else {
+                        // Enumeration answer is now partial — say so, don't
+                        // let the brain treat it as exhaustive.
+                        truncated = true;
+                    }
                 }
             }
             total_hits += 1;
-            if source_hits.len() + doc_hits.len() < MAX_REF_HITS {
-                let hit = RefHit {
+            // PER-PARTITION caps, NOT a joint budget: the `ignore` walker
+            // visits dirs alphabetically (docs/ before src/), so a joint cap
+            // would let 120+ doc lines exhaust the budget before the first
+            // source file is read — starving source_hits and inverting the
+            // whole source-first (I3) guarantee. Each partition gets its own
+            // MAX_REF_HITS so the authoritative source value always survives.
+            let hits = if source {
+                &mut source_hits
+            } else {
+                &mut doc_hits
+            };
+            if hits.len() < MAX_REF_HITS {
+                hits.push(RefHit {
                     file: p.display().to_string(),
                     line: lineno + 1,
                     sig: line.trim().chars().take(MAX_SIG_CHARS).collect(),
-                };
-                if source {
-                    source_hits.push(hit);
-                } else {
-                    doc_hits.push(hit);
-                }
+                });
             } else {
                 truncated = true;
             }
@@ -746,6 +758,51 @@ mod tests {
                 assert_eq!(
                     v["distinct_count"], 1,
                     "fell back to query as needle: {out}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn repo_refs_source_hits_survive_a_flood_of_earlier_doc_hits() {
+        // I3 guarantee under load: the walker visits docs/ before src/
+        // alphabetically. With a JOINT hit cap, 130 doc matches would
+        // exhaust the budget and the lone authoritative source hit would be
+        // dropped — silently inverting source-first. Per-partition caps must
+        // keep the source hit. (MAX_REF_HITS=120; 130 doc lines > that.)
+        let many_doc_lines = "MARKER_NEEDLE mentioned in the docs\n".repeat(130);
+        with_refs_fixture(
+            "flood",
+            &[
+                ("docs/big.md", &many_doc_lines),
+                ("src/run.rs", "const MARKER_NEEDLE: u32 = 3;\n"),
+            ],
+            |path| {
+                let input = json!({
+                    "query": "x", "mode": "refs", "name": "MARKER_NEEDLE", "path": path
+                })
+                .to_string();
+                let out = run_repo_map(&input).unwrap();
+                let v: Value = serde_json::from_str(&out).unwrap();
+                let src = v["source_hits"].as_array().unwrap();
+                assert!(
+                    !src.is_empty(),
+                    "source hit must NOT be starved by 130 earlier doc hits: {}",
+                    // truncated should be flagged; doc_hits capped at 120.
+                    serde_json::to_string(&json!({
+                        "source_len": src.len(),
+                        "doc_len": v["doc_hits"].as_array().unwrap().len(),
+                        "truncated": v["truncated"].clone(),
+                    }))
+                    .unwrap()
+                );
+                assert!(
+                    src[0]["sig"].as_str().unwrap().contains("= 3"),
+                    "the surviving source hit must be the real value"
+                );
+                assert_eq!(
+                    v["truncated"], true,
+                    "doc flood past the cap must flag truncated"
                 );
             },
         );

--- a/crates/claudette/src/tools/repomap.rs
+++ b/crates/claudette/src/tools/repomap.rs
@@ -14,6 +14,12 @@
 //! One call replaces N grep guesses, and the signature snippet frequently
 //! carries the answer itself (`const DEFAULT_MAX_FIX_ROUNDS: u32 = 3;`) so the
 //! brain can answer a "what's the default" question without a follow-up read.
+//!
+//! `mode="refs"` is the exhaustive counterpart: a literal substring scan over
+//! every readable file (not just the 4 definition languages) that returns a
+//! deduped `distinct_names` enumeration plus source-first / docs-last hit
+//! lists — for "list everywhere X is used" and "what's the real value past
+//! the stale docs". See [`run_repo_refs`].
 
 use std::path::Path;
 
@@ -26,18 +32,43 @@ const MAX_FILES_SCANNED: usize = 5000;
 const MAX_RESULT_FILES: usize = 15;
 const MAX_SYMBOLS_PER_FILE: usize = 40;
 const MAX_SIG_CHARS: usize = 160;
+/// `mode="refs"`: cap on individual hit lines returned (source + doc
+/// combined). Higher than grep's 100 because the per-hit payload is just
+/// file/line/snippet. `distinct_names` is computed over ALL hits before
+/// this cap, so the enumeration answer is never truncated.
+const MAX_REF_HITS: usize = 120;
+/// `mode="refs"`: cap on the deduped identifier list (the enumeration
+/// answer). 200 distinct matches of one needle is already pathological.
+const MAX_DISTINCT_NAMES: usize = 200;
+
+/// Source-code extensions for the refs-mode source/doc split. A hit in one
+/// of these is `source` (authoritative); everything else (`.md`, `.txt`,
+/// `.toml`, `.json`, `.yaml`, …) is `doc` and ranked below — so the brain
+/// sees the real `const X = 3;` ahead of a stale doc saying `2`.
+const SOURCE_EXTENSIONS: &[&str] = &[
+    "rs", "py", "js", "mjs", "cjs", "jsx", "ts", "tsx", "go", "java", "c", "cc", "cpp", "cxx", "h",
+    "hpp", "rb", "php", "sh", "bash", "sql", "kt", "swift", "scala", "cs",
+];
+
+fn is_source_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| SOURCE_EXTENSIONS.iter().any(|s| e.eq_ignore_ascii_case(s)))
+}
 
 pub(super) fn schemas() -> Vec<Value> {
     vec![json!({
         "type": "function",
         "function": {
             "name": "repo_map",
-            "description": "Localize code by concept. Returns a ranked outline of the workspace: the files whose top-level definitions (functions, types, constants) best match `query`, each with line numbers + signature snippets. Use this FIRST to find where something lives instead of guessing grep patterns — the snippet often shows the value/signature directly. Then read_file the cited line if you need more. (Languages: Rust, Python, JS/TS, Go.)",
+            "description": "Localize code by concept. Returns a ranked outline of the workspace: the files whose top-level definitions (functions, types, constants) best match `query`, each with line numbers + signature snippets. Use this FIRST to find where something lives instead of guessing grep patterns — the snippet often shows the value/signature directly. Then read_file the cited line if you need more. (Languages: Rust, Python, JS/TS, Go.) For an exhaustive list of everywhere a name is used (or to pin the real source value past stale docs), call with mode='refs' and name='<exact text>'.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "query": { "type": "string", "description": "What you're looking for, in words or symbol fragments (e.g. 'forge fix loop max rounds default')" },
-                    "path":  { "type": "string", "description": "Directory to map (default: the workspace/project root)" }
+                    "path":  { "type": "string", "description": "Directory to map (default: the workspace/project root)" },
+                    "mode":  { "type": "string", "enum": ["map", "refs"], "description": "map (default): ranked outline of code DEFINITIONS matching a concept. refs: exhaustive deduped list of every place a name appears (definitions, calls, env-var string literals, comments) — source files first, docs last. Use refs to enumerate ALL occurrences of something, or to find the authoritative source value when docs might be stale." },
+                    "name":  { "type": "string", "description": "mode=refs only: the exact text to find everywhere, e.g. 'CLAUDETTE_FORGE_' (prefix match finds all CLAUDETTE_FORGE_* vars) or 'DEFAULT_MAX_FIX_ROUNDS'. Case-sensitive literal substring." }
                 },
                 "required": ["query"]
             }
@@ -88,6 +119,20 @@ fn run_repo_map(input: &str) -> Result<String, String> {
     let root = validate_read_path(path_str)?;
     if !root.is_dir() {
         return Err(format!("repo_map: {} is not a directory", root.display()));
+    }
+
+    // mode="refs": exhaustive occurrence scan. Needle = `name` if given,
+    // else fall back to `query` (forgiving — a brain that forgets `name`
+    // still works). Default mode is "map" (everything below), so existing
+    // behaviour is byte-for-byte unchanged.
+    let mode = v.get("mode").and_then(Value::as_str).unwrap_or("map");
+    if mode == "refs" {
+        let needle = v
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or(query);
+        return run_repo_refs(&root, needle);
     }
 
     let query_tokens = tokenize(query);
@@ -212,6 +257,141 @@ fn run_repo_map(input: &str) -> Result<String, String> {
         "result_files": result_files,
         "truncated": truncated,
         "files": files_json,
+    })
+    .to_string())
+}
+
+struct RefHit {
+    file: String,
+    line: usize,
+    sig: String,
+}
+
+/// `mode="refs"` — exhaustive, deduped, source-first occurrence scan.
+///
+/// Unlike map mode (which extracts only top-level *definitions* in 4
+/// languages), refs scans the literal text of EVERY readable file
+/// (gitignore-aware, build dirs skipped) for `needle` as a case-sensitive
+/// substring. This is the only mechanism that surfaces things that are not
+/// definitions — env-var string literals (`std::env::var("CLAUDETTE_FORGE_…")`),
+/// call sites, doc/comment mentions — which is exactly the enumerate /
+/// deep-locate gap map mode can't close.
+///
+/// Two payloads do the heavy lifting for a weak brain:
+/// - `distinct_names`: the deduped set of full identifiers containing the
+///   needle, computed over ALL hits before any cap — the brain copies it
+///   verbatim as the enumeration answer, no per-line counting.
+/// - `source_hits` vs `doc_hits`: source files first, docs quarantined —
+///   so the authoritative `const X = 3;` outranks a stale doc saying `2`.
+fn run_repo_refs(root: &Path, needle: &str) -> Result<String, String> {
+    if needle.trim().is_empty() {
+        return Err("repo_map(refs): empty name/query".to_string());
+    }
+
+    // Identifier tokens containing the needle → the deduped enumeration
+    // answer. BTreeSet keeps it sorted + unique for free.
+    let ident_re = Regex::new(r"[A-Za-z_][A-Za-z0-9_]*").expect("static ident regex");
+    let mut distinct: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    let mut source_hits: Vec<RefHit> = Vec::new();
+    let mut doc_hits: Vec<RefHit> = Vec::new();
+    let mut total_hits = 0usize;
+    let mut files_scanned = 0usize;
+    let mut truncated = false;
+
+    let walker = ignore::WalkBuilder::new(root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .parents(true)
+        .follow_links(false)
+        .filter_entry(|entry| {
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                let name = entry.file_name().to_string_lossy();
+                if super::SEARCH_SKIP_DIRS.contains(&name.as_ref()) {
+                    return false;
+                }
+            }
+            true
+        })
+        .build();
+
+    for result in walker {
+        let Ok(entry) = result else { continue };
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        if files_scanned >= MAX_FILES_SCANNED {
+            truncated = true;
+            break;
+        }
+        let p = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        if meta.len() > MAX_FILE_BYTES as u64 {
+            continue;
+        }
+        // Language-agnostic: any file that reads as UTF-8 text is scanned
+        // (binaries fail read_to_string and are skipped). Docs/config are
+        // in scope precisely because they carry the conflicting values.
+        let Ok(content) = std::fs::read_to_string(p) else {
+            continue;
+        };
+        files_scanned += 1;
+        let source = is_source_file(p);
+
+        for (lineno, line) in content.lines().enumerate() {
+            if !line.contains(needle) {
+                continue;
+            }
+            // Enumeration answer: every full identifier on this line that
+            // contains the needle. Computed for ALL hits (before the cap).
+            for m in ident_re.find_iter(line) {
+                if m.as_str().contains(needle) && distinct.len() < MAX_DISTINCT_NAMES {
+                    distinct.insert(m.as_str().to_string());
+                }
+            }
+            total_hits += 1;
+            if source_hits.len() + doc_hits.len() < MAX_REF_HITS {
+                let hit = RefHit {
+                    file: p.display().to_string(),
+                    line: lineno + 1,
+                    sig: line.trim().chars().take(MAX_SIG_CHARS).collect(),
+                };
+                if source {
+                    source_hits.push(hit);
+                } else {
+                    doc_hits.push(hit);
+                }
+            } else {
+                truncated = true;
+            }
+        }
+    }
+
+    // Stable, useful order: by file then line within each partition.
+    let by_file_line = |a: &RefHit, b: &RefHit| a.file.cmp(&b.file).then(a.line.cmp(&b.line));
+    source_hits.sort_by(by_file_line);
+    doc_hits.sort_by(by_file_line);
+
+    let to_json = |hits: &[RefHit]| -> Vec<Value> {
+        hits.iter()
+            .map(|h| json!({ "file": h.file, "line": h.line, "sig": h.sig }))
+            .collect()
+    };
+    let distinct_names: Vec<String> = distinct.into_iter().collect();
+
+    Ok(json!({
+        "mode": "refs",
+        "needle": needle,
+        "root": root.display().to_string(),
+        "files_scanned": files_scanned,
+        "distinct_names": distinct_names,
+        "distinct_count": distinct_names.len(),
+        "source_hits": to_json(&source_hits),
+        "doc_hits": to_json(&doc_hits),
+        "total_hits": total_hits,
+        "truncated": truncated,
     })
     .to_string())
 }
@@ -414,7 +594,186 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" | ");
         assert!(sigs.contains("= 3"), "expected the value in a sig: {sigs}");
+        // map mode response shape: has `files`, no refs-only keys.
+        assert!(v.get("files").is_some(), "map mode must keep `files`");
+        assert!(
+            v.get("distinct_names").is_none(),
+            "map mode must NOT carry refs-only keys"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Build a throwaway fixture tree under a unique dir, run a closure with
+    /// its path, then clean up. Holds the env lock (home-resolving).
+    fn with_refs_fixture<F: FnOnce(&str)>(tag: &str, files: &[(&str, &str)], f: F) {
+        let _eg = crate::test_env_lock();
+        let base = super::super::user_home()
+            .join(".claudette")
+            .join("files")
+            .join(format!("claudette-refs-test-{tag}"));
+        let _ = std::fs::remove_dir_all(&base);
+        for (rel, content) in files {
+            let p = base.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, content).unwrap();
+        }
+        f(base.to_str().unwrap());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn repo_refs_enumerates_all_distinct_prefix_matches() {
+        // I1 proxy: the 6 CLAUDETTE_FORGE_* vars exist ONLY as env-read
+        // string literals / comments / error strings — ZERO definitions —
+        // so map mode finds none. refs must enumerate all 6, deduped across
+        // duplicate lines and across files.
+        let run_rs = r#"
+            // CLAUDETTE_FORGE_ABORT_WINDOW_SECS controls the abort window
+            let _ = std::env::var("CLAUDETTE_FORGE_ABORT_WINDOW_SECS");
+            if env_flag_enabled("CLAUDETTE_FORGE_ALLOW_DIRTY") {}
+            if env_flag_enabled("CLAUDETTE_FORGE_ALLOW_DIRTY") {} // duplicate line
+            let _ = std::env::var("CLAUDETTE_FORGE_AUTO_APPROVE");
+            let _ = std::env::var("CLAUDETTE_FORGE_SUBMIT_ON_FAIL");
+        "#;
+        let sec_rs = r#"
+            if env_flag_enabled("CLAUDETTE_FORGE_SECURITY_OVERRIDE") {}
+            // also CLAUDETTE_FORGE_SECURITY_REVIEW in this comment
+        "#;
+        with_refs_fixture(
+            "i1",
+            &[("src/run.rs", run_rs), ("src/security_review.rs", sec_rs)],
+            |path| {
+                let input = json!({
+                    "query": "forge env vars",
+                    "mode": "refs",
+                    "name": "CLAUDETTE_FORGE_",
+                    "path": path
+                })
+                .to_string();
+                let out = run_repo_map(&input).unwrap();
+                let v: Value = serde_json::from_str(&out).unwrap();
+                assert_eq!(v["mode"], "refs");
+                let names: Vec<&str> = v["distinct_names"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|n| n.as_str().unwrap())
+                    .collect();
+                let expected = [
+                    "CLAUDETTE_FORGE_ABORT_WINDOW_SECS",
+                    "CLAUDETTE_FORGE_ALLOW_DIRTY",
+                    "CLAUDETTE_FORGE_AUTO_APPROVE",
+                    "CLAUDETTE_FORGE_SECURITY_OVERRIDE",
+                    "CLAUDETTE_FORGE_SECURITY_REVIEW",
+                    "CLAUDETTE_FORGE_SUBMIT_ON_FAIL",
+                ];
+                for e in expected {
+                    assert!(names.contains(&e), "missing {e} in {names:?}");
+                }
+                assert_eq!(v["distinct_count"], 6, "deduped to exactly 6: {names:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn repo_refs_puts_source_before_docs_with_value_in_sig() {
+        // I3 proxy: the real const is in run.rs (= 3); stale docs say 2. The
+        // source hit must carry the value, and every doc_hit must be a .md.
+        with_refs_fixture(
+            "i3",
+            &[
+                ("src/run.rs", "const DEFAULT_MAX_FIX_ROUNDS: u32 = 3;\n"),
+                ("docs/forge.md", "The DEFAULT_MAX_FIX_ROUNDS is 2 rounds.\n"),
+                (
+                    "docs/configuration.md",
+                    "Set DEFAULT_MAX_FIX_ROUNDS (default 2).\n",
+                ),
+            ],
+            |path| {
+                let input = json!({
+                    "query": "max fix rounds",
+                    "mode": "refs",
+                    "name": "DEFAULT_MAX_FIX_ROUNDS",
+                    "path": path
+                })
+                .to_string();
+                let out = run_repo_map(&input).unwrap();
+                let v: Value = serde_json::from_str(&out).unwrap();
+                let src = v["source_hits"].as_array().unwrap();
+                assert!(!src.is_empty(), "source hit expected");
+                assert!(
+                    src[0]["file"]
+                        .as_str()
+                        .unwrap()
+                        .replace('\\', "/")
+                        .ends_with("/src/run.rs"),
+                    "source-first: {out}"
+                );
+                assert!(
+                    src[0]["sig"].as_str().unwrap().contains("= 3"),
+                    "source hit must carry the real value: {out}"
+                );
+                for d in v["doc_hits"].as_array().unwrap() {
+                    // Fixture filenames are literal lowercase `.md`, so a
+                    // case-sensitive check is exactly what we want here.
+                    #[allow(clippy::case_sensitive_file_extension_comparisons)]
+                    let is_md = d["file"].as_str().unwrap().ends_with(".md");
+                    assert!(is_md, "doc partition must hold only docs: {out}");
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn repo_refs_forgiving_args_falls_back_to_query() {
+        // Weak-brain forgiving args: mode=refs with NO `name` uses `query`.
+        with_refs_fixture(
+            "fallback",
+            &[(
+                "src/run.rs",
+                "std::env::var(\"CLAUDETTE_FORGE_AUTO_APPROVE\");\n",
+            )],
+            |path| {
+                let input = json!({
+                    "query": "CLAUDETTE_FORGE_",
+                    "mode": "refs",
+                    "path": path
+                })
+                .to_string();
+                let out = run_repo_map(&input).unwrap();
+                let v: Value = serde_json::from_str(&out).unwrap();
+                assert_eq!(
+                    v["distinct_count"], 1,
+                    "fell back to query as needle: {out}"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn repo_refs_finds_string_literals_not_only_definitions() {
+        // Guard against regressing into definition-only scanning (the
+        // rejected Design-1 failure mode): a needle with ZERO definitions
+        // but many string-literal occurrences must still produce source hits.
+        with_refs_fixture(
+            "literals",
+            &[(
+                "src/run.rs",
+                "let a = \"CLAUDETTE_FORGE_X\";\nlet b = \"CLAUDETTE_FORGE_Y\";\n",
+            )],
+            |path| {
+                let input = json!({
+                    "query": "x", "mode": "refs", "name": "CLAUDETTE_FORGE_", "path": path
+                })
+                .to_string();
+                let out = run_repo_map(&input).unwrap();
+                let v: Value = serde_json::from_str(&out).unwrap();
+                assert!(
+                    !v["source_hits"].as_array().unwrap().is_empty(),
+                    "string-literal occurrences must be found: {out}"
+                );
+            },
+        );
     }
 }


### PR DESCRIPTION
## Summary

Tier-3: adds `mode="refs"` to the existing `repo_map` tool — the exhaustive counterpart to map mode, targeting the two battery failures the flagship brain can't beat: **I1 (enumerate ALL occurrences)** and **I3 (find the authoritative value past stale docs)**.

map mode extracts only top-level *definitions* in 4 languages, so it structurally cannot find the 6+ `CLAUDETTE_FORGE_*` env vars — they exist only as `std::env::var("...")` string literals and comments, zero definitions. refs closes that.

## Design (3-way panel + judge)

The panel rejected a definition-only "exhaustive caps" approach (finds zero of the env vars) and a ~500-LOC per-language usage matrix, synthesizing this ~140-LOC content scan:

- **`mode="refs"`, `name="exact text"`** (falls back to `query` if `name` omitted — forgiving for a weak brain). Case-sensitive literal substring scan over **every readable file** (gitignore-aware, build dirs skipped), not just the 4 definition languages.
- **`distinct_names`** — deduped, sorted set of full identifiers containing the needle, computed over **all** hits before any cap. The enumeration answer, copied verbatim, no per-line counting (I1).
- **`source_hits` vs `doc_hits`** — source files first, docs quarantined, so the real `const X = 3;` outranks a stale doc saying `2`; schema description primes "source first, docs may be stale" (I3).

map mode is **byte-for-byte unchanged** (default; regression-guarded by the existing test). The +360-char schema is paid every coding turn (Search is in coding_core) but stays well under the 16k coding_core guardrail.

## Honest ceiling

These are model-bound failures. refs removes the *search* failure and gives the brain the best shot, but cannot force a q3-quantized model to transcribe the handed list into its prose answer. Real flip is **measured by the Phase C battery, not assumed** (design estimate ~60-65% to flip both). Verified against the real tree: refs enumerates all `CLAUDETTE_FORGE_*` vars — now **9**, a superset of the I1 verifier's original 6.

## Test plan

- [x] 6 new tests: prefix enumeration + dedup across duplicate lines/files, source-before-docs with value-in-sig, forgiving name->query fallback, string-literals-not-definitions guard, **map-mode-unchanged regression**
- [x] `cargo test -p claudette --lib --bins`: 1067 + 25 passed, 0 failed
- [x] clippy `-D warnings` clean; fmt no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)
