### PR TITLE
docs: reframe benchmark as tool-loop reliability, not task resolution (Wave 7.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Every candidate runs the same objective 50-task battery - 11 languages × 12 tas
 | `qwen3.6-35b-a3b` (q3_k_xl) | 16 GB | **92%** | Best accuracy - LM Studio only (not packaged on Ollama) |
 | `gpt-oss-20b` | 13 GB | 86% | Fastest |
 
+**What "Pass @ 50" is — and isn't.** It's a *tool-loop reliability* score: did the model drive Claudette's real tools to a verifier-confirmed result (build/test passes, ground-truth tokens present) across 50 short, mostly single-file tasks. It is **not** a SWE-bench-style task-resolution number and is **not comparable** to one - SWE-bench resolves multi-file issues in large real repos, a much harder bar. Read it as "how reliably does this model fly the tools," not "how good a coder is it."
+
 Full table, methodology, and the reusable harness → [MODEL-COMPARISON.md](runs/eval-2026-05-29/battery/MODEL-COMPARISON.md). Benching a model we haven't covered is the single most useful way to contribute - no Rust required.
 
 Runs on 8 GB VRAM or plain CPU; 16 GB for the 35B brain. Footprint details → [docs/hardware.md](docs/hardware.md).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -54,8 +54,12 @@ Distribution simplicity: Claudette ≈ opencode >> Aider > Cline / Continue > Op
 ## Where the alternatives win
 
 - **Raw coding benchmark performance**: OpenHands at 53%+ SWE-bench Verified is the current king.
-  Claudette doesn't have a SWE-bench number — its 100-prompt harness scores 94% but that's
-  pattern-matching, not real task resolution.
+  Claudette deliberately doesn't publish a SWE-bench number. Its in-repo harnesses measure a
+  *different, easier* thing — **tool-loop reliability** (does the model drive the tools to a
+  verifier-confirmed build/test/ground-truth result on short, mostly single-file tasks): ~90% on
+  the 50-task battery, 94% on the 100-prompt Brain100 set. That is not task resolution on real
+  multi-file repo issues and is **not comparable** to a SWE-bench score — treat it as a regression
+  signal across models, not a coding-skill ranking.
 - **IDE integration**: Cline + Continue are inside VS Code. Claudette doesn't ship an editor
   plugin.
 - **Autocomplete**: Continue and Cursor-style tab completion aren't Claudette's model at all —


### PR DESCRIPTION
**Wave 7.3 (David's call: reframe as a reliability battery).**

The published pass-rates (90/92/86% on the 50-task battery; 94% on Brain100) read like a coding-skill or SWE-bench-style number — which the project itself elsewhere admits they are not ("pattern-matching, not real task resolution"). Keep the data, kill the misleading framing.

- **README** — adds a *"What 'Pass @ 50' is — and isn't"* note: it's a **tool-loop reliability** score (did the model drive the real tools to a verifier-confirmed build/test/ground-truth result on short, mostly single-file tasks), explicitly **not** a SWE-bench task-resolution number and **not comparable** to one.
- **comparison.md** — relabels the SWE-bench-gap bullet the same way: a different, easier metric (tool-loop reliability), a regression signal across models, not a coding-skill ranking.

No number is inflated or removed; only the framing is corrected so a reader can't mistake ~90% reliability for ~90% SWE-bench. Doc-only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>