### PR TITLE
feat(semantic_grep): identifier-aware tokenizer (split camelCase)

### DIFF
--- a/crates/claudette/src/tools/semantic.rs
+++ b/crates/claudette/src/tools/semantic.rs
@@ -230,13 +230,19 @@ fn tokenize(s: &str) -> HashSet<String> {
         let mut prev_lower_or_digit = false;
         for ch in raw.chars() {
             if ch.is_uppercase() && prev_lower_or_digit && !cur.is_empty() {
-                out.push(cur.to_lowercase());
+                let lower = cur.to_lowercase();
+                if lower.chars().count() > 1 {
+                    out.push(lower);
+                }
                 cur.clear();
             }
             cur.push(ch);
             prev_lower_or_digit = ch.is_lowercase() || ch.is_ascii_digit();
         }
-        out.push(cur.to_lowercase());
+        let lower = cur.to_lowercase();
+        if lower.chars().count() > 1 {
+            out.push(lower);
+        }
     }
     out.into_iter().collect()
 }
@@ -316,6 +322,17 @@ mod tests {
         assert!(t.contains("max"));
         assert!(t.contains("fix"));
         assert!(t.contains("rounds"));
+    }
+
+    #[test]
+    fn tokenize_drops_single_char_tokens() {
+        let t = tokenize("a bb cCc x9");
+        assert!(!t.contains("a"), "single-char token must be dropped");
+        assert!(
+            !t.contains("x"),
+            "single-char split fragment must be dropped"
+        );
+        assert!(t.contains("bb"));
     }
 
     #[test]

--- a/crates/claudette/src/tools/semantic.rs
+++ b/crates/claudette/src/tools/semantic.rs
@@ -221,10 +221,24 @@ fn chunk_file(path: &Path, text: &str, chunks: &mut Vec<Chunk>) {
 }
 
 fn tokenize(s: &str) -> HashSet<String> {
-    s.split(|c: char| !c.is_alphanumeric())
-        .filter(|t| !t.is_empty() && t.len() > 1)
-        .map(str::to_lowercase)
-        .collect()
+    let mut out = Vec::new();
+    for raw in s.split(|c: char| !c.is_alphanumeric()) {
+        if raw.is_empty() {
+            continue;
+        }
+        let mut cur = String::new();
+        let mut prev_lower_or_digit = false;
+        for ch in raw.chars() {
+            if ch.is_uppercase() && prev_lower_or_digit && !cur.is_empty() {
+                out.push(cur.to_lowercase());
+                cur.clear();
+            }
+            cur.push(ch);
+            prev_lower_or_digit = ch.is_lowercase() || ch.is_ascii_digit();
+        }
+        out.push(cur.to_lowercase());
+    }
+    out.into_iter().collect()
 }
 
 fn jaccard(a: &HashSet<String>, b: &HashSet<String>) -> f32 {
@@ -287,9 +301,21 @@ mod tests {
         assert!(t.contains("payment"));
         assert!(t.contains("retry"));
         assert!(t.contains("logic"));
-        assert!(t.contains("myclass"));
+        // "MyClass" splits into two tokens: my + class.
+        assert!(t.contains("my"));
+        assert!(t.contains("class"));
         // Single-char tokens dropped — the slash isn't kept either.
         assert!(!t.contains(""));
+    }
+
+    #[test]
+    fn tokenize_splits_camelcase() {
+        let t = tokenize("loopBreaker maxFixRounds");
+        assert!(t.contains("loop"));
+        assert!(t.contains("breaker"));
+        assert!(t.contains("max"));
+        assert!(t.contains("fix"));
+        assert!(t.contains("rounds"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Port the camelCase-splitting logic from `repo_map`'s tokenizer into `semantic_grep`.

### Changes
- **`tokenize()` in `semantic.rs`**: After splitting on non-alphanumeric boundaries, each fragment is now further split at camelCase/PascalCase boundaries (uppercase preceded by lowercase-or-digit). Tokens are lowercased and ≤1-char tokens are dropped. Stop-word filtering is intentionally NOT ported — that's out of scope for this PR.
- **Updated test**: `tokenize_filters_short_tokens_and_lowercases` — `MyClass` now yields `my` + `class` instead of `myclass`.
- **New test**: `tokenize_splits_camelcase` asserts that `loopBreaker maxFixRounds` → `{loop, breaker, max, fix, rounds}`.

### Why
A query like `"loop breaker"` previously failed to match code written `loopBreaker`, and `"my class"` wouldn't match `MyClass`. This brings `semantic_grep`'s tokenization in line with `repo_map`'s already-working behavior.

### Acceptance
- `cargo fmt --all`: clean
- `cargo clippy --all-targets`: clean (no new warnings)
- `cargo test --lib --bins`: all semantic tests green (the one unrelated failure in `api::tests` is pre-existing)
