### PR TITLE
docs(bash): Windows shell guidance in tool description

### DIFF
--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -71,7 +71,7 @@ pub(super) fn schemas() -> Vec<Value> {
             "type": "function",
             "function": {
                 "name": "bash",
-                "description": "Run a shell command (asks for confirmation). PowerShell on Windows (use ; not &&, $env:VAR, backslash paths); sh elsewhere.",
+                "description": "Run a shell command (asks for confirmation). PowerShell on Windows (use ; not &&, $env:VAR, backslash paths); sh elsewhere. Prefer `git -C <dir>` / `cargo --manifest-path` over cd-chaining. For anything beyond one command, write_file a script and run that — inline -c/-Command quoting gets mangled.",
                 "parameters": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
## Task 6 — Windows shell guidance in the bash tool description

**What changed:** Updated the ash tool description to include Windows-specific shell best practices:
- Prefer \git -C <dir>\ / \cargo --manifest-path\ over cd-chaining
- For anything beyond one command, write a script file and run that — inline -c/-Command quoting gets mangled

**Why:** Transcript analysis of dogfood sessions showed iterations burned on Windows shell tarpits: \&&\ chaining (PowerShell parse error), \cd X\ chains that fail, and inline -c/-Command one-liners whose nested quoting gets mangled.

**Gate checks passed:**
- \cargo fmt --all\ ✓
- \cargo clippy --all-targets\ ✓
- \cargo test -p claudette --lib shell\ — 17/17 passed ✓