### PR TITLE
fix(cli): document --faceless; make flag-coverage test exhaustive

### DIFF
--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -136,6 +136,9 @@ MISC:
                          Gmail/Calendar, markets/weather/wikipedia, GitHub, and
                          the Telegram bridge; the local brain + recall still
                          work. See `--offline` in --doctor for the allow-list.
+    --faceless           Drop the persona overlay (Eva for the assistant,
+                         CodeX-7 for the forge Coder) and run with a plain,
+                         name-free prompt. Same as CLAUDETTE_FACELESS=1.
     --help, -h           Show this help and exit.
     --version, -V        Show the claudette version and exit.
 
@@ -1027,12 +1030,20 @@ mod tests {
 
     #[test]
     fn help_text_mentions_every_flag() {
-        // Guardrail: if someone adds a new flag to parse_args they'll break
-        // this test until HELP_TEXT documents it. Keeps the two in sync.
+        // Guardrail: every long flag parse_args matches must be documented in
+        // HELP_TEXT. This list must mirror the `"--*"` arms in parse_args
+        // (`grep -oE '"--[a-z-]+"' main.rs | sort -u`) — adding a flag without
+        // a HELP_TEXT line breaks this test on purpose. Previously it checked
+        // only 11 of 15 and silently let --forge/--doctor/--faceless/--offline
+        // ship undocumented.
         for flag in [
             "--resume",
             "--telegram",
             "--tui",
+            "--forge",
+            "--doctor",
+            "--faceless",
+            "--offline",
             "--chat",
             "--auth-google",
             "--revoke",


### PR DESCRIPTION
## Wave 2.1

`--faceless` was parsed (`main.rs:515`) but never appeared in `HELP_TEXT`, and the guardrail test `help_text_mentions_every_flag` checked only **11 of the 15** long flags — so it stayed green while `--forge`/`--doctor`/`--faceless`/`--offline` were unlisted (`--faceless` genuinely was). The "every flag" name gave false confidence.

- Add the `--faceless` line to `HELP_TEXT`'s MISC section.
- Extend the test to all 15 flags `parse_args` matches (`grep -oE '"--[a-z-]+"' main.rs | sort -u`), with a comment tying the list to the parse arms so the next new flag breaks the test until documented.

(`--forge`/`--doctor`/`--offline` were already in HELP_TEXT — the finding was partly stale; the real gap was `--faceless` + the under-covering test.)

Verified: `cargo fmt` + `clippy -D warnings` + the test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)