### PR TITLE
release: v0.9.0 — production-readiness pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,21 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-08
+
 ### Added
 
+- **Coding-only build (`--no-default-features`).** A new default-on
+  `integrations` Cargo feature gates the external-cloud personal-assistant
+  surface — Google OAuth, Gmail, Calendar, and the Telegram bot. Build with
+  `cargo install claudette --no-default-features` (or `cargo build
+  --no-default-features`) to compile **none** of that code into the binary: a
+  leaner, coding-focused build that physically cannot reach Google or Telegram
+  even by misconfiguration. In such a build `--auth-google` / `--telegram`
+  print a clear "compiled without integrations" message and `--doctor` skips
+  the Google OAuth probe. The default build — and everything a coding session
+  uses (files, search, git, shell, quality, vision, recall, notes, todos,
+  scheduler) — is unchanged.
 - **Destructive operations are now recoverable: action transcript, trash, and
   `/undo`.** `note_delete` and `todo_delete` were permanent and `write_file`
   silently truncated existing files — a misrouted "clean up my notes" from a
@@ -79,6 +92,31 @@ bumps are non-breaking bugfixes only.
   promise. Backed by a canonical `egress::NET_TOOLS` registry with a regression
   guard that catches a new always-network tool (`gh_*`/`gmail_*`/`calendar_*`/
   `tg_*`) added without its egress guard.
+
+### Fixed
+
+- **The TUI no longer leaves your terminal garbled if it panics.** The release
+  profile builds with `panic = "abort"`, which skips the `scopeguard::defer!`
+  that restores the terminal — so an unhandled panic during a `--tui` session
+  could exit with the shell stuck in raw mode + alternate screen. `run_tui` now
+  installs a `panic` hook that disables raw mode and leaves the alternate screen
+  *before* the process aborts (the hook runs on the panicking thread first),
+  then chains to the previous hook so the panic message still prints.
+- **Flaky vision test under parallel `cargo test`.**
+  `image_describe_rejects_non_image_extension` read the global `HOME` /
+  `USERPROFILE` directly and could lose a race with a concurrent test that
+  swapped it, failing the path read-guard before the assertion it meant to
+  exercise. It now uses the shared `with_temp_home` helper, which pins the home
+  dir and holds the process-wide env lock for the test body.
+
+### Docs
+
+- **`docs/decisions.md` marked HISTORICAL.** Its AD-1…AD-7 describe the
+  `claudettes-forge` planning-era design — a six-crate workspace, a cloud
+  "Claude" provider, a 7-stage forge pipeline, 5-tier permissions with platform
+  sandboxing — none of which matches the shipped single-crate, local-only,
+  air-gapped product. A banner at the top now flags exactly what never shipped
+  and points readers to `docs/architecture.md` (the accurate source of truth).
 
 ## [0.8.9] - 2026-06-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.8.9"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ ollama pull qwen3-coder:30b      # Codet coder — only if you'll use generate_c
 curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux/macOS
 iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows
 cargo install claudette                                                                    # Rust users
+cargo install claudette --no-default-features                                              # coding-only: no Google/Telegram code compiled in
 
 # 3. (Optional) Tokens for opt-in tools that reach the network.
 export BRAVE_API_KEY=...         # web_search

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.8.9"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -25,7 +25,23 @@ path = "src/main.rs"
 name = "claudette"
 path = "src/lib.rs"
 
+# The OAuth smoke example exercises the Google integration, so it only builds
+# when that surface is compiled in. Without this, a coding-only
+# `--no-default-features` build would fail to compile the example.
+[[example]]
+name = "oauth_smoke"
+required-features = ["integrations"]
+
 [features]
+default = ["integrations"]
+# `integrations` bundles the external personal-assistant surface that reaches
+# out to third-party clouds: Google OAuth + Gmail + Calendar, and the Telegram
+# bot. It is ON by default. Build a lean, coding-focused binary with NONE of it
+# compiled in via `--no-default-features` (a "coding-only" build — there is no
+# Google/Telegram code in the binary at all, so it cannot reach those services
+# even by misconfiguration). The coding core (files, search, git, shell,
+# quality, vision, recall, notes, todos, scheduler, …) is unaffected.
+integrations = []
 # Off-by-default scaffolds awaiting wiring: the SWE-bench / A-B benchmark
 # runner (`bench`) and the TUI typewriter renderer (`tui::typewriter`). Kept
 # in-tree for planned integration but excluded from the default build so they

--- a/crates/claudette/src/doctor.rs
+++ b/crates/claudette/src/doctor.rs
@@ -112,8 +112,13 @@ pub fn run() -> i32 {
     print_section("recall / embeddings");
     bump(probe_recall());
 
-    print_section("google oauth");
-    bump(probe_google_oauth());
+    // Google OAuth only exists in a default-features build; a coding-only
+    // build (--no-default-features) has no Google code to probe.
+    #[cfg(feature = "integrations")]
+    {
+        print_section("google oauth");
+        bump(probe_google_oauth());
+    }
 
     print_section("voice (optional)");
     bump(probe_voice());
@@ -658,6 +663,7 @@ fn probe_egress() -> Status {
     Status::Ok
 }
 
+#[cfg(feature = "integrations")]
 fn probe_google_oauth() -> Status {
     // Offline mode blocks every Google API call by design — attempting the
     // live verify here would just paint the report red. Show it as skipped so
@@ -715,6 +721,7 @@ fn probe_google_oauth() -> Status {
 /// for "does this token actually work against the API". Keeps the doctor
 /// and the OAuth flow in lockstep so a passing `--doctor` row implies
 /// the same thing as the "OK: ... verified" line the auth flow prints.
+#[cfg(feature = "integrations")]
 fn verify_scope(ctx: crate::google_auth::AuthContext, token: &str) -> Result<String, String> {
     crate::google_auth::verify_scope_live(ctx, token)
 }

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -50,6 +50,10 @@ pub mod egress;
 pub mod executor;
 pub mod firstrun;
 pub mod forge;
+// External-cloud integrations — gated behind the default-on `integrations`
+// feature so a `--no-default-features` build is coding-only (no Google/Telegram
+// code compiled in). See Cargo.toml `[features]`.
+#[cfg(feature = "integrations")]
 pub mod google_auth;
 pub mod hw;
 pub mod image_attach;
@@ -62,6 +66,7 @@ pub mod run;
 pub mod scheduler;
 pub mod secrets;
 pub mod security_review;
+#[cfg(feature = "integrations")]
 pub mod telegram_mode;
 pub mod test_runner;
 pub mod theme;

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -20,11 +20,15 @@
 use std::process::ExitCode;
 
 use claudette::{
-    briefing, clock, google_auth, probe_ollama, run_forge_mission, run_secretary,
-    run_secretary_repl, scheduler, secrets, telegram_mode, theme, try_load_session,
-    workspace_startup_diagnostics, SessionOptions,
+    briefing, clock, probe_ollama, run_forge_mission, run_secretary, run_secretary_repl, scheduler,
+    theme, try_load_session, workspace_startup_diagnostics, SessionOptions,
 };
 use claudette::{ContentBlock, Session};
+// External-cloud integrations: only compiled into a default-features build.
+// See Cargo.toml `[features]` and the `dispatch_google_auth` / `dispatch_telegram`
+// helpers below, which carry the coding-only fallback.
+#[cfg(feature = "integrations")]
+use claudette::{google_auth, secrets, telegram_mode};
 
 /// Parsed CLI invocation. Any flag below that doesn't make sense with the
 /// selected mode is quietly ignored (the old tuple contract) — the parser
@@ -217,7 +221,7 @@ fn main() -> ExitCode {
     let CliArgs {
         resume,
         telegram,
-        mut chat_ids,
+        chat_ids,
         prompt_words: prompt_args,
         tui: tui_mode,
         auth_google,
@@ -267,34 +271,7 @@ fn main() -> ExitCode {
     // Runs before the Ollama probe because it's a one-shot setup command —
     // the user doesn't need the brain running to grant OAuth consent.
     if auth_google {
-        let ctx = match auth_google_scope.as_deref() {
-            None => google_auth::AuthContext::Calendar, // backwards compat
-            Some(s) => match google_auth::AuthContext::parse(s) {
-                Some(c) => c,
-                None => {
-                    eprintln!(
-                        "{} {}",
-                        theme::error(theme::ERR_GLYPH),
-                        theme::error(&format!(
-                            "unknown --auth-google scope '{s}'. Try 'calendar' or 'gmail'."
-                        ))
-                    );
-                    return ExitCode::FAILURE;
-                }
-            },
-        };
-        let result = if auth_google_revoke {
-            google_auth::revoke(ctx)
-        } else {
-            google_auth::run_auth_flow(ctx)
-        };
-        return match result {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(e) => {
-                eprintln!("{} {}", theme::error(theme::ERR_GLYPH), theme::error(&e));
-                ExitCode::FAILURE
-            }
-        };
+        return dispatch_google_auth(auth_google_scope.as_deref(), auth_google_revoke);
     }
 
     // ── Scheduled-briefing setup ──────────────────────────────────────
@@ -431,39 +408,7 @@ fn main() -> ExitCode {
 
     // ── Telegram bot mode ──────────────────────────────────────────────
     if telegram {
-        // The Telegram bridge is a cloud service (api.telegram.org); it is
-        // fundamentally incompatible with an enforced air-gap. Refuse up front
-        // with the same vocabulary the egress guard uses, rather than letting
-        // the bot start and then fail every poll.
-        if claudette::egress::is_offline() {
-            eprintln!(
-                "{} {}",
-                theme::error(theme::ERR_GLYPH),
-                theme::error(
-                    "offline mode (--offline) blocks the Telegram bridge — it relays through \
-                     api.telegram.org (cloud). Drop --offline to run the bot, or drop --telegram \
-                     to stay air-gapped."
-                )
-            );
-            return ExitCode::FAILURE;
-        }
-        // Merge persisted chat IDs (from previous runs) with CLI flags.
-        for id in secrets::load_chat_ids() {
-            if !chat_ids.contains(&id) {
-                chat_ids.push(id);
-            }
-        }
-        match telegram_mode::run_telegram_bot(chat_ids, allow_any_chat, resume) {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(e) => {
-                eprintln!(
-                    "{} {}",
-                    theme::error(theme::ERR_GLYPH),
-                    theme::error(&format!("{e:#}"))
-                );
-                ExitCode::FAILURE
-            }
-        }
+        dispatch_telegram(chat_ids, allow_any_chat, resume)
     } else if prompt_args.is_empty() {
         // No prompt → interactive REPL. REPL always autosaves.
         let opts = SessionOptions {
@@ -580,7 +525,10 @@ fn parse_args(args: &[String]) -> CliArgs {
                 // capture it as the scope. Otherwise treat it as a
                 // regular prompt word so `--auth-google somebody typed
                 // more words` still parses the way the user expected.
+                // (Coding-only builds have no scope keywords — the token
+                // always falls through as a normal arg.)
                 expect = ExpectNext::Nothing;
+                #[cfg(feature = "integrations")]
                 if claudette::google_auth::AuthContext::parse(arg).is_some() {
                     out.auth_google_scope = Some(arg.clone());
                     continue;
@@ -635,6 +583,110 @@ enum ExpectNext {
     /// next token isn't a recognised scope we fall back to normal arg
     /// matching rather than consuming it.
     AuthGoogleScope,
+}
+
+/// Run the Google OAuth loopback flow (or revoke). The real implementation is
+/// only compiled into a default-features build; the coding-only build (built
+/// `--no-default-features`) carries no Google code at all, so this stub just
+/// explains that and exits non-zero.
+#[cfg(feature = "integrations")]
+fn dispatch_google_auth(scope: Option<&str>, revoke: bool) -> ExitCode {
+    let ctx = match scope {
+        None => google_auth::AuthContext::Calendar, // backwards compat
+        Some(s) => match google_auth::AuthContext::parse(s) {
+            Some(c) => c,
+            None => {
+                eprintln!(
+                    "{} {}",
+                    theme::error(theme::ERR_GLYPH),
+                    theme::error(&format!(
+                        "unknown --auth-google scope '{s}'. Try 'calendar' or 'gmail'."
+                    ))
+                );
+                return ExitCode::FAILURE;
+            }
+        },
+    };
+    let result = if revoke {
+        google_auth::revoke(ctx)
+    } else {
+        google_auth::run_auth_flow(ctx)
+    };
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("{} {}", theme::error(theme::ERR_GLYPH), theme::error(&e));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(not(feature = "integrations"))]
+fn dispatch_google_auth(_scope: Option<&str>, _revoke: bool) -> ExitCode {
+    eprintln!(
+        "{} {}",
+        theme::error(theme::ERR_GLYPH),
+        theme::error(
+            "--auth-google needs the `integrations` feature — this is a coding-only build \
+             (compiled --no-default-features), so there is no Google code in it. Reinstall \
+             with default features to use Gmail/Calendar."
+        )
+    );
+    ExitCode::FAILURE
+}
+
+/// Run the Telegram bot. Real implementation only in a default-features build;
+/// the coding-only build carries no Telegram bridge, so the stub exits non-zero
+/// with an explanation.
+#[cfg(feature = "integrations")]
+fn dispatch_telegram(mut chat_ids: Vec<i64>, allow_any_chat: bool, resume: bool) -> ExitCode {
+    // The Telegram bridge is a cloud service (api.telegram.org); it is
+    // fundamentally incompatible with an enforced air-gap. Refuse up front
+    // with the same vocabulary the egress guard uses, rather than letting
+    // the bot start and then fail every poll.
+    if claudette::egress::is_offline() {
+        eprintln!(
+            "{} {}",
+            theme::error(theme::ERR_GLYPH),
+            theme::error(
+                "offline mode (--offline) blocks the Telegram bridge — it relays through \
+                 api.telegram.org (cloud). Drop --offline to run the bot, or drop --telegram \
+                 to stay air-gapped."
+            )
+        );
+        return ExitCode::FAILURE;
+    }
+    // Merge persisted chat IDs (from previous runs) with CLI flags.
+    for id in secrets::load_chat_ids() {
+        if !chat_ids.contains(&id) {
+            chat_ids.push(id);
+        }
+    }
+    match telegram_mode::run_telegram_bot(chat_ids, allow_any_chat, resume) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!(
+                "{} {}",
+                theme::error(theme::ERR_GLYPH),
+                theme::error(&format!("{e:#}"))
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(not(feature = "integrations"))]
+fn dispatch_telegram(_chat_ids: Vec<i64>, _allow_any_chat: bool, _resume: bool) -> ExitCode {
+    eprintln!(
+        "{} {}",
+        theme::error(theme::ERR_GLYPH),
+        theme::error(
+            "--telegram needs the `integrations` feature — this is a coding-only build \
+             (compiled --no-default-features), so the Telegram bridge isn't in it. Reinstall \
+             with default features to run the bot."
+        )
+    );
+    ExitCode::FAILURE
 }
 
 /// Create (or replace) the scheduled morning-briefing entry. Used by the

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -23,7 +23,23 @@ use serde_json::{json, Value};
 
 // Per-group sub-modules. Each exports `schemas()` and `dispatch()`; see the
 // group-module contract at the top of `registry.rs`.
+//
+// `calendar`, `gmail`, and `telegram` talk to third-party clouds, so they are
+// gated behind the default-on `integrations` feature. In a `--no-default-
+// features` (coding-only) build they compile to an empty stub that advertises
+// no tools and dispatches nothing — the `GROUPS` table below stays unchanged,
+// the group simply contributes zero tools.
+#[cfg(feature = "integrations")]
 mod calendar;
+#[cfg(not(feature = "integrations"))]
+mod calendar {
+    pub fn schemas() -> Vec<serde_json::Value> {
+        Vec::new()
+    }
+    pub fn dispatch(_tool: &str, _args: &str) -> Option<Result<String, String>> {
+        None
+    }
+}
 mod clipboard;
 mod codegen;
 mod dialog;
@@ -33,7 +49,17 @@ mod forge_tail;
 mod fuzzy_apply;
 mod git;
 mod github;
+#[cfg(feature = "integrations")]
 mod gmail;
+#[cfg(not(feature = "integrations"))]
+mod gmail {
+    pub fn schemas() -> Vec<serde_json::Value> {
+        Vec::new()
+    }
+    pub fn dispatch(_tool: &str, _args: &str) -> Option<Result<String, String>> {
+        None
+    }
+}
 mod ide;
 mod markets;
 mod mission;
@@ -47,7 +73,17 @@ mod schedule;
 mod search;
 mod semantic;
 mod shell;
+#[cfg(feature = "integrations")]
 mod telegram;
+#[cfg(not(feature = "integrations"))]
+mod telegram {
+    pub fn schemas() -> Vec<serde_json::Value> {
+        Vec::new()
+    }
+    pub fn dispatch(_tool: &str, _args: &str) -> Option<Result<String, String>> {
+        None
+    }
+}
 mod todos;
 mod vision;
 mod web_search;

--- a/crates/claudette/src/tools/vision.rs
+++ b/crates/claudette/src/tools/vision.rs
@@ -278,20 +278,26 @@ mod tests {
 
     #[test]
     fn image_describe_rejects_non_image_extension() {
-        // Have to pass a path that survives validate_read_path. Use a
-        // unique non-image filename under $HOME — it doesn't need to
-        // exist; the extension check fires first.
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .unwrap_or_else(|_| ".".into());
-        let path = format!("{home}/claudette-not-an-image-xyz.txt");
-        let _ = std::fs::write(&path, "hi");
-        let err = run_image_describe(&json!({ "path": &path }).to_string()).unwrap_err();
-        let _ = std::fs::remove_file(&path);
-        assert!(
-            err.contains("not a supported image type") || err.contains("missing"),
-            "got: {err}"
-        );
+        // Use the shared temp-HOME helper rather than reading the ambient
+        // HOME/USERPROFILE directly. `validate_read_path` (called inside
+        // `run_image_describe`) re-resolves the home dir, so reading the
+        // global env here would race any concurrent test that swaps HOME —
+        // the path we built would fall outside the home seen at dispatch and
+        // fail the read-guard *before* the extension check we're asserting on.
+        // `with_temp_home` pins HOME to a private temp dir AND holds the
+        // process-wide env lock for the whole closure, killing the race. The
+        // file lives under that home so it survives the read-guard; the
+        // unsupported-extension check then fires as intended.
+        crate::with_temp_home(|home| {
+            let path = home.join("claudette-not-an-image-xyz.txt");
+            let _ = std::fs::write(&path, "hi");
+            let err = run_image_describe(&json!({ "path": path.to_string_lossy() }).to_string())
+                .unwrap_err();
+            assert!(
+                err.contains("not a supported image type") || err.contains("missing"),
+                "got: {err}"
+            );
+        });
     }
 
     #[test]

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -685,6 +685,28 @@ fn read_clipboard_paste() -> ClipboardPaste {
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub fn run_tui(session: Session) -> Result<()> {
+    // Restore the terminal even if a panic blows past the `scopeguard::defer!`
+    // below. The release profile builds with `panic = "abort"` (see the root
+    // Cargo.toml), and `defer!` only fires on normal return or unwind — under
+    // `abort` it is SKIPPED. Without this hook a panic mid-session would leave
+    // the user's shell in raw mode + alt-screen (a garbled, unusable terminal),
+    // which is the most plausible "it broke my shell" failure. A panic hook, by
+    // contrast, runs on the panicking thread *before* the process aborts, so the
+    // terminal is reset on every exit path. We chain to the previous hook so the
+    // panic message still prints. The restore calls are idempotent no-ops once
+    // the terminal is back to cooked mode, so leaving the hook installed after a
+    // clean exit is harmless.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(
+            std::io::stdout(),
+            DisableBracketedPaste,
+            LeaveAlternateScreen
+        );
+        previous_hook(info);
+    }));
+
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,5 +1,16 @@
 # Architecture Decisions
 
+> [!WARNING]
+> **HISTORICAL — planning-era design doc, NOT the shipped architecture.**
+> These ADs were written in April 2026 for the `claudettes-forge` predecessor and describe a design that was largely *not* built. They are kept for provenance only. For how claudette actually works today, read **[`architecture.md`](architecture.md)** — it is the source of truth.
+>
+> Specifically, the following claims below are **fiction relative to the shipped product**:
+> - **AD-1 / AD-2** — claudette is a **single-crate** workspace (`crates/claudette`), not six crates. There is no `claudette-verify` binary or `claudettes-forge-verifier` crate. Forge is invoked as `claudette --forge "<prompt>"`, not `claudettes-forge forge <mission>`.
+> - **AD-3** — **claudette has no cloud provider.** It is local-only / air-gapped and drives one local model (LM Studio or Ollama). The "Anthropic Claude as the only cloud option" never shipped; see [`../PRIVACY.md`](../PRIVACY.md) and `src/egress.rs`.
+> - **AD-4 / AD-7** — the real forge loop is a Coder → Verifier (with an optional CTO decomposition) cycle, **not** the 7-stage `Router → Planner → Coder → TestCoder → Verifier → SurgicalCoder → Gate` pipeline. There is no `--gate-threshold`, `--pro`, or `pipeline.gate_threshold` config.
+> - **AD-5** — permissions are **three-tier** (see `architecture.md`), not the 5-tier `ReadOnly/WorkspaceWrite/DangerFullAccess/Prompt/Allow` model, and there is **no platform sandboxing** (`sandbox-exec`/`bwrap`) — that module was removed in the 2026-06 dead-code cleanup.
+> - **AD-6** — MSRV is **1.88** and clippy/pedantic apply to the single crate; the "seven-crate workspace" framing is moot.
+
 Convention: AD-N sequential. Each captures *problem → options → decision → consequences*. Nice-to-have documentation for load-bearing choices; readers can go straight from "why does it work this way" to the rationale without asking.
 
 ---


### PR DESCRIPTION
Production-readiness pass from the 2026-06-07/08 audit (*useful enough / not bloated / production-ready for solo devs*). Implements all 5 recommendations.

## What's in here

| # | Change | Type |
|---|--------|------|
| 1 | **Coding-only build** via a default-on `integrations` Cargo feature — `--no-default-features` compiles out Google OAuth / Gmail / Calendar / Telegram entirely | feat |
| 2 | **Panic-safe TUI** — `run_tui` installs a panic hook that restores the terminal before `panic = "abort"` skips the `defer!` | fix |
| 3 | **`docs/decisions.md` marked HISTORICAL** — it described the unbuilt `claudettes-forge` design (incl. an AD-3 "cloud Claude" that contradicts the air-gap) | docs |
| 4 | **De-flaked** `vision::image_describe_rejects_non_image_extension` (global-`HOME` race under parallel tests) | test |
| 5 | **Cut v0.9.0** — version bump + lock, CHANGELOG `[Unreleased]→[0.9.0]`, README note | chore |

## Coding-only feature design

The `ToolGroup` enum is **untouched** — the gated tool modules (`gmail`/`calendar`/`telegram`) compile to empty-stub `schemas()`/`dispatch()` when the feature is off, so the `GROUPS` table and every hardcoded-count test still hold. `main.rs` routes `--auth-google`/`--telegram` through `#[cfg]`-gated helpers that print a clear "compiled without integrations" message in a coding-only build. The `oauth_smoke` example declares `required-features = ["integrations"]`.

## Verification (local, Windows)

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (default)
- `cargo clippy --no-default-features --all-targets -- -D warnings` ✅ (coding-only)
- `cargo test` (default): lib **1069 passed**, offline_egress **3**, bin **25**, 0 failed ✅
- `cargo test --lib --no-default-features`: **994 passed**, 0 failed ✅ (75-test delta = the gated module tests)

## ⚠️ Release note

Tagging `v0.9.0` auto-publishes to crates.io (irreversible) + a GitHub Release via `release.yml`. **Do not tag until this is merged and CI is green** — left for explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)