### PR TITLE
feat(tools): near-miss diagnostics for apply_diff/edit_file not-found

### DIFF
--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -63,6 +63,7 @@ mod gmail {
 mod ide;
 mod markets;
 mod mission;
+mod near_miss;
 mod notes;
 mod patch;
 pub(crate) mod quality;

--- a/crates/claudette/src/tools/fuzzy_apply.rs
+++ b/crates/claudette/src/tools/fuzzy_apply.rs
@@ -113,10 +113,21 @@ fn run_apply_diff(input: &str) -> Result<String, String> {
         }
         Err(e) => {
             let msg = match e {
-                FuzzyError::NotFound => format!(
-                    "apply_diff: 'before' block not found in {raw_path} (tried exact + line-trim \
-                     match). Re-read the file and copy the block exactly, or widen the context."
-                ),
+                FuzzyError::NotFound => {
+                    // Near-miss diagnostics (dogfood T2): a bare "not found"
+                    // sends small brains down CRLF/whitespace rabbit holes
+                    // when the real cause is usually over-escaped backslashes
+                    // or one drifted line. Name the difference when we can.
+                    let hint =
+                        super::near_miss::near_miss_hint(&original, before).unwrap_or_else(|| {
+                            "Re-read the file and copy the block exactly, or widen the context."
+                                .to_string()
+                        });
+                    format!(
+                        "apply_diff: 'before' block not found in {raw_path} (tried exact + \
+                         line-trim match). {hint}"
+                    )
+                }
                 FuzzyError::Ambiguous => format!(
                     "apply_diff: 'before' block matched in multiple places in {raw_path} — \
                      ambiguous. Add more surrounding lines so the block is unique."
@@ -519,5 +530,33 @@ mod tests {
     fn run_apply_diff_rejects_missing_before() {
         let err = run_apply_diff(r#"{"path":"x","after":"y"}"#).unwrap_err();
         assert!(err.contains("missing 'before'"), "got: {err}");
+    }
+
+    #[test]
+    fn not_found_error_carries_near_miss_hint() {
+        // Dogfood T2: a `before` with doubled backslashes must produce the
+        // over-escaping diagnosis end-to-end, not the generic "copy exactly".
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".into());
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = format!("{home}/claudette-diff-nearmiss-{nanos}.txt");
+        let original = "fn pat() {\n    let re = r\"^\\s*fn\";\n}\n";
+        fs::write(&path, original).unwrap();
+
+        let input = json!({
+            "path": &path,
+            "before": "    let re = r\"^\\\\s*fn\";\n",
+            "after": "    let re = r\"^\\\\s*struct\";\n"
+        })
+        .to_string();
+        let result = run_apply_diff(&input);
+        let _ = fs::remove_file(&path);
+
+        let err = result.expect_err("expected not-found error");
+        assert!(err.contains("'before' block not found"), "got: {err}");
+        assert!(err.contains("over-escapes backslashes"), "got: {err}");
     }
 }

--- a/crates/claudette/src/tools/near_miss.rs
+++ b/crates/claudette/src/tools/near_miss.rs
@@ -1,0 +1,223 @@
+//! Near-miss diagnostics for the block-edit tools (`apply_diff`,
+//! `edit_file`).
+//!
+//! When a `before`/`old_text` block isn't found, the bare "not found —
+//! copy the block exactly" error sends small local brains down
+//! wrong-hypothesis rabbit holes. Dogfood T2 (2026-06-11) burned ~15
+//! iterations theorizing about CRLF and trailing whitespace when the real
+//! problem was doubled backslashes (`r"^\\s*fn"` in the tool call where the
+//! file has `r"^\s*fn"`) — the classic JSON-escaping confusion every local
+//! model hits when raw-string regexes pass through tool-call JSON.
+//!
+//! [`near_miss_hint`] turns that one-shot diagnosable failure into an
+//! actionable message:
+//! 1. **Over-escaped backslashes** — if de-doubling `\\` → `\` in the
+//!    model's block produces a match, say exactly that.
+//! 2. **Closest line-window** — otherwise find the content window whose
+//!    trimmed lines best match the block's and report the first differing
+//!    line, file-side vs block-side.
+//!
+//! Pure functions over strings; both tools call this only on their failure
+//! path, so the O(lines × block-lines) scan never taxes a successful edit.
+
+/// Don't scan pathologically large files on the failure path.
+const MAX_CONTENT_BYTES: usize = 256 * 1024;
+/// Blocks longer than this are unlikely to be near-misses worth a window
+/// scan (and the model should be sending smaller edits anyway).
+const MAX_BLOCK_LINES: usize = 64;
+/// Cap quoted fragments in the hint so the tool_result stays readable.
+const SNIPPET_CHARS: usize = 120;
+
+/// Diagnose why `block` failed to match inside `content`. Returns a
+/// ready-to-append sentence, or `None` when there is no credible near-miss
+/// (the generic "re-read and copy exactly" advice is then the best we have).
+pub(super) fn near_miss_hint(content: &str, block: &str) -> Option<String> {
+    if block.is_empty() || content.len() > MAX_CONTENT_BYTES {
+        return None;
+    }
+
+    // 1. Over-escaped backslashes — check first because it is the #1
+    //    local-model failure mode and the fix is a one-line instruction.
+    if block.contains("\\\\") {
+        let dedoubled = block.replace("\\\\", "\\");
+        if block_found(content, &dedoubled) {
+            let sample = block
+                .lines()
+                .find(|l| l.contains("\\\\"))
+                .map(|l| truncate(l.trim()))
+                .unwrap_or_default();
+            return Some(format!(
+                "Your block over-escapes backslashes: de-doubling `\\\\` to \
+                 `\\` makes it match the file. The file has SINGLE \
+                 backslashes where your block doubles them (e.g. your \
+                 `{sample}`). Re-send the same edit with single backslashes."
+            ));
+        }
+    }
+
+    // 2. Closest line-window by trimmed-line equality.
+    let content_lines: Vec<&str> = content.lines().collect();
+    let block_trim: Vec<&str> = block.lines().map(str::trim).collect();
+    let m = block_trim.len();
+    if m == 0 || m > MAX_BLOCK_LINES || content_lines.len() < m {
+        return None;
+    }
+    let mut best_score = 0usize;
+    let mut best_start = 0usize;
+    for i in 0..=(content_lines.len() - m) {
+        let score = (0..m)
+            .filter(|&j| content_lines[i + j].trim() == block_trim[j])
+            .count();
+        if score > best_score {
+            best_score = score;
+            best_start = i;
+        }
+    }
+    // Require at least half the lines to line up — a lower score is not a
+    // near-miss, and pointing at it would mislead more than the generic
+    // advice. (Single-line blocks therefore need an exact trimmed match,
+    // which only triggers the whitespace arm below.)
+    if best_score == 0 || best_score * 2 < m {
+        return None;
+    }
+
+    let first_line = best_start + 1; // 1-based for the message
+    let last_line = best_start + m;
+    let diff = (0..m).find(|&j| content_lines[best_start + j].trim() != block_trim[j]);
+    match diff {
+        Some(j) => Some(format!(
+            "Closest match: lines {first_line}-{last_line} ({best_score}/{m} \
+             lines already match). First difference at line {}: file has \
+             `{}` but your block has `{}`.",
+            best_start + j + 1,
+            truncate(content_lines[best_start + j].trim()),
+            truncate(block_trim[j]),
+        )),
+        // Every line matches after trimming — the mismatch is pure
+        // whitespace/indentation (edit_file's exact matcher hits this).
+        None => Some(format!(
+            "Lines {first_line}-{last_line} match your block except for \
+             whitespace/indentation — re-read those lines and copy them \
+             exactly."
+        )),
+    }
+}
+
+/// True when `block` appears in `content`, either as an exact substring or
+/// as a contiguous window of trimmed-equal lines (the same tolerance the
+/// edit tools' fuzzy passes use).
+fn block_found(content: &str, block: &str) -> bool {
+    if content.contains(block) {
+        return true;
+    }
+    let content_lines: Vec<&str> = content.lines().collect();
+    let block_trim: Vec<&str> = block.lines().map(str::trim).collect();
+    let m = block_trim.len();
+    if m == 0 || content_lines.len() < m {
+        return false;
+    }
+    (0..=(content_lines.len() - m))
+        .any(|i| (0..m).all(|j| content_lines[i + j].trim() == block_trim[j]))
+}
+
+/// Trim a quoted fragment to [`SNIPPET_CHARS`] characters (char-boundary
+/// safe), appending an ellipsis when cut.
+fn truncate(s: &str) -> String {
+    if s.chars().count() <= SNIPPET_CHARS {
+        return s.to_string();
+    }
+    let cut: String = s.chars().take(SNIPPET_CHARS).collect();
+    format!("{cut}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn over_escaped_backslashes_detected() {
+        // The dogfood T2 failure verbatim: file has single backslashes in a
+        // raw-string regex, the model's block doubles them.
+        let content = "fn pat() {\n    let re = r\"^\\s*fn\\s+\\w+\";\n    re\n}\n";
+        let block = "    let re = r\"^\\\\s*fn\\\\s+\\\\w+\";\n    re\n";
+        let hint = near_miss_hint(content, block).expect("must diagnose over-escaping");
+        assert!(hint.contains("over-escapes backslashes"), "got: {hint}");
+        assert!(hint.contains("\\\\s"), "sample line should appear: {hint}");
+    }
+
+    #[test]
+    fn dedouble_that_still_does_not_match_is_not_reported() {
+        // Block has `\\` but even the de-doubled version isn't in the file —
+        // must not claim over-escaping.
+        let content = "alpha\nbeta\ngamma\n";
+        let block = "let re = r\"^\\\\d+\";\n";
+        let hint = near_miss_hint(content, block);
+        assert!(
+            hint.is_none() || !hint.as_ref().unwrap().contains("over-escapes"),
+            "got: {hint:?}"
+        );
+    }
+
+    #[test]
+    fn closest_window_reports_first_difference() {
+        let content = "fn main() {\n    let a = 1;\n    let b = 2;\n    let c = 3;\n}\n";
+        // 3 of 4 lines match; the `b` line differs.
+        let block = "fn main() {\n    let a = 1;\n    let b = 99;\n    let c = 3;\n";
+        let hint = near_miss_hint(content, block).expect("must find the near window");
+        assert!(hint.contains("Closest match: lines 1-4"), "got: {hint}");
+        assert!(hint.contains("3/4"), "got: {hint}");
+        assert!(hint.contains("First difference at line 3"), "got: {hint}");
+        assert!(hint.contains("let b = 2;"), "file side missing: {hint}");
+        assert!(hint.contains("let b = 99;"), "block side missing: {hint}");
+    }
+
+    #[test]
+    fn whitespace_only_mismatch_reported_as_such() {
+        // Trimmed lines all equal — the failure is indentation only (this is
+        // edit_file's exact-match blind spot).
+        let content = "if x {\n    do_it();\n}\n";
+        let block = "if x {\n        do_it();\n}";
+        let hint = near_miss_hint(content, block).expect("must diagnose whitespace");
+        assert!(
+            hint.contains("except for whitespace/indentation"),
+            "got: {hint}"
+        );
+    }
+
+    #[test]
+    fn unrelated_block_yields_no_hint() {
+        let content = "alpha\nbeta\ngamma\n";
+        let block = "fn totally() {\n    different();\n}\n";
+        assert_eq!(near_miss_hint(content, block), None);
+    }
+
+    #[test]
+    fn below_half_match_yields_no_hint() {
+        // Only 1 of 4 lines matches — not a credible near-miss.
+        let content = "one\ntwo\nthree\nfour\nfive\n";
+        let block = "one\nX\nY\nZ\n";
+        assert_eq!(near_miss_hint(content, block), None);
+    }
+
+    #[test]
+    fn oversized_content_is_skipped() {
+        let content = "x\n".repeat(200_000); // 400 KB > cap
+        let block = "x\ny\n";
+        assert_eq!(near_miss_hint(&content, block), None);
+    }
+
+    #[test]
+    fn empty_block_yields_no_hint() {
+        assert_eq!(near_miss_hint("anything\n", ""), None);
+    }
+
+    #[test]
+    fn long_lines_are_truncated_in_the_hint() {
+        let long_a = format!("let value = \"{}A\";", "a".repeat(200));
+        let long_b = format!("let value = \"{}B\";", "a".repeat(200));
+        let content = format!("start\n{long_a}\nend\n");
+        let block = format!("start\n{long_b}\nend\n");
+        let hint = near_miss_hint(&content, &block).expect("must diagnose");
+        assert!(hint.contains('…'), "snippets must be truncated: {hint}");
+    }
+}

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -238,8 +238,13 @@ fn run_edit_file(input: &str) -> Result<String, String> {
     let match_count = content.matches(old_text).count();
     match match_count {
         0 => {
+            // Near-miss diagnostics (dogfood T2): point at over-escaped
+            // backslashes or the closest drifted window instead of leaving
+            // the model to theorize about CRLF/whitespace.
+            let hint = super::near_miss::near_miss_hint(&content, old_text)
+                .unwrap_or_else(|| "The text to replace must match exactly.".to_string());
             return Err(format!(
-                "edit_file: old_text not found in {}. The text to replace must match exactly.",
+                "edit_file: old_text not found in {}. {hint}",
                 path.display()
             ));
         }
@@ -596,6 +601,29 @@ mod tests {
         let err = result.expect_err("expected not-found error");
         assert!(err.contains("not found"), "got: {err}");
         assert_eq!(after.as_deref(), Some(original));
+    }
+
+    #[test]
+    fn edit_file_zero_match_reports_over_escaped_backslashes() {
+        // Dogfood T2: old_text doubled the backslashes of a raw-string regex
+        // (JSON-escaping confusion). The error must name the real cause, not
+        // just say "not found".
+        let path = home_join("nearmiss");
+        let original = "fn pat() {\n    let re = r\"^\\s*fn\";\n}\n";
+        fs::write(&path, original).unwrap();
+
+        let input = json!({
+            "path": &path,
+            "old_text": "    let re = r\"^\\\\s*fn\";\n",
+            "new_text": "    let re = r\"^\\\\s*struct\";\n"
+        })
+        .to_string();
+        let result = run_edit_file(&input);
+        let _ = fs::remove_file(&path);
+
+        let err = result.expect_err("expected not-found error");
+        assert!(err.contains("not found"), "got: {err}");
+        assert!(err.contains("over-escapes backslashes"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Implements remediation-plan PR C (`plans/dogfood-2026-06-08/REMEDIATION-PLAN.md`, finding F1) — the highest-leverage tool-UX fix for local models. Dogfood T2 burned ~15 iterations on a wrong CRLF hypothesis when the real cause of "'before' block not found" was doubled backslashes (`r"^\\s*fn"` in the tool call vs `r"^\s*fn"` in the file — the classic JSON-escaping confusion on raw-string regexes).

## What

New shared `tools::near_miss::near_miss_hint(content, block)`, wired into both `apply_diff` (`FuzzyError::NotFound`) and `edit_file` (0-match arm). Failure path only — successful edits pay nothing.

1. **Over-escaped backslashes (checked first).** If de-doubling `\\` → `\` in the model's block makes it match (exact substring or trimmed-line window), the error says so and quotes the offending line: *"Your block over-escapes backslashes... Re-send the same edit with single backslashes."* This alone would have ended the T2 spiral in one round.
2. **Closest line-window.** Otherwise scan for the window whose trimmed lines best match the block (at least half must match) and report: *"Closest match: lines 510-516 (5/7 lines already match). First difference at line 512: file has `...` but your block has `...`"*. If every line matches after trimming, the report names whitespace/indentation drift instead (edit_file's exact-matcher blind spot — apply_diff's pass 2 already tolerates it).
3. **No credible near-miss** → the original generic advice is unchanged.

Guard rails: skips files > 256 KB and blocks > 64 lines; quoted snippets capped at 120 chars (char-boundary safe).

## Tests

11 new: 9 `near_miss` unit tests (including the T2 failure verbatim, a no-false-positive case for blocks that legitimately contain `\\`, the below-half-match rejection, and snippet truncation) + 2 end-to-end error-message tests (`run_apply_diff` and `run_edit_file` with a doubled-backslash block against a real sandboxed file).

Gate: fmt + clippy clean, full `cargo test -p claudette --lib` 1088 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
