### PR TITLE
docs(readme): make qwen3.5:4b the stated default, not the 35B

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Every candidate runs the same objective 50-task battery - 11 languages × 12 tas
 
 | Model | VRAM | Pass @ 50 | Best for |
 |-------|------|-----------|----------|
-| **`qwen3.6-35b-a3b`** (q3_k_xl) | 16 GB | **92%** | Best accuracy - the default |
-| `qwen3.5-4b` | **8 GB** | 90% | Best value - runs almost anywhere |
+| **`qwen3.5:4b`** | **8 GB** | 90% | **The default** - what `install` pulls; best value, runs on an 8 GB GPU or plain CPU |
+| `qwen3.6-35b-a3b` (q3_k_xl) | 16 GB | **92%** | Best accuracy - LM Studio only (not packaged on Ollama) |
 | `gpt-oss-20b` | 13 GB | 86% | Fastest |
 
 Full table, methodology, and the reusable harness → [MODEL-COMPARISON.md](runs/eval-2026-05-29/battery/MODEL-COMPARISON.md). Benching a model we haven't covered is the single most useful way to contribute - no Rust required.


### PR DESCRIPTION
## What

The "Which model should I run?" table crowned `qwen3.6-35b-a3b` as **"the default"**, but:
- the install snippet pulls `qwen3.5:4b` (`README.md:33`)
- the Auto preset's default brain *is* `qwen3.5:4b` (`docs/configuration.md:14`)
- the 35B isn't packaged on Ollama — `ollama pull qwen3.6-35b-a3b` fails (`hw.rs:87-90` already documents this)

Three independent roast agents (2026-06-21) flagged this as the #1 newcomer dead-end.

## Fix
Reorder the table so the actual default (`qwen3.5:4b`, 90%) leads and is marked **The default**, and relabel the 35B row "Best accuracy — LM Studio only (not packaged on Ollama)". Now the table, the install command, and the code agree.

Doc-only; no code touched (`hw.rs` was already backend-honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)