### PR TITLE
docs: fix six drifted claims; remove vestigial /agents

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ do not backport fixes to prior minor versions.
 
 | Version | Supported |
 |---------|-----------|
-| latest `0.8.x` | ✅  |
-| `< 0.8`  | ❌        |
+| latest released `0.x` | ✅ |
+| any older release | ❌ |
 
 ## Reporting a vulnerability
 

--- a/crates/claudette/src/commands.rs
+++ b/crates/claudette/src/commands.rs
@@ -61,7 +61,6 @@ pub enum SlashCommand {
     Capabilities,
     Exit,
     Validate(String),
-    Agents,
     /// Sprint 14: swap the whole preset bundle (brain + fallback) in one
     /// command. `fast` / `auto` / `smart`.
     PresetSwitch(Preset),
@@ -190,7 +189,6 @@ pub fn parse_slash_command(line: &str) -> Option<SlashCommand> {
                     .to_string(),
             ),
         },
-        "agents" => SlashCommand::Agents,
         "preset" => match arg.filter(|s| !s.is_empty()) {
             Some(p) => match p.parse::<Preset>() {
                 Ok(preset) => SlashCommand::PresetSwitch(preset),
@@ -374,10 +372,6 @@ where
             handle_validate(out, &path);
             SlashOutcome::Continue
         }
-        SlashCommand::Agents => {
-            handle_agents(out);
-            SlashOutcome::Continue
-        }
         SlashCommand::PresetSwitch(preset) => {
             handle_preset(out, runtime, preset, rebuild);
             SlashOutcome::Continue
@@ -483,7 +477,6 @@ fn print_help(out: &mut impl Write) {
                     "/validate (val) <path>",
                     "Run Codet code validator on a file",
                 ),
-                ("/agents", "List available agent types"),
                 ("/recall <query>", "Search cross-session memory"),
                 (
                     "/recall reprobe",
@@ -1252,27 +1245,6 @@ fn handle_reload<C, T, R>(
     }
 }
 
-fn handle_agents(out: &mut impl Write) {
-    let _ = writeln!(
-        out,
-        "{} {}",
-        theme::ROBOT,
-        theme::accent("available agents")
-    );
-    let agents: &[(&str, &str)] = &[(
-        "codet",
-        "code validation sidecar (automatic on write_file, supports py/rs/js/ts)",
-    )];
-    for (name, desc) in agents {
-        let _ = writeln!(out, "  {}  {}", theme::accent(name), theme::dim(desc));
-    }
-    let _ = writeln!(
-        out,
-        "\n  {}",
-        theme::dim("codet runs automatically on write_file/edit_file.")
-    );
-}
-
 fn handle_preset<C, T, R>(
     out: &mut impl Write,
     runtime: &mut ConversationRuntime<C, T>,
@@ -1993,12 +1965,6 @@ mod tests {
     fn parse_validate_without_path_is_invalid() {
         let parsed = parse_slash_command("/validate");
         assert!(matches!(parsed, Some(SlashCommand::Invalid(_))));
-    }
-
-    #[test]
-    fn parse_agents() {
-        assert_eq!(parse_slash_command("/agents"), Some(SlashCommand::Agents));
-        assert_eq!(parse_slash_command("/AGENTS"), Some(SlashCommand::Agents));
     }
 
     #[test]

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,6 @@
 # Claudette vs. the open-source AI agent landscape
 
-_As of April 2026._
+_As of June 2026._
 
 "Open claw" ≈ **opencode** (SST) — the most-cited open-source alternative to Claude Code. This doc
 compares Claudette against opencode and the other leading open-source AI coding / agent tools so
@@ -10,7 +10,7 @@ we're honest about what Claudette is, what it isn't, and where it has room to gr
 
 | Tool | Language | Local models | Primary UI | Agent style | Target use case |
 |---|---|---|---|---|---|
-| **Claudette** | Rust (single crate) | Ollama-only by default | REPL + CLI + TUI + **Telegram bot** | Agent loop w/ 3 sub-agents + tiered-brain fallback | Personal secretary + coding (local-first) |
+| **Claudette** | Rust (single crate) | Ollama or LM Studio | REPL + CLI + TUI + **Telegram bot** | Agent loop + tiered-brain fallback (4B→9B) | Local-first coding agent + personal assistant |
 | **opencode** (SST) | Go | Yes, 75+ models | Terminal TUI + VS Code ext | Plan + Build agents | Coding agent replacing Claude Code |
 | **Aider** | Python | Yes, any LLM | Terminal REPL | Repo-mapped pair programming | Coding with deep git integration |
 | **OpenHands** | Python + Docker | Yes, via Ollama | Web UI + Docker sandbox | Autonomous agent with browser + shell | Full SWE-agent, SWE-bench 53%+ |
@@ -19,14 +19,14 @@ we're honest about what Claudette is, what it isn't, and where it has room to gr
 
 ## Where Claudette differs
 
-### 1. It's a secretary, not a coding tool
-opencode, Aider, Cline, Continue — all framed as coding agents. Claudette's 12 tool groups cover
-`calendar` (Google Calendar CRUD + RSVP), `schedule` (proactive reminders + recurring briefings),
-`gmail` (read-only with `<email>` provenance wrapping), `markets` (TradingView + Algorand),
-`facts` (Wikipedia / Open-Meteo weather), `telegram` (voice-capable bot interface), plus
-`git`/`ide`/`search`/`advanced`/`registry`/`github` — alongside `core` (notes, todos, time, files).
-Code-generation exists (Codet sidecar + Code Reviewer sub-agent) but is one capability among
-many, not the whole point.
+### 1. A coding agent that's also a full personal assistant
+opencode, Aider, Cline, Continue are coding agents and nothing else. Claudette's coding core
+(files, search, repo-map, tests, `git`/`github`, the Codet code-gen sidecar, and the `--forge`
+Planner→Coder→Verifier pipeline) is first-class — and it ships alongside a deep assistant toolset
+no other tool here carries: `calendar` (Google Calendar CRUD + RSVP), `schedule` (proactive
+reminders + recurring briefings), `gmail` (read-only with `<email>` provenance wrapping), `markets`,
+`facts` (Wikipedia / Open-Meteo weather), and `telegram` (voice-capable bot interface). 22 opt-in
+tool groups in all, so the base schema stays tiny until the model enables what it needs.
 
 ### 2. Four interfaces, including a Telegram bot
 None of the comparison tools ship a messaging-app interface. Send a voice note while walking, get a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,6 @@ Claudette intentionally does **not** auto-load `.env` from the current working d
 | `CLAUDETTE_SKIP_OLLAMA_PROBE` | unset | Set to `1` to skip the Ollama startup probe (CI / offline). |
 | `CLAUDETTE_SKIP_LM_STUDIO_PROBE` | unset | Set to `1` to skip the LM Studio probe (only used when `CLAUDETTE_OPENAI_COMPAT=1`). The probe checks `/v1/models` returns a non-empty model list — set this if you load models post-launch. |
 | `CLAUDETTE_FALLBACK_BRAIN_MODEL` | `qwen3.5:9b` (Auto preset) | Brain to fall back to on stuck signals. |
-| `CLAUDETTE_LIVE_GOOGLE` | unset | Set to `1` to run live Google integration tests via `cargo test --ignored`. Never set in CI. |
 | `CLAUDETTE_WORKSPACE` | unset | Extra read roots outside `$HOME`, colon-separated on Unix, semicolon-separated on Windows. Example: `D:\dev\claudette` for developing Claudette itself. Reads under `$HOME` and under a `$HOME`-rooted CWD are always allowed regardless. |
 
 ### Backend quirks: LM Studio variant suffix
@@ -82,9 +81,9 @@ Two layers enforce it: an HTTP-layer guard in the reqwest path checks the destin
 | `BRAVE_API_KEY` | Brave Search API key — required for `web_search`. |
 | `GITHUB_TOKEN` | GitHub PAT — required for the `github` tool group. Falls back to `CLAUDETTE_GITHUB_TOKEN` if unset. |
 | `TELEGRAM_BOT_TOKEN` | Bot token from `@BotFather` — required for `--telegram`. |
+| `CLAUDETTE_TELEGRAM_CHAT` | Comma-separated chat-ID allowlist for the Telegram bot (same as repeating `--chat`). The bot default-denies when no allowlist is set. |
 | `CLAUDETTE_GOOGLE_CLIENT_ID` | Google OAuth client ID — required for `--auth-google` + the Calendar / Gmail tool groups. Falls back to `GOOGLE_CLIENT_ID`, or to `~/.claudette/secrets/google_oauth_client.json`. |
 | `CLAUDETTE_GOOGLE_CLIENT_SECRET` | Google OAuth client secret. Same fallback chain as the client ID. |
-| `VESTIGE_API_BASE` | Override for the vestige.fi Algorand API (`markets` group). |
 
 All tokens also support file-based fallback: save them to `~/.claudette/secrets/<name>.token` (for example `github.token`, `telegram.token`, `brave.token`). Environment variables win over files when both are present.
 
@@ -102,13 +101,3 @@ All tokens also support file-based fallback: save them to `~/.claudette/secrets/
 | `CLAUDETTE_RECALL_DISABLE` | unset | Set to `1` to disable post-turn recall indexing entirely (privacy / no embed model available). |
 | `CLAUDETTE_RECALL_MODEL` | `nomic-embed-text` | Embed model id. Under `CLAUDETTE_OPENAI_COMPAT=1`, set to whatever embedding model you've loaded in LM Studio (e.g. `text-embedding-nomic-embed-text-v1.5`). |
 | `CLAUDETTE_RECALL_DB` | `~/.claudette/recall.sqlite` | Override the recall DB path (mostly useful in tests). |
-
-## Sub-agent tuning
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `CLAUDETTE_RESEARCHER_MODEL` | inherits brain | Override the Researcher agent's model. |
-| `CLAUDETTE_GITOPS_MODEL` | inherits brain | Override the GitOps agent's model. |
-| `CLAUDETTE_RESEARCHER_MAX_ITER` | `10` | Hard cap on Researcher tool calls per delegation. |
-| `CLAUDETTE_GITOPS_MAX_ITER` | `8` | Hard cap on GitOps tool calls per delegation. |
-| `CLAUDETTE_TELEGRAM_CHAT` | unset | Comma-separated chat-ID allowlist for Telegram bot. |

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -100,7 +100,9 @@ The default compaction threshold of 1M tokens is effectively "off" — it exists
 
 ## Disabling network paths
 
-Today there's no `--offline` master flag (it's on the roadmap — see [`../PRIVACY.md`](../PRIVACY.md)). What you have today:
+The blunt instrument is the master flag — **`claudette --offline`** (or `CLAUDETTE_OFFLINE=1`), shipped in v0.8.9. It enforces the air-gap: every outbound call except the local model backend + loopback is hard-blocked, in both the in-process HTTP path and any subprocess (`git`, `gh`, edge-tts). Inspect the live allow-list with `claudette --offline --doctor`, and see [Enforced offline mode](configuration.md#enforced-offline-mode---offline) in `configuration.md` for the full block/allow list. This is the recommended way to go dark.
+
+For finer-grained control — disabling one outbound path while leaving the rest live — unset the relevant token instead of flipping the master flag:
 
 | Outbound | How to disable |
 |----------|----------------|

--- a/docs/show-me.md
+++ b/docs/show-me.md
@@ -24,15 +24,15 @@ You'll get the note back from a search later even if you forgot the exact words 
 
 ## Calendar and email
 
-Once you've connected Google (one-time OAuth — see [`google_setup.md`](google_setup.md)), Claudette can read and write your calendar and inbox.
+Once you've connected Google (one-time OAuth — see [`google_setup.md`](google_setup.md)), Claudette can manage your calendar and read your inbox.
 
 - *"What's on my calendar tomorrow?"*
 - *"Schedule a 30-minute coffee with Sam on Thursday at 3pm."*
+- *"Move my Tuesday dentist appointment to Wednesday at the same time."*
 - *"Did Lisa email me about the lease this week?"*
-- *"Draft a reply to the landlord saying I'll send the deposit on Monday."*
-- *"Cancel my Tuesday dentist appointment and email the office."*
+- *"Summarize the unread mail from my landlord."*
 
-Drafts are saved as drafts. Nothing gets sent without you saying "send it."
+Calendar events are created, moved, and cancelled only after you confirm. Your **inbox is read-only** — Claudette can search and read mail (sending and drafting aren't built yet), so nothing ever leaves on its own.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,7 +24,6 @@ Run `claudette --help` for the authoritative reference.
 
 ```
 /help                Show this list.
-/agents              List available sub-agent types.
 /validate <path>     Run Codet on an existing code file.
 /status              Session info + token counts.
 /cost                Lifetime token usage.


### PR DESCRIPTION
Wave 0.3–0.8 of the 2026-06-21 roast remediation — claims that were **false in shipped docs/code**. Batched per the goal's allowance for pure-doc cleanups.

| # | Fix |
|---|---|
| 0.3 | `power-user.md` said `--offline` was "on the roadmap"; it shipped v0.8.9. Section now leads with the master flag; env-unset table is the granular fallback. |
| 0.4 | Drop six env vars present in **zero** source files (`CLAUDETTE_RESEARCHER_MODEL`/`GITOPS_MODEL`/`*_MAX_ITER`, `CLAUDETTE_LIVE_GOOGLE`, `VESTIGE_API_BASE`). The real `CLAUDETTE_TELEGRAM_CHAT` moves into the Tokens table. |
| 0.5 | `SECURITY.md` pinned a dead `0.8.x` minor (current: 0.14.0) → "latest released 0.x". |
| 0.6 | `comparison.md`: refresh date, tool-group count 12→22, drop removed "Code Reviewer sub-agent"/"3 sub-agents", align section-1 with the shipped README. |
| 0.7 | `show-me.md`: Gmail is read-only (`gmail.rs:4`) — drop the draft/send examples + the "drafts are saved" line. |
| 0.8 | `/agents` was vestigial (listed the codet sidecar as an "agent type" after `spawn_agent` was cut). Command + parse/dispatch/help/handler/test removed; `usage.md` line dropped. |

## Verification
`cargo fmt` + `cargo clippy --all-targets --no-deps -- -D warnings` + `cargo test --lib --bins --tests` all green (1124 lib / 25 bin / 3 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)