### PR TITLE
ci: add cargo-deny supply-chain gate (licenses/bans/sources)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,27 @@ jobs:
       - name: Run cargo audit
         run: cargo audit
 
+  deny:
+    name: cargo deny (supply chain)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+        with:
+          key: cargo-deny
+      # Install the CLI directly (same rationale as the cargo-audit job above):
+      # avoids a Node-20 third-party action and keeps the job permission set to
+      # contents:read. `cargo deny check` enforces deny.toml — license allow-list,
+      # duplicate-version bans, source allow-list, and a second pass over the
+      # RustSec advisory DB.
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: Run cargo deny
+        run: cargo deny check
+
   test:
     name: test (${{ matrix.os }})
     strategy:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,79 @@
+# Supply-chain policy, enforced in CI by `cargo deny check` (roast 2026-06-21,
+# Wave 3.1/3.2). A security-positioned, air-gapped project shipping 300+
+# transitive crates with no supply-chain gate is a contradiction; this closes
+# it. Runs alongside the standalone `cargo audit` job — deny re-checks the
+# RustSec advisory DB and adds license, duplicate-version, and source gates.
+#
+# Update procedure: if a new dependency trips this, prefer fixing the tree
+# (swap/drop the dep) over loosening policy. When a loosen is genuinely
+# warranted, add a *narrow, commented* exception below.
+
+[advisories]
+version = 2
+# A yanked crate in the lockfile means a `--locked` build pulls a version the
+# author retracted — treat it as hard a failure as a CVE.
+yanked = "deny"
+# ignore = [
+#   # "RUSTSEC-0000-0000", # why it's tolerated + tracking link
+# ]
+
+[licenses]
+version = 2
+# Permissive licenses only — every entry is OSI-approved and compatible with
+# claudette's own MIT OR Apache-2.0 dual license. The set is the minimum that
+# satisfies the current tree: OR-expressions are covered by MIT/Apache, while
+# `(MIT OR Apache-2.0) AND Unicode-3.0` and `Apache-2.0 AND ISC` force
+# Unicode-3.0 and ISC to be listed explicitly.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.9
+# exceptions = [
+#   # { allow = ["..."], crate = "some-crate" },
+# ]
+
+[bans]
+# Duplicate versions of the same crate bloat the binary and widen the audit
+# surface. Today the tree carries a handful of unavoidable transitive dupes
+# (getrandom, hashbrown, windows-sys, winnow, rand, foldhash, r-efi) pinned by
+# upstreams we don't control; they're skipped below so a *new* dupe we
+# introduce fails CI while the known ones don't block merges. Re-audit the
+# skip list when dependencies are bumped — `cargo tree -d` shows the current
+# set.
+multiple-versions = "deny"
+wildcards = "deny"
+# Crates allowed to appear at multiple versions (known, upstream-driven). Most
+# of these are the windows-sys 0.60/0.61 split dragging two copies of the
+# windows-targets → windows_* import-lib family; the rest are common transitive
+# pins. Keep in sync with `cargo tree -d`.
+skip = [
+    { crate = "getrandom" },
+    { crate = "hashbrown" },
+    { crate = "winnow" },
+    { crate = "windows-sys" },
+    { crate = "windows-targets" },
+    { crate = "windows_aarch64_gnullvm" },
+    { crate = "windows_aarch64_msvc" },
+    { crate = "windows_i686_gnu" },
+    { crate = "windows_i686_gnullvm" },
+    { crate = "windows_i686_msvc" },
+    { crate = "windows_x86_64_gnu" },
+    { crate = "windows_x86_64_gnullvm" },
+    { crate = "windows_x86_64_msvc" },
+    { crate = "wit-bindgen" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Wave 3.1 + 3.2

A security-positioned, air-gapped project shipping 300+ transitive crates had **no supply-chain gate** beyond `cargo audit`. This adds `deny.toml` + a `cargo deny` CI job.

| Check | Policy |
|---|---|
| **licenses** | Permissive-only allow-list (MIT/Apache-2.0/BSD/ISC/Zlib/Unicode-3.0/BSL-1.0/MPL-2.0/CDLA-Permissive-2.0) — the minimum that satisfies the current tree (`(MIT OR Apache) AND Unicode-3.0` and `Apache AND ISC` force Unicode-3.0/ISC explicit). |
| **bans** | `multiple-versions = "deny"` with a documented skip-list for known upstream dupes (windows-sys 0.60/0.61 split + its `windows_*` family, getrandom, hashbrown, winnow, wit-bindgen) → a **new** dup we introduce fails CI; known ones don't block. `wildcards = "deny"`. |
| **sources** | crates.io only. |
| **advisories** | `yanked = "deny"` + a second pass over the RustSec DB. |

Job installs the CLI directly (no Node-20 action), mirroring the existing `cargo audit` job's rationale.

## Verification
`cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (exit 0, no warnings) locally.

> Follow-up: once merged, add **"cargo deny (supply chain)"** to the branch-protection required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)