### PR TITLE
test: serialize remaining HOME-reading tests under the env lock

### DIFF
--- a/crates/claudette/src/missions.rs
+++ b/crates/claudette/src/missions.rs
@@ -533,6 +533,9 @@ mod tests {
 
     #[test]
     fn path_under_permitted_roots_accepts_home_subpath() {
+        // home-resolving: serialize against the temp-HOME swaps in
+        // runtime/prompt.rs (path_under_permitted_roots re-reads $HOME).
+        let _eg = crate::test_env_lock();
         let home = std::env::var("USERPROFILE")
             .or_else(|_| std::env::var("HOME"))
             .expect("HOME or USERPROFILE must be set for this test");

--- a/crates/claudette/src/tools/fuzzy_apply.rs
+++ b/crates/claudette/src/tools/fuzzy_apply.rs
@@ -601,6 +601,9 @@ mod tests {
     fn not_found_error_carries_near_miss_hint() {
         // Dogfood T2: a `before` with doubled backslashes must produce the
         // over-escaping diagnosis end-to-end, not the generic "copy exactly".
+        // home-resolving: serialize against the temp-HOME swaps in
+        // runtime/prompt.rs so $HOME doesn't change mid-test.
+        let _eg = crate::test_env_lock();
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .unwrap_or_else(|_| ".".into());
@@ -630,6 +633,9 @@ mod tests {
         // The dogfood 2026-06-13 spiral: before == after (the model could not
         // see its own doubled backslash). The edit must FAIL with a no-op error,
         // not report ok:true after writing nothing.
+        // home-resolving: serialize against the temp-HOME swaps in
+        // runtime/prompt.rs so $HOME doesn't change mid-test.
+        let _eg = crate::test_env_lock();
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .unwrap_or_else(|_| ".".into());

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -842,6 +842,7 @@ mod tests {
 
     #[test]
     fn edit_file_errors_on_ambiguous_match() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("ambig");
         let original = "alpha\nalpha\nbeta\n";
         fs::write(&path, original).unwrap();
@@ -865,6 +866,7 @@ mod tests {
 
     #[test]
     fn edit_file_replace_all_replaces_every_occurrence() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("replace_all");
         fs::write(&path, "foo / foo / foo\n").unwrap();
 
@@ -884,6 +886,7 @@ mod tests {
 
     #[test]
     fn edit_file_without_replace_all_still_refuses_multiple_matches() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("replace_all_no_default");
         fs::write(&path, "foo / foo / foo\n").unwrap();
 
@@ -900,6 +903,7 @@ mod tests {
 
     #[test]
     fn edit_file_replace_all_still_fires_noop_guard() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("replace_all_noop");
         fs::write(&path, "foo foo\n").unwrap();
 
@@ -921,6 +925,7 @@ mod tests {
 
     #[test]
     fn edit_file_replaces_unique_match() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("unique");
         fs::write(&path, "one\ntwo\nthree\n").unwrap();
 
@@ -935,6 +940,7 @@ mod tests {
 
     #[test]
     fn edit_file_errors_on_zero_matches() {
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("zero");
         let original = "one\ntwo\n";
         fs::write(&path, original).unwrap();
@@ -953,6 +959,7 @@ mod tests {
     fn edit_file_identical_old_new_is_a_loud_no_op() {
         // Dogfood 2026-06-13: old_text == new_text writes nothing but reported
         // ok:true. It must now FAIL with a no-op error and leave the file alone.
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("noop");
         let original = "alpha\nbeta\ngamma\n";
         fs::write(&path, original).unwrap();
@@ -972,6 +979,7 @@ mod tests {
         // Dogfood T2: old_text doubled the backslashes of a raw-string regex
         // (JSON-escaping confusion). The error must name the real cause, not
         // just say "not found".
+        let _eg = crate::test_env_lock(); // home-resolving: serialize vs temp-HOME swaps
         let path = home_join("nearmiss");
         let original = "fn pat() {\n    let re = r\"^\\s*fn\";\n}\n";
         fs::write(&path, original).unwrap();


### PR DESCRIPTION
Now that CI runs the full suite (`--lib --bins --tests`, PR #99), two more cross-test `$HOME` races surfaced:
- `fuzzy_apply::tests::identical_before_after_is_a_loud_no_op` (ubuntu, PR #99 CI)
- `shell::tests::edit_file_*` (windows, PR #103 CI)

**Root cause:** tests that resolve a scratch path from `$HOME`/`$USERPROFILE` and write to it can have the directory yanked out from under them by the concurrent HOME swaps in `runtime/prompt.rs`, yielding a wrong/`NotFound` error instead of the asserted one.

`patch.rs` already took `crate::test_env_lock()` for exactly this. This applies the same convention to the stragglers:
- `tools/fuzzy_apply.rs` — both apply_diff scratch-file tests
- `tools/shell.rs` — all 8 `edit_file` `home_join` tests
- `missions.rs` — `path_under_permitted_roots_accepts_home_subpath` (re-reads `$HOME`)

**Verification:** `clippy -D warnings` clean; **6× full-suite stress loop** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)