### PR TITLE
ci: lock-version guard, npm dependabot, macOS coverage note

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,25 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+
+  # The VS Code extension's npm subtree was on security-alert life-support
+  # (only cargo + actions were scheduled). Keep it patched on the same cadence.
+  - package-ecosystem: "npm"
+    directory: "/editor/vscode"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps-dev"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "vscode"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,23 +61,31 @@ jobs:
           CLAUDETTE_SKIP_OLLAMA_PROBE: "1"
 
   tag-version-match:
-    name: tag matches Cargo.toml version
+    name: tag matches Cargo.toml + Cargo.lock version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - name: Compare tag to package version
         # Tag format `v0.2.3` must match the `version = "0.2.3"` line in
-        # Cargo.toml. Mismatch is almost always a forgot-to-bump in the
-        # release prep — fail fast rather than publish a wrong version.
+        # Cargo.toml *and* the claudette entry in Cargo.lock. A stale lockfile
+        # (bumped Cargo.toml but forgot `cargo update -p claudette`) sails past
+        # a Cargo.toml-only check and then fails the expensive `--locked`
+        # publish/build jobs minutes later — catch it here in seconds.
         # Skipped on workflow_dispatch (dry-run) — there is no tag to compare.
         if: github.event_name == 'push'
         run: |
           tag="${GITHUB_REF#refs/tags/v}"
           ver="$(grep -E '^version = ' crates/claudette/Cargo.toml | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')"
+          lock_ver="$(grep -A1 '^name = "claudette"$' Cargo.lock | grep -E '^version = ' | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')"
           echo "tag = $tag"
           echo "crates/claudette/Cargo.toml version = $ver"
+          echo "Cargo.lock claudette version = $lock_ver"
           if [ "$tag" != "$ver" ]; then
             echo "::error::tag $tag does not match crates/claudette/Cargo.toml version $ver"
+            exit 1
+          fi
+          if [ "$tag" != "$lock_ver" ]; then
+            echo "::error::tag $tag does not match Cargo.lock claudette version $lock_ver — run 'cargo update -p claudette' and commit the lockfile"
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,13 +41,20 @@ locally, CI will be green too:
 ```bash
 cargo fmt --all --check
 cargo clippy --all-targets --no-deps -- -D warnings
-cargo test --lib --bins
+cargo test --lib --bins --tests
 ```
 
-All must pass. The `--lib` suite has 1000+ tests plus 6 ignored (4
-POSIX-only hook tests, 2 live-recall smokes that need an LM Studio
-embedding server) — a PR that drops the pass count needs a
-justification in the description.
+All must pass. The suite has 1000+ tests plus 6 ignored (4 POSIX-only
+hook tests, 2 live-recall smokes that need an LM Studio embedding
+server) — a PR that drops the pass count needs a justification in the
+description. (`--tests` pulls in the `tests/` integration targets,
+notably the air-gap proof `offline_egress.rs` — CI runs these too.)
+
+**Platform coverage:** CI runs the test suite on **Ubuntu and Windows
+only**. macOS targets (`aarch64`/`x86_64-apple-darwin`) are *build*-checked
+at release time but not test-gated, and the x86_64 mac binary is
+cross-compiled. If your change has macOS-specific behaviour, test it
+locally — CI won't catch a mac-only regression.
 
 ## Commit style
 


### PR DESCRIPTION
Three release/CI hardening fixes from the 2026-06-21 roast:

- **4.4** — `tag-version-match` now also checks **Cargo.lock**'s claudette version, not just Cargo.toml. A stale lockfile (bumped Cargo.toml but forgot `cargo update -p claudette`) used to sail past and fail the expensive `--locked` publish/build jobs minutes later; now it fails in seconds. (Extraction verified locally against the current lockfile.)
- **3.3** — add the **npm** ecosystem (`/editor/vscode`) to dependabot; the VS Code extension subtree was on security-alert life-support with only cargo + actions scheduled.
- **4.5** — CONTRIBUTING notes CI tests **Ubuntu + Windows only** (macOS targets are build-checked at release, x64 cross-compiled, never test-gated), and syncs the local pre-PR command to CI's (`--lib --bins --tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)