### PR TITLE
feat(repo_map): C# definitions in mode=map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ bumps are non-breaking bugfixes only.
   Enter; any other key denies. TTY-only: piped / scripted / agent runs keep
   the line-buffered reader unchanged.
 
+- **`repo_map` maps C# definitions.** `mode=map` now extracts C# `class`,
+  `interface`, `enum`, `struct`, and method definitions — previously `.cs`
+  files were scanned only in `mode=refs`. The schema's language list now
+  includes C#.
+
 ### Changed
 
 - **`repo_map` map output is a compact outline, and the tool steers to

--- a/crates/claudette/src/tools/repomap.rs
+++ b/crates/claudette/src/tools/repomap.rs
@@ -62,7 +62,7 @@ pub(super) fn schemas() -> Vec<Value> {
         "type": "function",
         "function": {
             "name": "repo_map",
-            "description": "Find where code lives by concept — for INITIAL orientation when you don't already know the location. Returns a compact outline of the workspace files whose top-level definitions best match `query`, each line as `<line>  <signature>`. Orientation only: if you already know the exact symbol or string, use grep_search; to find a file by name, use glob_search; to re-read a known file, use read_file. One pass is enough — do NOT call repo_map repeatedly. (Languages: Rust, Python, JS/TS, Go, Ruby.) To list every place a name appears (or pin the real source value past stale docs), call with mode='refs' and name='<exact text>'.",
+            "description": "Find where code lives by concept — for INITIAL orientation when you don't already know the location. Returns a compact outline of the workspace files whose top-level definitions best match `query`, each line as `<line>  <signature>`. Orientation only: if you already know the exact symbol or string, use grep_search; to find a file by name, use glob_search; to re-read a known file, use read_file. One pass is enough — do NOT call repo_map repeatedly. (Languages: Rust, Python, JS/TS, Go, Ruby, C#.) To list every place a name appears (or pin the real source value past stale docs), call with mode='refs' and name='<exact text>'.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -524,6 +524,28 @@ fn patterns_for(path: &Path) -> Option<Vec<(&'static str, Regex)>> {
             ("class", r"^\s*class\s+([A-Za-z_][\w:]*)"),
             ("module", r"^\s*module\s+([A-Za-z_][\w:]*)"),
         ],
+        "cs" => vec![
+            (
+                "class",
+                r"^\s*(?:(?:public|private|protected|internal|static|sealed|abstract|partial)\s+)*class\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "interface",
+                r"^\s*(?:(?:public|private|protected|internal|partial)\s+)*interface\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "enum",
+                r"^\s*(?:(?:public|private|protected|internal)\s+)*enum\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "struct",
+                r"^\s*(?:(?:public|private|protected|internal|readonly|partial)\s+)*struct\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "method",
+                r"^\s*(?:(?:public|private|protected|internal|static|async|virtual|override|sealed|abstract|extern|new|partial|unsafe)\s+)+[\w<>\[\],.?]+\s+([A-Za-z_]\w*)\s*\(",
+            ),
+        ],
         _ => return None,
     };
     Some(
@@ -644,6 +666,85 @@ mod tests {
             "def say_hello",
         ] {
             assert!(out.contains(sig), "expected `{sig}` in the outline:\n{out}");
+        }
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn csharp_patterns_capture_class_interface_enum_and_method() {
+        let pats = patterns_for(Path::new("x.cs")).unwrap();
+        let hit = |line: &str| {
+            pats.iter()
+                .find_map(|(k, re)| re.captures(line).map(|c| (*k, c[1].to_string())))
+        };
+
+        assert_eq!(
+            hit("    public class Foo"),
+            Some(("class", "Foo".to_string()))
+        );
+        assert_eq!(
+            hit("public interface IBar"),
+            Some(("interface", "IBar".to_string()))
+        );
+        assert_eq!(
+            hit("    internal enum Color"),
+            Some(("enum", "Color".to_string()))
+        );
+        assert_eq!(
+            hit("public struct Point"),
+            Some(("struct", "Point".to_string()))
+        );
+        // method = modifier(s) + return type + name + '('
+        assert_eq!(
+            hit("    public void Baz()"),
+            Some(("method", "Baz".to_string()))
+        );
+        assert_eq!(
+            hit("    private static int Add(int a, int b)"),
+            Some(("method", "Add".to_string()))
+        );
+        assert_eq!(
+            hit("    public async Task<int> GetAsync()"),
+            Some(("method", "GetAsync".to_string()))
+        );
+        // control flow must NOT be captured as a method (no keyword swallow)
+        assert_eq!(hit("    if (ready)"), None);
+        assert_eq!(hit("    return Add(1, 2);"), None);
+    }
+
+    #[test]
+    fn repo_map_csharp_definitions_extracted_in_map_mode() {
+        let _eg = crate::test_env_lock();
+        let base = super::super::user_home()
+            .join(".claudette")
+            .join("files")
+            .join("claudette-repomap-test-csharp");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("src")).unwrap();
+        let cs_content = "namespace App\n{\n    public interface IGreeter\n    {\n        string Greet(string name);\n    }\n\n    public class Greeter : IGreeter\n    {\n        private readonly string _prefix;\n\n        public Greeter(string prefix)\n        {\n            _prefix = prefix;\n        }\n\n        public string Greet(string name)\n        {\n            return _prefix + name;\n        }\n\n        public static int Add(int a, int b)\n        {\n            return a + b;\n        }\n    }\n\n    public enum Mood\n    {\n        Happy,\n        Sad,\n    }\n}\n";
+        std::fs::write(base.join("src").join("Greeter.cs"), cs_content).unwrap();
+
+        let input = json!({
+            "query": "greeter class interface method add enum",
+            "path": base.to_str().unwrap()
+        })
+        .to_string();
+        let out = run_repo_map(&input).unwrap().replace('\\', "/");
+
+        assert!(
+            out.contains("src/Greeter.cs"),
+            "Greeter.cs should be found:\n{out}"
+        );
+        // Each sig appears in the outline (kind keyword + name come from the line).
+        for sig in [
+            "public interface IGreeter",
+            "public class Greeter",
+            "public string Greet",
+            "public static int Add",
+            "public enum Mood",
+        ] {
+            assert!(out.contains(sig), "missing `{sig}` in:\n{out}");
         }
 
         let _ = std::fs::remove_dir_all(&base);


### PR DESCRIPTION
Adds C# definition extraction to `repo_map` `mode=map`.

`cs` was already in `SOURCE_EXTENSIONS` (so `.cs` files were scanned in
`mode=refs`) but had no definition patterns, so `mode=map` found nothing in
them. This adds a `"cs"` arm to `patterns_for` capturing `class`, `interface`,
`enum`, `struct`, and method definitions, and lists C# in the schema
description.

**Method-pattern design:** C# methods have no leading keyword (unlike
`fn`/`def`/`func`), so a naive regex would swallow control flow (`if (...)`,
`return Add(...)`). The `regex` crate has no lookahead, so the guard is
*requiring at least one access/method modifier* before the return type — control
flow has none and can't match. Deliberate trade-off: a bare `void Baz()` (no
modifier) is not captured; under-capturing beats swallowing `if (`.

**Tests:** a unit test asserting each pattern (incl. control-flow lines
returning `None`) and an end-to-end `mode=map` extraction test on a sample
`.cs` file.

Gate: fmt / clippy (`--all-targets`) clean; `cargo test -p claudette --lib`
green (1105 passed, 12/12 repomap incl. both new C# tests). `SOURCE_EXTENSIONS`
untouched; omitted-language behavior unchanged.
