### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-19
+
 ### Added
 
 - **`repo_map` C/C++ support.** `mode=map` now extracts C and C++ definitions —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release prep for **v0.14.0** — version bump + CHANGELOG + Cargo.lock only, no code changes.

Once merged, tagging `v0.14.0` triggers `release.yml` (crates.io publish via OIDC + 5-target binaries + GitHub Release).

## Included since v0.13.1
**Added**
- `repo_map` C/C++ support
- `repo_map` PHP support
- `grep_search` context lines (`-C`)
- `edit_file` `replace_all`
- Redirect a tool at the `[y/N]` gate
- Context-window gauge on the status line
- Read-loop breaker

**Changed**
- Auto-compaction now tracks the context window (`num_ctx/2`)
- Safer mid-task compaction (preserve 12 + verify-before-done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)