### PR TITLE
feat(security): redact credential-shaped tokens before disk/stderr sinks (Wave 1.3a)

### DIFF
--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -55,6 +55,7 @@ pub mod missions;
 pub mod model_config;
 pub mod prompt;
 pub mod recall;
+pub mod redact;
 pub mod run;
 pub mod scheduler;
 pub mod secrets;

--- a/crates/claudette/src/redact.rs
+++ b/crates/claudette/src/redact.rs
@@ -1,0 +1,148 @@
+//! Secret redaction for on-disk and stderr log sinks.
+//!
+//! Mutating tool calls are appended verbatim to the action transcript
+//! (`~/.claudette/transcript/actions.jsonl`) and the `git_*` tools echo their
+//! argv + stderr to the terminal. A model that pastes a PAT into a `bash`
+//! argument, a `git remote set-url https://x-access-token:<PAT>@github.com/…`,
+//! or an `Authorization: Bearer …` header would otherwise persist that secret
+//! in plaintext on disk and in scrollback — credential-at-rest leakage that
+//! flatly contradicts the air-gap / privacy posture. [`redact`] masks the
+//! common token shapes before anything reaches a sink.
+//!
+//! The match set is deliberately **high-precision** (named provider shapes,
+//! not a generic entropy scan) so it never mangles legitimate content like
+//! git hashes or base64 blobs. Each match is replaced with a
+//! `<redacted:KIND>` marker so the log still reads sensibly.
+
+use regex::Regex;
+use std::borrow::Cow;
+use std::sync::OnceLock;
+
+/// Compiled `(pattern, replacement)` table, built once. Patterns are ordered
+/// most-specific first; `Bearer`/`Authorization` come before the bare-token
+/// shapes so the header keyword is preserved in the replacement.
+fn rules() -> &'static [(Regex, &'static str)] {
+    static RULES: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+    RULES.get_or_init(|| {
+        // `expect` here is on compile-time-constant patterns: a malformed
+        // regex is a build-time authoring bug, surfaced by the unit tests,
+        // never a runtime condition.
+        let r = |p: &str| Regex::new(p).expect("redaction pattern must compile");
+        vec![
+            // `Authorization: Bearer <token>` / `Bearer <token>` — keep the
+            // scheme word, drop the credential.
+            (
+                r(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+                "Bearer <redacted>",
+            ),
+            // GitHub PATs and friends: ghp_, gho_, ghu_, ghs_, ghr_.
+            (
+                r(r"\bgh[pousr]_[A-Za-z0-9]{16,}"),
+                "<redacted:github-token>",
+            ),
+            // Slack tokens: xoxb-, xoxp-, xoxa-, xoxr-, xoxs-.
+            (
+                r(r"\bxox[baprs]-[A-Za-z0-9-]{8,}"),
+                "<redacted:slack-token>",
+            ),
+            // AWS access-key id: AKIA + 16 upper/digit.
+            (r(r"\bAKIA[0-9A-Z]{16}\b"), "<redacted:aws-key>"),
+            // Google OAuth access tokens.
+            (r(r"\bya29\.[A-Za-z0-9._-]{20,}"), "<redacted:google-token>"),
+            // OpenAI-style and other `sk-`/`sk-proj-` API keys.
+            (
+                r(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}"),
+                "<redacted:api-key>",
+            ),
+            // `x-access-token:<pat>@` and `<user>:<pat>@github` URL creds.
+            // The char classes exclude `<>` so this rule can never re-match an
+            // already-substituted `<redacted:KIND>` marker (whose internal
+            // colon would otherwise be read as a user:pass separator).
+            (
+                r(r"://[^/\s:@<>]+:[^/\s:@<>]{8,}@"),
+                "://<redacted:url-credential>@",
+            ),
+        ]
+    })
+}
+
+/// Mask credential-shaped substrings in `input`. Returns the original string
+/// borrowed unchanged when nothing matched (the common case), so callers pay
+/// no allocation on clean input.
+#[must_use]
+pub fn redact(input: &str) -> Cow<'_, str> {
+    let mut out: Cow<'_, str> = Cow::Borrowed(input);
+    for (re, repl) in rules() {
+        if re.is_match(&out) {
+            // `replace_all` over an owned String; only reached when a rule
+            // actually fires, so clean input stays borrowed.
+            out = Cow::Owned(re.replace_all(&out, *repl).into_owned());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_input_is_borrowed_unchanged() {
+        let s = "git commit -m \"fix the parser\"";
+        let out = redact(s);
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "clean input must not allocate"
+        );
+        assert_eq!(out, s);
+    }
+
+    #[test]
+    fn masks_github_pat() {
+        let out = redact("git remote add o https://ghp_ABCDEFGHIJKLMNOP0123456789@github.com/x/y");
+        assert!(!out.contains("ghp_ABCDEFGHIJKLMNOP"), "got: {out}");
+        assert!(out.contains("<redacted:github-token>"), "got: {out}");
+    }
+
+    #[test]
+    fn masks_bearer_header_keeps_scheme() {
+        let out = redact("curl -H 'Authorization: Bearer sk_live_abc123DEF456ghi789'");
+        assert!(out.contains("Bearer <redacted>"), "got: {out}");
+        assert!(!out.contains("abc123DEF456"), "got: {out}");
+    }
+
+    #[test]
+    fn masks_slack_aws_google_openai() {
+        assert!(redact("xoxb-1234567890-abcdefghij").contains("<redacted:slack-token>"));
+        assert!(redact("AKIAIOSFODNN7EXAMPLE").contains("<redacted:aws-key>"));
+        assert!(
+            redact("token=ya29.a0AfH6SMxxxxxxxxxxxxxxxxxxxx").contains("<redacted:google-token>")
+        );
+        assert!(redact("OPENAI=sk-proj-abcdefghijklmnopqrstuvwx").contains("<redacted:api-key>"));
+    }
+
+    #[test]
+    fn masks_url_embedded_credentials() {
+        let out = redact("https://x-access-token:ghs_supersecretvalue123456@github.com/o/r.git");
+        // Either the github-token rule or the url-credential rule must hide it;
+        // assert the secret value itself is gone.
+        assert!(!out.contains("supersecretvalue123456"), "got: {out}");
+    }
+
+    #[test]
+    fn does_not_mangle_a_git_sha_or_plain_path() {
+        // A 40-char hex sha and a normal file path must survive untouched.
+        let s = "diff 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b src/tools/git.rs";
+        assert_eq!(redact(s), s);
+    }
+
+    #[test]
+    fn redaction_is_idempotent() {
+        let once = redact("Authorization: Bearer ghp_ABCDEFGHIJKLMNOP0123456789").into_owned();
+        let twice = redact(&once);
+        assert_eq!(
+            twice, once,
+            "re-redacting already-masked text must be stable"
+        );
+    }
+}

--- a/crates/claudette/src/tools/git.rs
+++ b/crates/claudette/src/tools/git.rs
@@ -218,23 +218,30 @@ fn run_git(args: &[&str]) -> Result<String, String> {
     // mission tree. Outside of a mission this resolves to the process
     // cwd — i.e. exactly the pre-T2 behaviour.
     let cwd = crate::missions::active_cwd();
+    // Redact credential-shaped argv before echoing to stderr: a model can pass
+    // a PAT through `git remote set-url …token@github.com` or a `-c http.
+    // extraheader=Authorization: Bearer …`, and this debug line lands in the
+    // terminal scrollback verbatim. (roast 2026-06-21, Wave 1.3)
+    let args_fmt = format!("{args:?}");
+    let args_dbg = crate::redact::redact(&args_fmt);
     eprintln!(
         "  {} {}",
         crate::theme::dim("▸"),
         crate::theme::dim(&format!(
-            "git: using {git_exe:?}, args={args:?}, cwd={}",
+            "git: using {git_exe:?}, args={args_dbg}, cwd={}",
             cwd.display()
         )),
     );
     let result = run_command_with_timeout(&git_exe, args, 30, Some(&cwd));
     if !result.success {
+        let stderr_head = result.stderr.chars().take(200).collect::<String>();
+        let stderr_dbg = crate::redact::redact(&stderr_head);
         eprintln!(
             "  {} {}",
             crate::theme::dim("▸"),
             crate::theme::dim(&format!(
-                "git: failed — exit={:?} stderr={:?}",
+                "git: failed — exit={:?} stderr={stderr_dbg:?}",
                 result.exit_code,
-                result.stderr.chars().take(200).collect::<String>()
             )),
         );
     }

--- a/crates/claudette/src/transcript.rs
+++ b/crates/claudette/src/transcript.rs
@@ -130,11 +130,16 @@ pub fn snapshot_to_trash(original: &Path) -> std::io::Result<PathBuf> {
 /// failed write logs to stderr and returns — it must never fail the tool
 /// call it describes.
 pub fn record(tool: &str, input: &str, undo: Option<Value>) {
-    let capped: String = if input.chars().count() > MAX_RECORDED_INPUT_CHARS {
-        let head: String = input.chars().take(MAX_RECORDED_INPUT_CHARS).collect();
-        format!("{head}… [capped, {} chars total]", input.chars().count())
+    // Mask credential-shaped substrings BEFORE capping/storing: tool input can
+    // carry a PAT (e.g. a `git remote set-url` with an embedded token), and the
+    // transcript is a plaintext file on disk. Redact first so the secret never
+    // lands in actions.jsonl. (roast 2026-06-21, Wave 1.3)
+    let redacted = crate::redact::redact(input);
+    let capped: String = if redacted.chars().count() > MAX_RECORDED_INPUT_CHARS {
+        let head: String = redacted.chars().take(MAX_RECORDED_INPUT_CHARS).collect();
+        format!("{head}… [capped, {} chars total]", redacted.chars().count())
     } else {
-        input.to_string()
+        redacted.into_owned()
     };
     let line = json!({
         "ts": now_ms() as u64,
@@ -565,6 +570,28 @@ mod tests {
             let stored = v.get("input").and_then(Value::as_str).unwrap();
             assert!(stored.chars().count() < 2_100, "input must be capped");
             assert!(stored.contains("capped"), "cap marker missing");
+        });
+    }
+
+    #[test]
+    fn record_redacts_secrets_before_writing_to_disk() {
+        // Wave 1.3: a PAT pasted into a tool argument must never reach the
+        // plaintext transcript file on disk.
+        with_temp_home(|_| {
+            record(
+                "run_bash",
+                r#"{"command":"git push https://ghp_ABCDEFGHIJKLMNOP0123456789@github.com/o/r"}"#,
+                None,
+            );
+            let raw = fs::read_to_string(transcript_path()).unwrap();
+            assert!(
+                !raw.contains("ghp_ABCDEFGHIJKLMNOP"),
+                "the PAT must not be persisted: {raw}"
+            );
+            assert!(
+                raw.contains("redacted"),
+                "a redaction marker should remain: {raw}"
+            );
         });
     }
 


### PR DESCRIPTION
**Wave 1.3 (part 1 of 2) — secret redaction.**

The action transcript (`~/.claudette/transcript/actions.jsonl`) recorded mutating tool input verbatim, and the `git_*` tools echo their argv + stderr to the terminal. A model that pastes a PAT into a `bash` argument or a `git remote set-url …<token>@github.com` would persist that credential in **plaintext on disk and in scrollback** — credential-at-rest leakage that contradicts the air-gap / privacy posture.

## What changed
- New `src/redact.rs`: `redact(&str) -> Cow<str>` masks high-precision provider token shapes:
  - GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`, Slack `xox{b,a,p,r,s}-`, AWS `AKIA…`, Google `ya29.…`, OpenAI `sk-`/`sk-proj-`, `Authorization: Bearer …`, and `user:pass@` URL credentials → `<redacted:KIND>`.
  - **Named-shape only — no generic entropy scan** — so it never mangles git SHAs or base64 blobs.
  - `Cow::Borrowed` on clean input (the common case → zero allocation). Idempotent (re-redacting masked text is stable).
- Wired into `transcript::record` (redact **before** cap+store) and the two `git` stderr debug lines (argv + failure stderr, which can echo a token-bearing remote URL on auth failure).

## Tests
- 7 unit tests in `redact` (each provider shape, clean-input-stays-borrowed, SHA-not-mangled, idempotency).
- `transcript::record_redacts_secrets_before_writing_to_disk` proves a PAT in tool input never reaches `actions.jsonl`.
- Full suite green: **1132 lib + 26 bin + 3 offline-egress integration**, fmt + clippy (`--all-features -D warnings`) clean.

The **Windows secret-file ACL** half of Wave 1.3 (`secrets.rs`) lands in a separate follow-up PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>