### PR TITLE
fix(tests): pin openai_compat in default chat-body test

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -2729,7 +2729,9 @@ mod tests {
 
     #[test]
     fn build_chat_body_default_stays_ollama_shape() {
-        let client = OllamaApiClient::new("qwen3.5:4b", json!([]));
+        // Pin compat off — ambient CLAUDETTE_OPENAI_COMPAT must not flip the
+        // ollama body shape this test asserts.
+        let client = OllamaApiClient::new("qwen3.5:4b", json!([])).with_openai_compat(false);
         let req = ApiRequest {
             messages: vec![user_text("hi")].into(),
             system_prompt: vec!["sys".to_string()],


### PR DESCRIPTION
Pins openai_compat(false) on the Ollama client in \uild_chat_body_default_stays_ollama_shape\ so ambient \CLAUDETTE_OPENAI_COMPAT\ (e.g. from ~/.claudette/.env) doesn't flip it to an OpenAI-shaped body and cause a false failure.\n\nOne commit, one file changed.