### PR TITLE
docs: reframe crate identity as coding agent, not personal secretary (Wave 5.1/7.1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,12 @@ saves us both from a 500-line PR that doesn't fit the project's
 direction. Bug reports with a reproducer are always welcome without
 prior discussion; feature proposals work best as an issue first.
 
-**What Claudette is:** a local-first AI personal secretary in Rust.
-Single binary, Ollama-only brain path by default, four interfaces
-(REPL, one-shot, TUI, Telegram bot). See
-[`docs/comparison.md`](docs/comparison.md) for where Claudette sits
-relative to other agents.
+**What Claudette is:** an air-gapped, local-first AI coding agent in
+Rust. Single binary, one local model (LM Studio or Ollama), four
+interfaces (REPL, one-shot, TUI, Telegram bot). It also carries a
+personal-assistant surface (notes, calendar, voice), but the coding
+agent is the core. See [`docs/comparison.md`](docs/comparison.md) for
+where Claudette sits relative to other agents.
 
 **What Claudette isn't going to become:** a hosted SaaS, a plugin
 marketplace, a VS Code extension, a multi-cloud-provider abstraction.

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -1,8 +1,12 @@
-//! Claudette — local-first AI personal secretary, powered by Ollama.
+//! Claudette — an air-gapped, local-first AI coding agent that drives one
+//! local model (LM Studio or Ollama). It also carries a personal-assistant
+//! surface (notes, calendar, Telegram, voice), gated behind the default-on
+//! `integrations` feature; the coding agent is the core and the headline.
 //!
 //! This crate bundles the agent-loop/session/compaction/permissions kernel
-//! (`src/runtime/*.rs`) and the Claudette secretary layer (tools, REPL, TUI,
-//! Codet sidecar, agents, Telegram bot). Single-crate — no path dependencies.
+//! (`src/runtime/*.rs`) and the Claudette tool/REPL/TUI layer (tools, REPL,
+//! TUI, Codet sidecar, plus the feature-gated assistant integrations).
+//! Single-crate — no path dependencies.
 //!
 //! Runtime modules are mounted at the crate root via `#[path = "runtime/..."]`
 //! attributes so their internal `use crate::session::X` / `use crate::compact::X`


### PR DESCRIPTION
**Executes David's Wave 7.1 decision (coding agent), the safe doc-only first step of Wave 5.1.**

The crate-level docstring (`lib.rs:1`) and `CONTRIBUTING.md` both led with "local-first AI personal secretary" — the identity crisis the roast flagged as the root of the positioning problems. Reframed both to lead with the **air-gapped coding agent** that drives one local model (LM Studio or Ollama), with the assistant surface noted as the feature-gated secondary. Also fixes CONTRIBUTING's stale "Ollama-only brain path by default."

Doc/comment only — no behavior change (build confirmed). The **code-level amputation** (moving markets/gmail/calendar/telegram/voice/space behind off-by-default features, removing the TradingView scraper) is the larger Wave 5.1 effort, queued as its own reviewed PR per the agreed one-at-a-time cadence.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>