### PR TITLE
fix(tests): write_file allow-tests pin workspace env + assert location

### DIFF
--- a/crates/claudette/src/tools/file_ops.rs
+++ b/crates/claudette/src/tools/file_ops.rs
@@ -655,22 +655,23 @@ mod tests {
         // the workspace root) and the sandbox check rejected it. Now bare
         // relative paths are rooted at files_dir() so the model's intuition
         // works without it having to know the sandbox path.
-        let _guard = crate::test_env_lock(); // home-resolving
-        let target = files_dir().join("claudette-relative-test.txt");
-        let _ = fs::remove_file(&target);
+        with_workspace_env(None, || {
+            let target = files_dir().join("claudette-relative-test.txt");
+            let _ = fs::remove_file(&target);
 
-        let input = json!({
-            "path": "claudette-relative-test.txt",
-            "content": "wrote via bare relative path",
-        })
-        .to_string();
-        let out = run_write_file(&input).expect("relative write should succeed under sandbox");
-        assert!(out.contains("\"ok\":true"), "got: {out}");
-        assert!(target.exists(), "expected {} to exist", target.display());
-        let content = fs::read_to_string(&target).unwrap();
-        assert_eq!(content, "wrote via bare relative path");
+            let input = json!({
+                "path": "claudette-relative-test.txt",
+                "content": "wrote via bare relative path",
+            })
+            .to_string();
+            let out = run_write_file(&input).expect("relative write should succeed under sandbox");
+            assert!(out.contains("\"ok\":true"), "got: {out}");
+            assert!(target.exists(), "expected {} to exist", target.display());
+            let content = fs::read_to_string(&target).unwrap();
+            assert_eq!(content, "wrote via bare relative path");
 
-        let _ = fs::remove_file(&target);
+            let _ = fs::remove_file(&target);
+        });
     }
 
     #[test]

--- a/crates/claudette/src/tools/file_ops.rs
+++ b/crates/claudette/src/tools/file_ops.rs
@@ -723,37 +723,49 @@ mod tests {
 
     #[test]
     fn write_file_allows_text_extension() {
-        let _guard = crate::test_env_lock(); // home-resolving
-        let target = files_dir().join("write_refuse_allows_txt.txt");
-        let _ = fs::remove_file(&target);
-        let input = json!({
-            "path": "write_refuse_allows_txt.txt",
-            "content": "plain notes",
-        })
-        .to_string();
-        let out = run_write_file(&input).expect(".txt should be allowed");
-        assert!(out.contains("\"ok\":true"), "got: {out}");
-        let _ = fs::remove_file(&target);
+        with_workspace_env(None, || {
+            let target = files_dir().join("write_refuse_allows_txt.txt");
+            let _ = fs::remove_file(&target);
+            let input = json!({
+                "path": "write_refuse_allows_txt.txt",
+                "content": "plain notes",
+            })
+            .to_string();
+            let out = run_write_file(&input).expect(".txt should be allowed");
+            assert!(out.contains("\"ok\":true"), "got: {out}");
+            assert!(
+                target.exists(),
+                "file must land in files_dir, got nothing at {}",
+                target.display()
+            );
+            let _ = fs::remove_file(&target);
+        });
     }
 
     #[test]
     fn write_file_allows_data_and_config_extensions() {
         // JSON, MD, YAML, TOML — config/data formats stay on write_file.
-        let _guard = crate::test_env_lock(); // home-resolving
-        for (path, content) in [
-            ("write_refuse_data.json", r#"{"k":"v"}"#),
-            ("write_refuse_data.md", "# heading"),
-            ("write_refuse_data.yaml", "k: v"),
-            ("write_refuse_data.toml", "k = 'v'"),
-        ] {
-            let target = files_dir().join(path);
-            let _ = fs::remove_file(&target);
-            let input = json!({ "path": path, "content": content }).to_string();
-            let out = run_write_file(&input)
-                .unwrap_or_else(|e| panic!("{path} should be allowed, got: {e}"));
-            assert!(out.contains("\"ok\":true"), "{path}: got {out}");
-            let _ = fs::remove_file(&target);
-        }
+        with_workspace_env(None, || {
+            for (path, content) in [
+                ("write_refuse_data.json", r#"{"k":"v"}"#),
+                ("write_refuse_data.md", "# heading"),
+                ("write_refuse_data.yaml", "k: v"),
+                ("write_refuse_data.toml", "k = 'v'"),
+            ] {
+                let target = files_dir().join(path);
+                let _ = fs::remove_file(&target);
+                let input = json!({ "path": path, "content": content }).to_string();
+                let out = run_write_file(&input)
+                    .unwrap_or_else(|e| panic!("{path} should be allowed, got: {e}"));
+                assert!(out.contains("\"ok\":true"), "{path}: got {out}");
+                assert!(
+                    target.exists(),
+                    "file must land in files_dir, got nothing at {}",
+                    target.display()
+                );
+                let _ = fs::remove_file(&target);
+            }
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\nFixes two tests (write_file_allows_text_extension and write_file_allows_data_and_config_extensions) that leaked artifacts into the repo when CLAUDETTE_WORKSPACE was set in the test process.\n\n## Changes\n\n- Replaced manual crate::test_env_lock() guards with with_workspace_env(None, || { ... }) wrapping the entire test body for both tests — this pins workspace env to unset under the global lock, preventing bare relative paths from resolving against CWD instead of iles_dir().\n- Added regression assertions (ssert!(target.exists(), ...)) after each successful write to verify files land in iles_dir() before cleanup. With the old code and a leaked workspace env, these would have failed.\n\n## Gate\n\n- cargo fmt --all — clean\n- cargo clippy --all-targets — clean\n- cargo test -p claudette --lib write_file_allows — 2/2 passed\n- No untracked junk files after test run