### PR TITLE
ci: run integration tests so the air-gap proof actually executes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
-      - run: cargo test --lib --bins
+      # `--tests` is what makes the air-gap a CI-proven guarantee: it pulls in
+      # the integration targets under tests/ (notably offline_egress.rs, which
+      # drives every networked tool under CLAUDETTE_OFFLINE=1 and asserts each
+      # refuses before a socket opens). Without `--tests` that proof never ran.
+      - run: cargo test --lib --bins --tests
         env:
           CLAUDETTE_SKIP_OLLAMA_PROBE: "1"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,10 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
       - run: cargo fmt --all --check
       - run: cargo clippy --all-targets --no-deps -- -D warnings
-      - run: cargo test --lib --bins
+      # `--tests` includes the integration targets under tests/ (notably
+      # offline_egress.rs, the end-to-end air-gap proof) so a release can't ship
+      # with the flagship guarantee silently broken.
+      - run: cargo test --lib --bins --tests
         env:
           CLAUDETTE_SKIP_OLLAMA_PROBE: "1"
 

--- a/crates/claudette/src/tools/forge_tail.rs
+++ b/crates/claudette/src/tools/forge_tail.rs
@@ -149,26 +149,28 @@ mod tests {
 
     #[test]
     fn forge_tail_reads_existing_log() {
-        // Plant a fake log file and confirm we read it.
-        let unique = format!(
-            "claudette-forge-tail-real-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_or(0, |d| d.as_nanos())
-        );
-        let _ = std::fs::create_dir_all(forge_log_dir());
-        let log_path = forge_log_dir().join(format!("{unique}.log"));
-        std::fs::write(&log_path, "one\ntwo\nthree\nfour\nfive\n").unwrap();
+        // Run under an isolated HOME held by the shared env lock. forge_log_dir()
+        // resolves through $HOME, and a concurrent HOME-swapping test (e.g. in
+        // runtime/prompt.rs) used to yank the directory out from under us between
+        // the create_dir_all and the write — flaking this test with a NotFound on
+        // ubuntu CI. with_temp_home serialises against those and gives us a dir
+        // nothing else touches.
+        crate::with_temp_home(|_home| {
+            let unique = "claudette-forge-tail-real";
+            let dir = forge_log_dir();
+            std::fs::create_dir_all(&dir).expect("create forge log dir");
+            let log_path = dir.join(format!("{unique}.log"));
+            std::fs::write(&log_path, "one\ntwo\nthree\nfour\nfive\n").unwrap();
 
-        let out =
-            run_forge_tail(&json!({ "mission_id": &unique, "lines": 3 }).to_string()).expect("ok");
-        let v: Value = serde_json::from_str(&out).unwrap();
-        let _ = std::fs::remove_file(&log_path);
+            let out = run_forge_tail(&json!({ "mission_id": unique, "lines": 3 }).to_string())
+                .expect("ok");
+            let v: Value = serde_json::from_str(&out).unwrap();
 
-        assert_eq!(v["exists"], true);
-        assert_eq!(v["lines_returned"], 3);
-        let lines = v["lines"].as_array().unwrap();
-        assert_eq!(lines.last().unwrap(), "five");
-        assert_eq!(lines.first().unwrap(), "three");
+            assert_eq!(v["exists"], true);
+            assert_eq!(v["lines_returned"], 3);
+            let lines = v["lines"].as_array().unwrap();
+            assert_eq!(lines.last().unwrap(), "five");
+            assert_eq!(lines.first().unwrap(), "three");
+        });
     }
 }


### PR DESCRIPTION
## What

`cargo test --lib --bins` excludes every target under `tests/`, so `tests/offline_egress.rs` — the end-to-end proof that every networked tool refuses under `CLAUDETTE_OFFLINE=1` — **never ran in CI or release verify**. The flagship air-gap claim could have regressed silently between releases.

This switches both workflows to `cargo test --lib --bins --tests`.

## Evidence
- `.github/workflows/ci.yml:85` and `release.yml:56` both used `--lib --bins`
- Roast 2026-06-21, recurred across multiple agents (Testing/CI angle)

## Verification
`offline_egress.rs` is already green locally:
```
Running tests\offline_egress.rs
test result: ok. 3 passed; 0 failed
```
Full suite: 1125 + 25 + 3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)