### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-14
+
 ### Added
 
 - **Colored diff preview on the `[y/N]` edit gate.** When `apply_diff`,
@@ -2087,7 +2089,8 @@ Initial public release of Claudette as a standalone repository.
 
 ---
 
-[Unreleased]: https://github.com/mrdushidush/claudette/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/mrdushidush/claudette/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/mrdushidush/claudette/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mrdushidush/claudette/compare/v0.10.0...v0.11.0
 [0.4.0]: https://github.com/mrdushidush/claudette/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/mrdushidush/claudette/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release prep for **v0.12.0** — rolls up the backlog-clean batch since v0.11.0.

- **Added:** colored unified-diff preview on the `[y/N]` edit gate (#79)
- **Fixed:** no-op edits fail loudly + loop-breaker for exact-repeat block edits (#77)
- **Removed:** legacy-audit cuts — typewriter, bench + `experimental` feature, antipatterns, `--cto` flag, `spawn_agent` sub-agents, Sentinel-9 persona (#78, ~2.3k LOC)

**Minor** bump (not patch): the cuts remove public surface (modules, the `--cto` CLI flag, the `spawn_agent` tool) — breaking under the pre-1.0 SemVer policy.

Bumped `crates/claudette/Cargo.toml` → 0.12.0, `cargo update -p claudette` (Cargo.lock), rolled CHANGELOG `[Unreleased]` → `[0.12.0]` + compare links. After merge, tagging `v0.12.0` triggers `release.yml` (crates.io OIDC publish + 5-target binaries + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)