### PR TITLE
docs: add Anthropic non-affiliation / trademark disclaimer (Wave 7.2, urgent half)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ Bugs and PRs welcome - see [CONTRIBUTING.md](CONTRIBUTING.md). Conventional Comm
 Dual-licensed under **MIT** ([LICENSE-MIT](LICENSE-MIT)) **OR Apache-2.0** ([LICENSE-APACHE](LICENSE-APACHE)), at your option. The Apache option adds a patent grant; neither grants a trademark.
 
 © 2026 [mrdushidush](https://github.com/mrdushidush).
+
+### Trademarks & affiliation
+
+Claudette is an independent open-source project. It is **not affiliated with, endorsed by, or sponsored by Anthropic**, and it does **not** use the Claude API or any Anthropic service - it drives a model *you* run locally through [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai/). "Claude" and "Anthropic" are trademarks of Anthropic, PBC; "Ollama" and "LM Studio" are trademarks of their respective owners. The name "Claudette" and this project's code are the work of its independent maintainer, used here in a nominative/descriptive sense only.


### PR DESCRIPTION
**Wave 7.2 — the urgent, non-decision half.**

The project name riffs on "Claude" and there was **zero** affiliation notice anywhere (`grep "Anthropic"` in docs = 0 hits) — live brand/legal risk for an AI assistant.

Adds a **Trademarks & affiliation** note to the README License section:
- "not affiliated with, endorsed by, or sponsored by **Anthropic**",
- states plainly it uses **no** Anthropic service / Claude API (drives a local Ollama / LM Studio model),
- acknowledges the relevant trademarks with nominative use.

This README is the crate's rendered page on crates.io, so the notice covers both GitHub and crates.io.

The separate **rename** question (also Wave 7.2) stays a David decision — surfaced separately. This PR is the strictly risk-reducing, reversible half the goal flagged for "today." Doc-only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>