### PR TITLE
fix(runtime): safer mid-task compaction (preserve 12 + verify-before-done note)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ bumps are non-breaking bugfixes only.
   full prompt re-prefill that made every turn slow once the window filled.
   `CLAUDETTE_COMPACT_THRESHOLD` still overrides it exactly.
 
+- **Safer mid-task compaction.** Auto-compaction now preserves 12 recent
+  messages (was 4) and the post-compaction continuation message tells the model
+  to re-verify state with a tool before reporting a step done — so a small brain
+  doesn't lose track of an in-progress action across a compact and confabulate
+  completion (e.g. claiming a PR is open that was never created).
+
 ## [0.13.1] - 2026-06-17
 
 ### Changed

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -119,14 +119,16 @@ pub fn soft_compact_threshold() -> Option<usize> {
         .filter(|n| *n > 0)
 }
 
-/// Recent-message preservation count for the hard (1M default) compaction
-/// path. Aggressive — keeps just enough context for the model to continue
-/// the immediate conversation.
-const HARD_COMPACT_PRESERVE: usize = 4;
+/// Recent-message preservation count for the hard compaction path. Since the
+/// threshold became adaptive (`num_ctx / 2`, PR #92) this is the EVERYDAY
+/// trigger, not a 1M last resort — so keep enough recent turns that a small
+/// brain doesn't lose track of an in-progress action ("have I pushed / opened
+/// the PR yet?") and confabulate completion from the lossy summary.
+const HARD_COMPACT_PRESERVE: usize = 12;
 
-/// Recent-message preservation count for the soft (env-var-gated) path.
-/// Three times the hard count: the user opted into early compaction, so
-/// trade summary aggressiveness for continuity.
+/// Recent-message preservation count for the soft (env-var-gated) path. Same
+/// count as the hard path now — the soft tier's job is to compact EARLIER (a
+/// lower threshold the user opts into), not to preserve more.
 const SOFT_COMPACT_PRESERVE: usize = 12;
 
 /// Which compaction tier fired in a given pass. Carried back out of
@@ -3143,10 +3145,10 @@ mod tests {
         std::env::set_var("CLAUDETTE_COMPACT_THRESHOLD", "10");
 
         // Build a session with enough messages to hit the
-        // CompactionConfig::preserve_recent_messages = 4 floor; we need
-        // strictly more than 4 messages or compact_session is a no-op.
+        // CompactionConfig::preserve_recent_messages = 12 floor; we need
+        // strictly more than 12 messages or compact_session is a no-op.
         let mut session = Session::default();
-        for i in 0..8 {
+        for i in 0..16 {
             session.messages.push(ConversationMessage {
                 role: MessageRole::User,
                 blocks: vec![ContentBlock::Text {

--- a/crates/claudette/src/runtime/compact.rs
+++ b/crates/claudette/src/runtime/compact.rs
@@ -64,6 +64,8 @@ pub fn get_compact_continuation_message(
         base.push_str("\n\nRecent messages are preserved verbatim.");
     }
 
+    base.push_str("\n\nThe summary above is lossy and may omit the RESULT of an action that was still in progress. Do NOT assume any step (a file edit, a commit, a push, opening a PR, a test run) finished just because it appears above — re-check the current state with a tool before reporting that step as done.");
+
     if suppress_follow_up_questions {
         base.push_str("\nContinue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, and do not preface with continuation text.");
     }
@@ -508,8 +510,8 @@ fn collapse_blank_lines(content: &str) -> String {
 mod tests {
     use super::{
         collect_key_files, compact_session, estimate_image_tokens, estimate_session_tokens,
-        evict_older_image_bytes, format_compact_summary, infer_pending_work, should_compact,
-        CompactionConfig,
+        evict_older_image_bytes, format_compact_summary, get_compact_continuation_message,
+        infer_pending_work, should_compact, CompactionConfig,
     };
     use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
 
@@ -641,6 +643,17 @@ mod tests {
     fn formats_compact_summary_like_upstream() {
         let summary = "<analysis>scratch</analysis>\n<summary>Kept work</summary>";
         assert_eq!(format_compact_summary(summary), "Summary:\nKept work");
+    }
+
+    #[test]
+    fn continuation_message_warns_against_assuming_completion() {
+        let msg =
+            get_compact_continuation_message("<summary>work in progress</summary>", false, true);
+        assert!(
+            msg.contains("re-check the current state with a tool"),
+            "continuation must tell the model to verify before claiming done: {msg}"
+        );
+        assert!(msg.contains("Do NOT assume"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
Companion to the adaptive-compaction change (#92, threshold = `num_ctx / 2`). Now that auto-compaction is the **everyday** trigger (~32K on a 64K window) rather than a 1M last resort that never fired, two cheap guards stop a small brain from losing track of an in-progress action across a compact and confabulating completion (e.g. claiming a PR is open that was never created).

## Changes
- **Preserve 12 recent messages on the hard path** (was 4). `SOFT_COMPACT_PRESERVE` was already 12; both paths now keep enough real recent context for the model to know what it has/hasn't done. Doc comments updated to explain the new everyday-trigger rationale.
- **Verify-before-done note** added to the post-compaction continuation message (always, regardless of the suppress-follow-up flag): the summary is lossy and may omit the RESULT of an in-progress action, so the model must re-check state with a tool before reporting any step done.
- Adjusted `maybe_compact_session_fires_when_over_threshold` (8→16 messages) so it still exceeds the new preserve=12 floor.
- New test `continuation_message_warns_against_assuming_completion`.
- CHANGELOG bullet under the existing `[Unreleased] ### Changed`.

## Verification
- `cargo fmt --all`, `cargo clippy --all-targets` clean.
- `cargo test -p claudette --lib compact` — 36/36 green (incl. the adjusted test).
- Full lib suite green (1118 passed locally).

Authored by Claudette per spec `plans/codev-2026-06-14/TASK-COMPACT-SAFETY-FIX.md`; reviewed by Claude (diff faithful to spec, build + targeted tests reverified).