### PR TITLE
chore(grep_search): align count_only schema indentation

### DIFF
--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -70,11 +70,11 @@ pub(super) fn schemas() -> Vec<Value> {
                     "type": "object",
                     "properties": {
                         "pattern": { "type": "string", "description": "Regex to search for (e.g. 'TODO|FIXME', 'fn\\s+\\w+'). Invalid regex falls back to literal substring." },
-                            "path":    { "type": "string", "description": "Directory to search (default: the workspace/project root)" },
-                            "glob":    { "type": "string", "description": "Optional filename glob to restrict the search (e.g. '*.rs', 'src/**/*.ts'). A bare name matches files at any depth; a pattern with '/' matches the path relative to the search root. When omitted, all files are searched." },
-                            "count_only": { "type": "boolean", "description": "When true, return only the total match count and a per-file breakdown — no line bodies, and not capped at 100. Use to gauge how widespread a pattern is. Default false." }
-                        },
-                        "required": ["pattern"]
+                        "path":    { "type": "string", "description": "Directory to search (default: the workspace/project root)" },
+                        "glob":    { "type": "string", "description": "Optional filename glob to restrict the search (e.g. '*.rs', 'src/**/*.ts'). A bare name matches files at any depth; a pattern with '/' matches the path relative to the search root. When omitted, all files are searched." },
+                        "count_only": { "type": "boolean", "description": "When true, return only the total match count and a per-file breakdown — no line bodies, and not capped at 100. Use to gauge how widespread a pattern is. Default false." }
+                    },
+                    "required": ["pattern"]
                 }
             }
         }),


### PR DESCRIPTION
Cosmetic only. The `count_only` schema properties (PR #71) landed over-indented inside the `json!` macro — rustfmt does not reformat macro internals, so it passed CI but was visually inconsistent with every other schema in the file.

Re-aligns `path`/`glob`/`count_only` to their sibling properties (24 spaces) and the closing `},`/`required` to their parent (20 spaces). No behavior change; all tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)