### PR TITLE
chore(presence): air-gapped crate keywords; backend-agnostic bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ labels: ["bug"]
 
 - Claudette version (`claudette --version`):
 - Host OS + arch (e.g. `Windows 11 x64`, `macOS 14.5 arm64`, `Ubuntu 24.04 x64`):
-- Ollama version (`ollama --version`):
+- Backend + version (LM Studio or Ollama — e.g. `lms --version` / `ollama --version`):
 - Model + preset (`/preset`, `/brain` output, or the default):
 - GPU + VRAM, if relevant:
 

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../README.md"
 repository = "https://github.com/mrdushidush/claudette"
 homepage = "https://github.com/mrdushidush/claudette"
 authors = ["mrdushidush <mrdushidush@gmail.com>"]
-keywords = ["coding-agent", "local-llm", "privacy", "tui", "ollama"]
+keywords = ["air-gapped", "offline-first", "coding-agent", "local-llm", "privacy"]
 categories = ["command-line-utilities", "development-tools"]
 # Keep the published crate lean: the tests/ tree is benchmark-harness data
 # (run logs, results dirs, shell scripts, prompt fixtures) with no .rs targets,


### PR DESCRIPTION
Two small presence/positioning cleanups from the roast remediation sprint (Wave 6).

## 6.1 — Crate keywords lead with the positioning
`crates/claudette/Cargo.toml` keywords now read
`["air-gapped", "offline-first", "coding-agent", "local-llm", "privacy"]`,
matching how the README and crates.io page lead (air-gap first), instead of
burying the differentiator. Still within the 5-keyword / 20-char crates.io caps.

## 6.5 — Backend-agnostic bug report template
`.github/ISSUE_TEMPLATE/bug_report.md` Environment line now asks for
"Backend + version (LM Studio or Ollama — e.g. `lms --version` / `ollama --version`)"
instead of assuming Ollama. Claudette drives either backend; the template
shouldn't presume one.

Doc/metadata only — no code, no test impact.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>