### PR TITLE
fix(tools): raise file-size cap to 1MB; flag oversized grep skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ bumps are non-breaking bugfixes only.
   to `glob_search`, so it is no longer over-called in place of a targeted
   search. `mode=refs` output is unchanged.
 
+### Fixed
+
+- **Large source files are no longer invisible to search/read.** The shared
+  file-size cap was 100 KB, so a source file over it — including Claudette's
+  own 135 KB `api.rs` — was hard-refused by `read_file` and *silently* skipped
+  by `grep_search`/`repo_map`. A search for a symbol that was actually present
+  returned nothing, which on a small brain read as "the code was deleted." The
+  cap is raised to 1 MB (covers hand-written source; still excludes
+  pathological minified/generated blobs), and `grep_search` now reports a
+  `skipped_oversize` count plus a note pointing to `read_file` when a file is
+  too large to scan, instead of dropping it silently.
+
 ## [0.10.0] - 2026-06-12
 
 All three changes come straight from dogfooding claudette on her own

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -457,7 +457,13 @@ fn run_get_capabilities() -> String {
 // doc comment and `path_is_allowed`.
 // ────────────────────────────────────────────────────────────────────────────
 
-pub(super) const MAX_FILE_BYTES: usize = 100 * 1024; // 100 KB
+// 1 MB: raised from 100 KB after a dogfood session went blind to the repo's
+// own `api.rs` (135 KB) — read_file refused it and grep_search/repo_map
+// silently skipped it, so a search for a symbol that was actually present
+// returned nothing and the model concluded the code had been deleted. Normal
+// source files routinely exceed 100 KB; 1 MB still excludes pathological
+// minified/generated/data blobs while covering hand-written code.
+pub(super) const MAX_FILE_BYTES: usize = 1024 * 1024; // 1 MB
 
 /// Expand a leading `~` to the user's home directory. Other tildes are left
 /// alone (matching shell behaviour). `pub(crate)` so the `/validate` slash

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -279,6 +279,7 @@ fn run_grep_search(input: &str) -> Result<String, String> {
     let mut matches: Vec<Value> = Vec::new();
     let mut files_scanned: usize = 0;
     let mut truncated = false;
+    let mut skipped_oversize: usize = 0;
 
     // Walk with ripgrep's `ignore` crate: respects .gitignore / .ignore,
     // skips hidden files, and never descends into VCS metadata. `filter_entry`
@@ -350,9 +351,13 @@ fn run_grep_search(input: &str) -> Result<String, String> {
         }
         files_scanned += 1;
 
-        // Skip oversized files — same 100 KB cap as read_file.
+        // Skip oversized files — same cap as read_file. Counted, not silently
+        // dropped, so the result can flag that a too-big file went unsearched
+        // instead of looking like a clean "no match" (a silent skip once made a
+        // model conclude present code had been deleted).
         let Ok(meta) = entry.metadata() else { continue };
         if meta.len() > MAX_FILE_BYTES as u64 {
+            skipped_oversize += 1;
             continue;
         }
         // Read as text; binary files fail UTF-8 and get skipped.
@@ -375,7 +380,7 @@ fn run_grep_search(input: &str) -> Result<String, String> {
         }
     }
 
-    Ok(json!({
+    let mut result = json!({
         "pattern": pattern,
         "mode": mode,
         "root": root.display().to_string(),
@@ -383,8 +388,16 @@ fn run_grep_search(input: &str) -> Result<String, String> {
         "match_count": matches.len(),
         "truncated": truncated,
         "matches": matches,
-    })
-    .to_string())
+    });
+    if skipped_oversize > 0 {
+        result["skipped_oversize"] = json!(skipped_oversize);
+        result["note"] = json!(format!(
+            "{skipped_oversize} file(s) exceeded the {MAX_FILE_BYTES}-byte size cap and were NOT \
+             searched — a low match_count may be incomplete. Open such a file directly with \
+             read_file (it pages) instead of assuming the pattern is absent."
+        ));
+    }
+    Ok(result.to_string())
 }
 
 // ────── web_fetch ────────────────────────────────────────────────────────
@@ -778,6 +791,62 @@ mod tests {
         let out2 = run_grep_search(&input2).unwrap();
         let v2: Value = serde_json::from_str(&out2).unwrap();
         assert_eq!(v2["mode"], json!("literal"), "got: {out2}");
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn grep_search_searches_large_files_and_flags_oversized() {
+        let _eg = crate::test_env_lock();
+        let base = user_home()
+            .join(".claudette")
+            .join("files")
+            .join("claudette-greptest-bigfiles");
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+
+        // ~200 KB: over the OLD 100 KB cap, under the new 1 MB cap → must be
+        // searched now (this is exactly the api.rs-went-invisible regression).
+        let mut medium = "x".repeat(200 * 1024);
+        medium.push_str("\nFINDME_NEEDLE\n");
+        fs::write(base.join("medium.rs"), &medium).unwrap();
+
+        // ~1.1 MB: over the new cap → skipped, but FLAGGED, not silent.
+        let mut huge = "y".repeat(1_100 * 1024);
+        huge.push_str("\nFINDME_NEEDLE\n");
+        fs::write(base.join("huge.rs"), &huge).unwrap();
+
+        let input =
+            json!({ "pattern": "FINDME_NEEDLE", "path": base.to_str().unwrap() }).to_string();
+        let out = run_grep_search(&input).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+
+        let files: Vec<String> = v["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m["file"].as_str().unwrap().replace('\\', "/"))
+            .collect();
+        // The 200 KB file is now searched (would have been skipped at 100 KB).
+        assert!(
+            files.iter().any(|f| f.contains("/medium.rs")),
+            "200 KB file must be searched now: {out}"
+        );
+        // The 1.1 MB file is skipped…
+        assert!(
+            !files.iter().any(|f| f.contains("/huge.rs")),
+            "1.1 MB file must be skipped: {out}"
+        );
+        // …but flagged, not silent.
+        assert_eq!(
+            v["skipped_oversize"].as_u64().unwrap(),
+            1,
+            "the oversized file must be counted: {out}"
+        );
+        assert!(
+            v["note"].as_str().unwrap().contains("read_file"),
+            "the note must point to read_file: {out}"
+        );
 
         let _ = fs::remove_dir_all(&base);
     }


### PR DESCRIPTION
**Stacked on #62** (base = `feat/repomap-digestible`, so this diff is only the cap fix). Merge #62 first; GitHub will auto-retarget this to `main`.

## The bug (cost a live dogfood session)

The shared `MAX_FILE_BYTES` was **100 KB**. This repo's own `api.rs` is **135 KB**. So:
- `read_file` **hard-refused** api.rs (`exceeds … -byte limit`) — even a paged request for one region.
- `grep_search` and `repo_map` **silently skipped** it.

Result: Claudette, doing Task 5 (which edits api.rs), searched for `build_chat_body_default_stays_ollama_shape` — a test that is *definitely present* (raw `grep` finds it ×1, `build_chat_body` ×8) — got zero hits from every tool, and concluded *"the code drifted / was deleted."* It hadn't. Her tools just couldn't see a 135 KB file. (`apply_diff`/`edit_file` have no cap, so she could *edit* it — she just couldn't *find* the line.)

## Fix

- **Raise `MAX_FILE_BYTES` 100 KB → 1 MB** (`tools.rs`). Covers hand-written source (135 KB api.rs now reads/greps/maps fine); still excludes pathological minified/generated/data blobs. `read_file`, `grep_search`, `repo_map`, `write_file` all share it.
- **De-silence `grep_search` skips** (`search.rs`): files still over the cap are counted and surfaced as `skipped_oversize` + a `note` pointing to `read_file`, so a "no match" is never silently incomplete again — that silent skip is what produced the confidently-wrong "it's gone."

`repo_map`'s own skip-notice is intentionally **deferred** so this PR doesn't touch `repomap.rs` and collide with #62 (the cap raise alone re-enables repo_map on large files).

## Tests

New `grep_search_searches_large_files_and_flags_oversized`: a 200 KB file (over the old cap, under the new) is now searched; a 1.1 MB file is skipped but reported via `skipped_oversize` + the note. Full lib suite green (1102 passed); clippy `--all-targets` clean.

## Why only api.rs is affected today

Checked every queued task file: only `api.rs` (135 KB) exceeded 100 KB; shell.rs/search.rs/repomap.rs/etc. are all 28–40 KB. So this unblocks Task 5 specifically and prevents the failure recurring as files grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)