### PR TITLE
feat(cli): colored unified-diff preview on the edit permission gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Added
+
+- **Colored diff preview on the `[y/N]` edit gate.** When `apply_diff`,
+  `edit_file`, or `apply_patch` ask for approval, the prompt now shows a
+  unified-diff-style preview — a file header, red removals, green additions, and
+  dim context around the change, with real newlines — instead of dumping the raw
+  escaped-JSON payload (`{"before":"…\n…","after":"…"}`) on one line. The full
+  content is still shown (nothing truncated), and color is dropped on non-TTY /
+  piped output.
+
 ### Fixed
 
 - **No-op edits fail loudly instead of reporting false success.** `apply_diff`

--- a/crates/claudette/src/diff_preview.rs
+++ b/crates/claudette/src/diff_preview.rs
@@ -1,0 +1,186 @@
+//! Human-readable, colored previews of edit-tool inputs for the danger gate.
+//!
+//! The `[y/N]` permission prompt used to dump an edit tool's raw JSON payload
+//! (`{"path":"…","before":"…\n…","after":"…"}`) on one line, with the `\n` and
+//! `\\` escaped — a wall of text that's effectively unreviewable. This turns the
+//! payload of `apply_diff` / `edit_file` / `apply_patch` into a unified-diff
+//! style block instead: a file header, red removals (`-`), green additions
+//! (`+`), and a little dim context around the changed lines, with real newlines.
+//!
+//! Color is handled by the global `colored` override (see [`crate::theme::init`]),
+//! so piped / non-TTY output renders as plain text. Nothing is truncated — the
+//! full before/after (or full diff) is shown, preserving the property the raw
+//! line-dump had: an adversarial payload can't hide content past a preview edge.
+
+use serde_json::Value;
+
+use crate::theme;
+
+/// Build a colored, unified-diff-style preview of an edit tool's `input`, or
+/// `None` when `tool_name` is not an edit tool or the input doesn't parse (the
+/// caller falls back to the raw line dump). Returned lines are colored but NOT
+/// indented — the caller adds its own leading whitespace.
+#[must_use]
+pub fn render(tool_name: &str, input: &str) -> Option<Vec<String>> {
+    match tool_name {
+        "apply_diff" => render_replacement(input, "before", "after"),
+        "edit_file" => render_replacement(input, "old_text", "new_text"),
+        "apply_patch" => render_unified(input),
+        _ => None,
+    }
+}
+
+/// Render a find-and-replace edit (apply_diff / edit_file) as a single hunk:
+/// the common leading/trailing lines become dim context, the differing middle
+/// shows as `-` (old) then `+` (new).
+fn render_replacement(input: &str, old_key: &str, new_key: &str) -> Option<Vec<String>> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let path = v.get("path").and_then(Value::as_str)?;
+    let old = v.get(old_key).and_then(Value::as_str)?;
+    let new = v.get(new_key).and_then(Value::as_str)?;
+
+    let old_lines: Vec<&str> = old.split('\n').collect();
+    let new_lines: Vec<&str> = new.split('\n').collect();
+
+    // Trim common leading/trailing lines so only the changed middle is marked,
+    // surrounded by a little dim context — a clean single hunk.
+    let prefix = common_prefix_len(&old_lines, &new_lines);
+    let max_suffix = (old_lines.len() - prefix).min(new_lines.len() - prefix);
+    let suffix = common_suffix_len(&old_lines[prefix..], &new_lines[prefix..]).min(max_suffix);
+
+    let mut out = Vec::new();
+    out.push(theme::accent(path).to_string());
+
+    for line in &old_lines[..prefix] {
+        out.push(theme::dim(&format!("  {line}")).to_string());
+    }
+    for line in &old_lines[prefix..old_lines.len() - suffix] {
+        out.push(theme::diff_del(&format!("- {line}")).to_string());
+    }
+    for line in &new_lines[prefix..new_lines.len() - suffix] {
+        out.push(theme::diff_add(&format!("+ {line}")).to_string());
+    }
+    for line in &old_lines[old_lines.len() - suffix..] {
+        out.push(theme::dim(&format!("  {line}")).to_string());
+    }
+    Some(out)
+}
+
+/// Render an apply_patch unified diff with per-line coloring: file headers and
+/// `@@` hunk markers stand out, `+`/`-` lines are green/red, context is dim.
+fn render_unified(input: &str) -> Option<Vec<String>> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let diff = v.get("diff").and_then(Value::as_str)?;
+
+    let mut out = Vec::new();
+    if v.get("dry_run").and_then(Value::as_bool) == Some(true) {
+        out.push(theme::dim("(dry run — validate only)").to_string());
+    }
+    for line in diff.split('\n') {
+        let colored = if line.starts_with("+++")
+            || line.starts_with("---")
+            || line.starts_with("diff ")
+            || line.starts_with("index ")
+        {
+            theme::accent(line).to_string()
+        } else if line.starts_with("@@") {
+            theme::info(line).to_string()
+        } else if line.starts_with('+') {
+            theme::diff_add(line).to_string()
+        } else if line.starts_with('-') {
+            theme::diff_del(line).to_string()
+        } else {
+            theme::dim(line).to_string()
+        };
+        out.push(colored);
+    }
+    Some(out)
+}
+
+fn common_prefix_len(a: &[&str], b: &[&str]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+fn common_suffix_len(a: &[&str], b: &[&str]) -> usize {
+    a.iter()
+        .rev()
+        .zip(b.iter().rev())
+        .take_while(|(x, y)| x == y)
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point: a `+`/`-` line for the change, full content shown.
+    #[test]
+    fn apply_diff_renders_a_hunk() {
+        let input = r#"{"path":"src/lib.rs","before":"let x = 1;\n","after":"let x = 2;\n"}"#;
+        let out = render("apply_diff", input).expect("apply_diff should render");
+        let joined = out.join("\n");
+        assert!(joined.contains("src/lib.rs"), "header missing: {joined}");
+        assert!(joined.contains("- let x = 1;"), "removal missing: {joined}");
+        assert!(
+            joined.contains("+ let x = 2;"),
+            "addition missing: {joined}"
+        );
+    }
+
+    /// Common leading/trailing lines become context, not noise: only the
+    /// changed middle is marked `-`/`+`.
+    #[test]
+    fn common_lines_become_context_not_markers() {
+        let input = r#"{"path":"f","before":"a\nb\nc","after":"a\nB\nc"}"#;
+        let out = render("apply_diff", input).expect("should render");
+        let joined = out.join("\n");
+        assert!(joined.contains("- b"), "changed old line missing: {joined}");
+        assert!(joined.contains("+ B"), "changed new line missing: {joined}");
+        // 'a' and 'c' are unchanged context — never marked - or +.
+        assert!(
+            !joined.contains("- a") && !joined.contains("+ a"),
+            "{joined}"
+        );
+        assert!(
+            !joined.contains("- c") && !joined.contains("+ c"),
+            "{joined}"
+        );
+    }
+
+    #[test]
+    fn edit_file_uses_old_new_text_keys() {
+        let input = r#"{"path":"f","old_text":"foo","new_text":"bar"}"#;
+        let out = render("edit_file", input).expect("edit_file should render");
+        let joined = out.join("\n");
+        assert!(joined.contains("- foo"), "{joined}");
+        assert!(joined.contains("+ bar"), "{joined}");
+    }
+
+    #[test]
+    fn apply_patch_colors_unified_diff() {
+        let input = r#"{"diff":"--- a/f\n+++ b/f\n@@ -1 +1 @@\n-old\n+new\n"}"#;
+        let out = render("apply_patch", input).expect("apply_patch should render");
+        let joined = out.join("\n");
+        assert!(
+            joined.contains("@@ -1 +1 @@"),
+            "hunk header missing: {joined}"
+        );
+        assert!(
+            joined.contains("-old") && joined.contains("+new"),
+            "{joined}"
+        );
+    }
+
+    #[test]
+    fn non_edit_tool_returns_none() {
+        assert!(render("bash", r#"{"command":"ls"}"#).is_none());
+        assert!(render("read_file", r#"{"path":"f"}"#).is_none());
+    }
+
+    #[test]
+    fn unparseable_or_incomplete_input_returns_none() {
+        assert!(render("apply_diff", "not json").is_none());
+        assert!(render("apply_diff", r#"{"path":"f","before":"x"}"#).is_none());
+        assert!(render("apply_patch", r#"{"dry_run":true}"#).is_none());
+    }
+}

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -37,6 +37,7 @@ pub mod briefing;
 pub mod clock;
 pub mod codet;
 pub mod commands;
+pub mod diff_preview;
 pub mod doctor;
 pub mod egress;
 pub mod executor;

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -2742,6 +2742,15 @@ impl PermissionPrompter for CliPrompter {
         // less single-line case correctly — yields the one line.
         if request.input.is_empty() {
             let _ = writeln!(err, "    {}", theme::dim("(empty input)"));
+        } else if let Some(diff_lines) =
+            crate::diff_preview::render(&request.tool_name, &request.input)
+        {
+            // Edit tools (apply_diff / edit_file / apply_patch): show a colored
+            // unified-diff preview instead of the escaped-JSON wall. Full
+            // content, nothing truncated.
+            for line in diff_lines {
+                let _ = writeln!(err, "    {line}");
+            }
         } else {
             for line in request.input.lines() {
                 let _ = writeln!(err, "    {}", theme::dim(line));

--- a/crates/claudette/src/theme.rs
+++ b/crates/claudette/src/theme.rs
@@ -111,6 +111,19 @@ pub fn brand(s: &str) -> ColoredString {
     s.magenta().bold()
 }
 
+/// Green — an added line in a diff preview (the `+` side). Plain (not bold) so
+/// a multi-line hunk stays easy on the eyes.
+#[must_use]
+pub fn diff_add(s: &str) -> ColoredString {
+    s.green()
+}
+
+/// Red — a removed line in a diff preview (the `-` side). Plain (not bold).
+#[must_use]
+pub fn diff_del(s: &str) -> ColoredString {
+    s.red()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,7 +141,9 @@ mod tests {
     /// array to confirm the helpers all share the same signature.
     #[test]
     fn all_helpers_round_trip_text() {
-        let funcs: [fn(&str) -> ColoredString; 7] = [accent, info, warn, error, dim, ok, brand];
+        let funcs: [fn(&str) -> ColoredString; 9] = [
+            accent, info, warn, error, dim, ok, brand, diff_add, diff_del,
+        ];
         for f in funcs {
             let s = f("hello");
             assert!(


### PR DESCRIPTION
**David's ask (2026-06-13):** the `[y/N]` approval prompt dumped an edit tool's raw JSON payload — `{"path":...,"before":"...\n...","after":"..."}` — on one line with escaped `\n`/`\`, a wall of text that's effectively unreviewable. It was very visible in the dogfood transcripts, where every `apply_diff` approval showed it.

## What changed
A new `diff_preview` module renders `apply_diff` / `edit_file` / `apply_patch` as a unified-diff-style block on the permission prompt:

```
  ⚠ apply_diff wants to run (52 chars):
    src/lib.rs
    - let x = 1;
    + let x = 2;
```

- **apply_diff / edit_file** — trims common leading/trailing lines to a tight single hunk (dim context, red `-` removals, green `+` additions).
- **apply_patch** — colorizes the supplied unified diff per-line (`@@` markers, `---`/`+++` headers, `+`/`-` lines).
- **TTY-only color** via the existing global `colored` override (`theme::init`) — piped / non-TTY output stays plain text.
- **Nothing truncated** — the full before/after (or full diff) is shown, preserving the no-hiding security property of the old raw line-dump.
- **Falls back** to the raw line dump for non-edit tools or unparseable input.

New `theme::diff_add` / `theme::diff_del` helpers (green / red, non-bold).

Scope note: the TUI's ratatui-based prompt is unchanged (raw ANSI wouldn't render in ratatui widgets) — that would be a separate follow-up. This targets the CLI/REPL gate, which is the documented pain.

## Gate
- `cargo fmt` clean
- `cargo clippy --all-targets -- -D warnings` (default + `--no-default-features`) clean
- `cargo test -p claudette --lib` → **1096 passed** / `--no-default-features` → **1021 passed** (+6 new `diff_preview` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)