### PR TITLE
test(battery): auto-retry once on EC=124 timeout (eviction flakes) (Wave 4.2a)

### DIFF
--- a/runs/eval-2026-05-29/battery/run_battery.sh
+++ b/runs/eval-2026-05-29/battery/run_battery.sh
@@ -65,11 +65,31 @@ while IFS=$'\t' read -r id lang type fixture timeout; do
     echo "### ---- claudette output ----"
   } > "$log"
 
-  start=$(date +%s)
-  ( cd "$work" && CLAUDETTE_WORKSPACE="$wswin" timeout "$timeout" "$BIN" "$prompt" ) >> "$log" 2>&1
-  ec=$?
-  elapsed=$(($(date +%s)-start))
-  echo "### EXIT=$ec  ELAPSED=${elapsed}s" >> "$log"
+  # Run claudette under a hard timeout. EC=124 on a LOCAL model is usually an
+  # LM Studio eviction / JIT-load flake — the model got unloaded and the cold
+  # reload blew the time budget — NOT a code regression (see the unload
+  # investigation note). Retry ONCE on a timeout: the first attempt warms the
+  # model, so a genuine flake passes on the retry while a real spiral times out
+  # again and keeps its (TIMEOUT) stamp, no longer masking real regressions.
+  # Tune with BATTERY_TIMEOUT_RETRIES (default 1; 0 disables).
+  retries="${BATTERY_TIMEOUT_RETRIES:-1}"
+  attempt=0
+  while : ; do
+    start=$(date +%s)
+    ( cd "$work" && CLAUDETTE_WORKSPACE="$wswin" timeout "$timeout" "$BIN" "$prompt" ) >> "$log" 2>&1
+    ec=$?
+    elapsed=$(($(date +%s)-start))
+    { [ "$ec" -ne 124 ] || [ "$attempt" -ge "$retries" ]; } && break
+    attempt=$((attempt+1))
+    echo "### TIMEOUT (ec=124) — retry $attempt/$retries (likely model eviction; warming)" >> "$log"
+    # Fresh work tree for the retry so a partial mutation from the timed-out
+    # attempt doesn't taint the verifier.
+    rm -rf "$work"; cp -r "$BAT/fixtures/$fixture" "$work"
+    [ -f "$BAT/setup/$id.sh" ] && bash "$BAT/setup/$id.sh" "$work" >/dev/null 2>&1
+  done
+  suffix=""
+  [ "$attempt" -gt 0 ] && suffix="  (after $attempt timeout-retr$([ "$attempt" -eq 1 ] && echo y || echo ies))"
+  echo "### EXIT=$ec  ELAPSED=${elapsed}s$suffix" >> "$log"
 
   res="$(bash "$BAT/verify/$id.sh" "$work" "$log" 2>&1)"
   status="$(printf '%s\n' "$res" | sed -n 's/^RESULT: \([A-Z]*\).*/\1/p' | head -1)"


### PR DESCRIPTION
**Wave 4.2 (part 1) — timeout-flake retry in the eval battery.**

`EC=124` (the hard `timeout` kill) on a *local* model is usually an LM Studio eviction / JIT cold-load flake — the model was unloaded between tasks and the reload blew the per-task budget — **not** a code regression. The runner stamped `(TIMEOUT)` and moved on, so these infra flakes masked real PASS/FAIL signal across a 50-task sweep.

## What changed (`run_battery.sh`)
- On `EC=124`, retry the task **once**: the first attempt warms the model, so a genuine flake passes on the retry while a **real** spiral times out again and keeps its `(TIMEOUT)` stamp.
- The work tree is re-copied from the fixture before the retry, so a partial mutation from the timed-out attempt can't taint the verifier.
- Tunable: `BATTERY_TIMEOUT_RETRIES` (default `1`; `0` restores old behavior).

## Verification
- Loop traced with a fake always-timeout binary: `retries=1` → 2 runs max; `retries=0` → 1 run (disabled). `bash -n` clean.
- Empty-log-timeout = infra flake vs timeout-with-output = real spiral, per the unload-frequency investigation.

The other half of 4.2 — gating a **model-free verify slice** as CI `#[test]`s — is a separate, larger effort, left as a follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>