### PR TITLE
chore(deps): make --no-default-features a real dep reduction, not just cfg (Wave 3.5)

### DIFF
--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -41,7 +41,15 @@ default = ["integrations"]
 # Google/Telegram code in the binary at all, so it cannot reach those services
 # even by misconfiguration). The coding core (files, search, git, shell,
 # quality, vision, recall, notes, todos, scheduler, …) is unaffected.
-integrations = []
+#
+# The PRIMARY effect is code-surface reduction (the #[cfg(feature =
+# "integrations")] modules — google_auth, telegram_mode, the gmail/calendar
+# tool groups — are not compiled), which is what makes the air-gap guarantee
+# structural rather than configurable. It ALSO drops a real dependency:
+# `getrandom` (the OAuth loopback-state entropy source) is used only by
+# google_auth, so it is gated behind this feature via `dep:getrandom` and
+# leaves the tree entirely under `--no-default-features`.
+integrations = ["dep:getrandom"]
 
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json", "multipart"] }
@@ -76,7 +84,9 @@ arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png"] }
 # OS-entropy source for the OAuth loopback state parameter. Kept to
 # `getrandom` (small, widely deployed) instead of pulling all of `rand`.
-getrandom = "0.4"
+# OAuth lives entirely behind the `integrations` feature, so this is an
+# optional dep activated by it — a `--no-default-features` build drops it.
+getrandom = { version = "0.4", optional = true }
 # Cross-session recall feature: SQLite for the embedded vector store at
 # ~/.claudette/recall.sqlite. `bundled` ships its own libsqlite3 so users
 # don't need a system sqlite — same trade-off as keeping the whole CLI a


### PR DESCRIPTION
**Wave 3.5** — `--no-default-features` honesty.

`integrations = []` activated no `dep:`, so `--no-default-features` removed **zero** crates — it only dead-coded the `#[cfg(feature = "integrations")]` points. A reader reasonably expects the feature to shrink the dependency tree; the roast flagged that gap.

## Fix
`getrandom` (OAuth loopback-state entropy) is used **only** by `google_auth`, which is already integrations-gated. So gate the dep to match the code:
```toml
integrations = ["dep:getrandom"]
getrandom    = { version = "0.4", optional = true }
```

Now `--no-default-features` genuinely drops a dependency.

## Proof
```
$ cargo tree -p claudette -i getrandom@0.4.2
getrandom v0.4.2
└── claudette v0.14.0

$ cargo tree -p claudette --no-default-features -i getrandom@0.4.2
error: ... did not match any packages   # gone
```
(The unrelated transitive `getrandom` 0.2.17 / 0.3.4 are untouched.)

The Cargo.toml comment is rewritten to state honestly that the **primary** effect is code-surface reduction (what makes the air-gap structural — no Google/Telegram code compiled in) and that it now **also** drops this dep.

## Checks
- Default + coding-only builds compile, clippy `-D warnings` clean on both.
- Coding-only lib suite: **1058 passed**. `Cargo.lock` unchanged; `--locked` build OK.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>