### PR TITLE
fix(edit): no-op guard + loop-breaker for repeat block edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **No-op edits fail loudly instead of reporting false success.** `apply_diff`
+  and `edit_file` now return an error when the requested change would produce
+  byte-identical file content (most often `before`/`old_text` equal to
+  `after`/`new_text`) instead of writing nothing and reporting `ok:true` — a
+  false success that spiralled small models into re-sending the same edit (the
+  tool-result display collapses `\\`->`\`, hiding an over-escaped block).
+- **The loop-breaker suppresses an exact-repeat block edit.** An identical
+  `apply_diff`/`edit_file`/`apply_patch` call re-issued within a turn is no
+  longer re-executed — it returns a "you already tried this; re-read and change
+  tactic" result. Previously only read-only navigation calls were deduped, so a
+  failed or no-op edit could be retried byte-identical until the turn died.
+
 ## [0.11.0] - 2026-06-14
 
 ### Added

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -333,6 +333,12 @@ where
         // an answer; past SEARCH_NUDGE_AT we append a "stop and answer" hint to
         // its search results (see the Allow arm below).
         let mut consecutive_nav = 0usize;
+        // Loop-breaker (block edits): exact (name, args) of block-edit calls
+        // already attempted this turn. An identical retry is always a spiral
+        // (see is_block_edit_tool), so it is suppressed with a pointer to
+        // re-read and change tactic. Kept separate from seen_nav: edits are not
+        // navigation, and a suppressed edit must not perturb the nav dedup.
+        let mut seen_edits: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut hit_iteration_cap = false;
 
         loop {
@@ -419,6 +425,24 @@ where
                     self.session.messages.push(result_message.clone());
                     tool_results.push(result_message);
                     continue;
+                }
+
+                // Loop-breaker (block edits): suppress an exact repeat of a
+                // block edit (apply_diff/edit_file/apply_patch). The first
+                // attempt runs; a byte-identical repeat this turn cannot help
+                // (it failed before, or already applied), so return a "change
+                // tactic" tool_result instead of re-executing. Before the nav
+                // block so the suppressed edit leaves seen_nav untouched.
+                if is_block_edit_tool(&tool_name) {
+                    let key = format!("{tool_name}\u{1f}{input}");
+                    if !seen_edits.insert(key) {
+                        let body = duplicate_edit_body(&tool_name);
+                        let result_message =
+                            ConversationMessage::tool_result(tool_use_id, tool_name, body, true);
+                        self.session.messages.push(result_message.clone());
+                        tool_results.push(result_message);
+                        continue;
+                    }
                 }
 
                 // Loop-breaker: suppress an exact repeat of a read-only
@@ -744,6 +768,31 @@ fn duplicate_call_body(tool_name: &str) -> String {
          above. Re-reading it changes nothing. Either answer now from what you have, or take a \
          DIFFERENT action: grep_search for the specific symbol, or read_file with an offset/limit \
          to page to a new region.\"}}"
+    )
+}
+
+/// Block-edit tools whose *exact repeat* within a turn is a spiral, never
+/// useful work. Unlike a re-read (handled by [`is_navigation_tool`]), an
+/// identical block edit re-issued in the same turn can only do one of two
+/// things: the first attempt failed, so a byte-identical retry fails the same
+/// way (the dogfood 2026-06-13 doubled-backslash no-op loop); or the first
+/// succeeded, so the target block is gone and the retry can't match. Either
+/// way it changes nothing. `write_file` is excluded — a whole-file overwrite
+/// is idempotent, not a find-and-replace, and isn't part of the spiral.
+fn is_block_edit_tool(name: &str) -> bool {
+    matches!(name, "apply_diff" | "edit_file" | "apply_patch")
+}
+
+/// Tool result for a block-edit call that exactly repeats one already
+/// attempted this turn. Pushes the brain off the retry spiral toward
+/// re-reading the file and changing tactic.
+fn duplicate_edit_body(tool_name: &str) -> String {
+    format!(
+        "{{\"error\":\"duplicate edit suppressed\",\"tool\":\"{tool_name}\",\"hint\":\"You \
+         already attempted this EXACT edit earlier in this turn. A byte-identical retry \
+         changes nothing — the first attempt either failed (it will fail the same way) or \
+         already applied (the target is gone). Re-read the file with read_file to see its \
+         CURRENT contents, then send a DIFFERENT edit that matches what is actually there.\"}}"
     )
 }
 
@@ -1222,6 +1271,107 @@ mod tests {
             })
             .expect("a suppressed duplicate tool_result should exist");
         assert!(dup.contains("duplicate call suppressed"), "got: {dup}");
+    }
+
+    #[test]
+    fn duplicate_block_edit_call_is_suppressed_not_re_executed() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        // The brain re-issues the IDENTICAL apply_diff twice (the dogfood
+        // 2026-06-13 no-op spiral), then answers. The loop must execute it
+        // once, suppress the exact repeat with a "duplicate edit" tool_result,
+        // and still finish.
+        struct EditSpiralApi {
+            calls: usize,
+        }
+        impl ApiClient for EditSpiralApi {
+            fn stream(
+                &mut self,
+                _request: &ApiRequest<'_>,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.calls += 1;
+                match self.calls {
+                    1 | 2 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("ad-{}", self.calls),
+                            name: "apply_diff".to_string(),
+                            input: "{\"path\":\"x.rs\",\"before\":\"a\",\"after\":\"b\"}"
+                                .to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                }
+            }
+        }
+
+        let exec_count = Rc::new(Cell::new(0usize));
+        let ec = Rc::clone(&exec_count);
+        let tool_executor = StaticToolExecutor::new().register("apply_diff", move |_input| {
+            ec.set(ec.get() + 1);
+            Ok("{\"ok\":true}".to_string())
+        });
+        let permission_policy = PermissionPolicy::new(PermissionMode::WorkspaceWrite)
+            .with_tool_requirement("apply_diff", PermissionMode::WorkspaceWrite);
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            EditSpiralApi { calls: 0 },
+            tool_executor,
+            permission_policy,
+            vec!["sys".to_string()],
+        );
+
+        let summary = runtime
+            .run_turn("fix the regex", None)
+            .expect("loop should finish");
+
+        assert_eq!(
+            exec_count.get(),
+            1,
+            "apply_diff must execute once; the identical repeat is suppressed"
+        );
+        assert_eq!(summary.iterations, 3);
+        let dup = runtime
+            .session()
+            .messages
+            .iter()
+            .find_map(|m| {
+                m.blocks.iter().find_map(|b| match b {
+                    ContentBlock::ToolResult {
+                        output, is_error, ..
+                    } if *is_error => Some(output.clone()),
+                    _ => None,
+                })
+            })
+            .expect("a suppressed duplicate tool_result should exist");
+        assert!(dup.contains("duplicate edit suppressed"), "got: {dup}");
+    }
+
+    #[test]
+    fn block_edit_tool_classifier_matches_edits_only() {
+        for edit in ["apply_diff", "edit_file", "apply_patch"] {
+            assert!(
+                super::is_block_edit_tool(edit),
+                "{edit} should be a block edit"
+            );
+        }
+        for other in [
+            "read_file",
+            "grep_search",
+            "bash",
+            "write_file",
+            "git_commit",
+        ] {
+            assert!(
+                !super::is_block_edit_tool(other),
+                "{other} must NOT be a block edit"
+            );
+        }
     }
 
     #[test]

--- a/crates/claudette/src/tools/fuzzy_apply.rs
+++ b/crates/claudette/src/tools/fuzzy_apply.rs
@@ -84,6 +84,27 @@ fn run_apply_diff(input: &str) -> Result<String, String> {
 
     match fuzzy_replace(&original, before, after) {
         Ok(new_content) => {
+            // No-op guard (dogfood 2026-06-13): a before/after that produce
+            // byte-identical content changed nothing. Reporting ok:true here is
+            // a false success that spirals small brains — they "fixed" the file,
+            // see success, but nothing moved, so they re-send the same edit. The
+            // display layer collapses `\\`->`\`, so an over-escaped block looks
+            // identical to the model and it cannot see why. Fail loudly instead.
+            if new_content == original {
+                let msg = format!(
+                    "apply_diff: no change — 'before' and 'after' produce identical \
+                     content in {raw_path}, so nothing was written. Re-read the file \
+                     to see its CURRENT bytes: what you intend to change may already \
+                     be present, or your two blocks are the same. Do NOT re-send this \
+                     edit unchanged."
+                );
+                eprintln!(
+                    "  {} {}",
+                    crate::theme::dim("▸"),
+                    crate::theme::dim(&format!("apply_diff: {raw_path} no-op")),
+                );
+                return Err(msg);
+            }
             // Atomic write via sibling tmp + rename, matching apply_patch.
             let tmp = path.with_extension("claudette-diff.tmp");
             fs::write(&tmp, &new_content)
@@ -602,5 +623,36 @@ mod tests {
         let err = result.expect_err("expected not-found error");
         assert!(err.contains("'before' block not found"), "got: {err}");
         assert!(err.contains("over-escapes backslashes"), "got: {err}");
+    }
+
+    #[test]
+    fn identical_before_after_is_a_loud_no_op() {
+        // The dogfood 2026-06-13 spiral: before == after (the model could not
+        // see its own doubled backslash). The edit must FAIL with a no-op error,
+        // not report ok:true after writing nothing.
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".into());
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let path = format!("{home}/claudette-diff-noop-{nanos}.txt");
+        let original = "fn main() {\n    let x = 1;\n}\n";
+        fs::write(&path, original).unwrap();
+
+        let input = json!({
+            "path": &path,
+            "before": "    let x = 1;\n",
+            "after": "    let x = 1;\n"
+        })
+        .to_string();
+        let result = run_apply_diff(&input);
+        // The file must be untouched.
+        let after_disk = fs::read_to_string(&path).unwrap();
+        let _ = fs::remove_file(&path);
+
+        let err = result.expect_err("identical before/after must be a no-op error");
+        assert!(err.contains("no change"), "got: {err}");
+        assert_eq!(after_disk, original, "file must not be modified by a no-op");
     }
 }

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -404,6 +404,20 @@ fn run_edit_file(input: &str) -> Result<String, String> {
 
     let new_content = content.replacen(old_text, new_text, 1);
 
+    // No-op guard (dogfood 2026-06-13): old_text == new_text writes the file
+    // unchanged but reports ok:true — a false success that spirals small brains
+    // into re-sending the same edit (the display layer hides over-escaped
+    // backslashes, so they cannot see the blocks are identical). Fail loudly.
+    if new_content == content {
+        return Err(format!(
+            "edit_file: no change — 'old_text' and 'new_text' are identical, so \
+             nothing was written to {}. Re-read the file to see its CURRENT \
+             contents: what you intend to change may already be present. Do NOT \
+             re-send this edit unchanged.",
+            path.display()
+        ));
+    }
+
     // Atomic write: serialise to a sibling tmp file, preserve the original
     // file's permissions, then rename. A mid-write crash leaves either the
     // original file intact or the tmp behind for manual recovery — never a
@@ -864,6 +878,24 @@ mod tests {
         let err = result.expect_err("expected not-found error");
         assert!(err.contains("not found"), "got: {err}");
         assert_eq!(after.as_deref(), Some(original));
+    }
+
+    #[test]
+    fn edit_file_identical_old_new_is_a_loud_no_op() {
+        // Dogfood 2026-06-13: old_text == new_text writes nothing but reported
+        // ok:true. It must now FAIL with a no-op error and leave the file alone.
+        let path = home_join("noop");
+        let original = "alpha\nbeta\ngamma\n";
+        fs::write(&path, original).unwrap();
+
+        let input = json!({"path": &path, "old_text": "beta\n", "new_text": "beta\n"}).to_string();
+        let result = run_edit_file(&input);
+        let after_disk = fs::read_to_string(&path).unwrap();
+        let _ = fs::remove_file(&path);
+
+        let err = result.expect_err("identical old/new must be a no-op error");
+        assert!(err.contains("no change"), "got: {err}");
+        assert_eq!(after_disk, original, "file must not be modified by a no-op");
     }
 
     #[test]


### PR DESCRIPTION
Closes the dogfood 2026-06-13 (Task 11) no-op edit spiral, in two layers. Implements `plans/dogfood-2026-06-08/TASK12A-NOOP-GUARD.md` + `TASK12B-LOOP-BREAKER.md` directly (no co-dev this round).

## The bug
An `apply_diff` wrote a doubled-backslash regex (`r"^\s*…"`), tests failed, and the model re-sent a **byte-identical** edit ~6 times. Each identical edit reported `ok:true` and wrote nothing — the tool-result display collapses `\`→`\`, so the over-escaping was invisible to the model. It kept "succeeding" while changing nothing, burning the turn and bloating context until prompt-processing stalled.

## Fix
**12A — no-op edits fail loudly** (`fuzzy_apply.rs`, `shell.rs`):
`apply_diff` and `edit_file` now return an error when `before`/`after` (or `old_text`/`new_text`) produce byte-identical content, instead of a silent false success.

**12B — loop-breaker dedups block edits** (`runtime/conversation.rs`):
A new `is_block_edit_tool` set (`apply_diff`/`edit_file`/`apply_patch`) is deduped per turn; an exact repeat is suppressed with a "re-read and change tactic" result. Previously only read-only navigation was deduped, and a mutating tool *cleared* that set — so an identical failing/no-op edit was never caught. `write_file` is excluded (a whole-file overwrite is idempotent, not part of the spiral). No reset of `seen_edits` (a genuine re-edit sends different bytes → different key).

Together: the spiral is caught at attempt 1 (loud no-op) and attempt 2 (suppressed repeat).

## Tests
- `identical_before_after_is_a_loud_no_op` (apply_diff)
- `edit_file_identical_old_new_is_a_loud_no_op` (edit_file)
- `duplicate_block_edit_call_is_suppressed_not_re_executed` + `block_edit_tool_classifier_matches_edits_only` (loop-breaker)

## Gate
`cargo fmt` clean · `cargo clippy --all-targets -D warnings` clean · `cargo test -p claudette --lib` → **1120 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)