### PR TITLE
feat(cli): single-keypress y to approve danger prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ bumps are non-breaking bugfixes only.
   scripted / CI runs stay clean; opt out with `CLAUDETTE_NO_SPINNER`. The
   TUI, forge, sub-agents, one-shot mode, and tests are unaffected.
 
+- **Single-keypress approval.** The interactive `Allow? [y/N]` danger-gate
+  prompt now accepts a single keypress — `y` approves immediately without
+  Enter; any other key denies. TTY-only: piped / scripted / agent runs keep
+  the line-buffered reader unchanged.
+
 ### Changed
 
 - **`repo_map` map output is a compact outline, and the tool steers to

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -2766,6 +2766,17 @@ impl PermissionPrompter for CliPrompter {
         let _ = write!(err, "  Allow? [y/N] ");
         let _ = err.flush();
 
+        // Interactive terminal: accept a single keypress so `y` allows
+        // without Enter. Falls through to the line reader below when stdin
+        // isn't a TTY (piped / scripted / spawned agent) or raw mode is
+        // unavailable, keeping that path byte-identical to before.
+        use std::io::IsTerminal as _;
+        if io::stdin().is_terminal() {
+            if let Some(decision) = read_single_key(&mut err) {
+                return decision;
+            }
+        }
+
         let stdin = io::stdin();
         let mut buf = String::new();
         match stdin.read_line(&mut buf) {
@@ -2784,6 +2795,48 @@ impl PermissionPrompter for CliPrompter {
             },
         }
     }
+}
+
+/// Single-keypress confirmation for the `[y/N]` danger gate on an
+/// interactive terminal: `y`/`Y` allows immediately (no Enter needed); any
+/// other key — including Ctrl-C/Ctrl-D, `n`, Esc, Enter — denies. Returns
+/// `None` if raw mode can't be enabled, so the caller falls back to the
+/// line reader. Mirrors the TUI prompt's key handling in `tui.rs`.
+fn read_single_key(err: &mut impl io::Write) -> Option<PermissionPromptDecision> {
+    use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+    enable_raw_mode().ok()?;
+    let mut allow = false;
+    loop {
+        match event::read() {
+            // Windows fires Press + Release — act on Press only.
+            Ok(Event::Key(k)) if k.kind == KeyEventKind::Press => {
+                allow = matches!(
+                    (k.code, k.modifiers),
+                    (
+                        KeyCode::Char('y' | 'Y'),
+                        KeyModifiers::NONE | KeyModifiers::SHIFT
+                    )
+                );
+                break; // first key press decides — anything but `y` denies
+            }
+            Ok(_) => {}      // resize / mouse / key-release — keep waiting
+            Err(_) => break, // read error denies
+        }
+    }
+    // ALWAYS restore cooked mode before returning, on every path above.
+    let _ = disable_raw_mode();
+    // Raw mode suppressed the echo — print the resolved choice + newline so
+    // the transcript reads cleanly.
+    let _ = writeln!(err, "{}", if allow { "y" } else { "n" });
+    Some(if allow {
+        PermissionPromptDecision::Allow
+    } else {
+        PermissionPromptDecision::Deny {
+            reason: "user denied permission".to_string(),
+        }
+    })
 }
 
 /// The nudge message appended when the model returns an empty response.


### PR DESCRIPTION
Single-keypress approval for the interactive `Allow? [y/N]` danger gate.

Per `plans/dogfood-2026-06-08/TASK-CLI-SINGLEKEY-FIX.md`: on an interactive
TTY, pressing `y` now approves immediately with no Enter; any other key
denies. Non-TTY (piped / scripted / spawned-agent) runs fall through to the
unchanged line-buffered `read_line`, so nothing automated changes.

- `CliPrompter::decide` tries a single keypress first via the new
  `read_single_key` helper, gated on `io::stdin().is_terminal()`.
- The helper always restores cooked mode (`disable_raw_mode` on every exit
  path), mirrors the TUI prompt key handling, and acts on Press only for the
  Windows Press+Release pair.

Gate: fmt / clippy --all-targets clean / `cargo test -p claudette --lib`
green (1103 passed). No new unit test by design — the keypress path needs a
real TTY; David verifies live after merge.

Authored by Claudette; CHANGELOG indentation fixed in Claude Code review.
