### PR TITLE
W5.1: make integrations off-by-default (lean coding agent by default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,12 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
+      # Default features are now OFF (the shipped binary is the lean coding
+      # agent), so this lints the default build. The second pass keeps the
+      # off-by-default `integrations` surface (Gmail/Calendar/Telegram/voice/
+      # tts/briefing) from rotting uncompiled.
       - run: cargo clippy --all-targets --no-deps -- -D warnings
+      - run: cargo clippy --all-targets --all-features --no-deps -- -D warnings
 
   audit:
     name: cargo audit (RustSec advisories)
@@ -108,6 +113,12 @@ jobs:
       # drives every networked tool under CLAUDETTE_OFFLINE=1 and asserts each
       # refuses before a socket opens). Without `--tests` that proof never ran.
       - run: cargo test --lib --bins --tests
+        env:
+          CLAUDETTE_SKIP_OLLAMA_PROBE: "1"
+      # Re-run with the off-by-default `integrations` feature on so the optional
+      # cloud surface (Gmail/Calendar/Telegram/voice/tts/briefing) and its slice
+      # of the offline-egress proof stay tested.
+      - run: cargo test --all-features --lib --bins --tests
         env:
           CLAUDETTE_SKIP_OLLAMA_PROBE: "1"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Changed
+
+- **The default build is now a lean, air-gapped coding agent.** The
+  `integrations` feature — Gmail/Calendar, the Telegram bot, and the
+  Telegram-only voice/tts + morning-briefing (`--briefing`) helpers — is now
+  **off by default**. `cargo install claudette` and the release binaries
+  contain no cloud code at all, so the air-gap is structural rather than a
+  setting. Opt back in with `cargo install claudette --features integrations`
+  (or `cargo build --features integrations`). Previously `integrations` was on
+  by default and you opted *out* via `--no-default-features`.
+
+### Removed
+
+- **The TradingView / `markets` tool group** (`tv_get_quote`). A scraper of
+  `scanner.tradingview.com` has no place in an air-gapped coding agent.
+- **The Space Invaders easter egg** (the TUI `Ctrl+G` game).
+
 ## [0.14.0] - 2026-06-19
 
 ### Added

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -33,22 +33,24 @@ name = "oauth_smoke"
 required-features = ["integrations"]
 
 [features]
-default = ["integrations"]
-# `integrations` bundles the external personal-assistant surface that reaches
-# out to third-party clouds: Google OAuth + Gmail + Calendar, and the Telegram
-# bot. It is ON by default. Build a lean, coding-focused binary with NONE of it
-# compiled in via `--no-default-features` (a "coding-only" build — there is no
-# Google/Telegram code in the binary at all, so it cannot reach those services
-# even by misconfiguration). The coding core (files, search, git, shell,
-# quality, vision, recall, notes, todos, scheduler, …) is unaffected.
+# OFF by default: Claudette ships as a lean, air-gapped *coding agent*. The
+# default `cargo install claudette` / release binary contains NO cloud code —
+# no Google/Telegram, no voice/tts/briefing — so it cannot reach those services
+# even by misconfiguration; the air-gap guarantee is structural, not a setting.
+# The coding core (files, search, git, shell, quality, vision, recall, notes,
+# todos, scheduler, …) is in every build.
+default = []
+# `integrations` opts back IN to the external personal-assistant surface that
+# reaches third-party clouds: Google OAuth + Gmail + Calendar, the Telegram bot,
+# and the Telegram-only voice/tts + morning-briefing helpers. Build it with
+# `cargo install claudette --features integrations` (or `cargo build --features
+# integrations`).
 #
-# The PRIMARY effect is code-surface reduction (the #[cfg(feature =
-# "integrations")] modules — google_auth, telegram_mode, the gmail/calendar
-# tool groups — are not compiled), which is what makes the air-gap guarantee
-# structural rather than configurable. It ALSO drops a real dependency:
-# `getrandom` (the OAuth loopback-state entropy source) is used only by
-# google_auth, so it is gated behind this feature via `dep:getrandom` and
-# leaves the tree entirely under `--no-default-features`.
+# Turning it on compiles the #[cfg(feature = "integrations")] modules
+# (google_auth, telegram_mode, voice, tts, briefing, and the gmail/calendar
+# tool groups) and pulls one real dependency: `getrandom` (the OAuth
+# loopback-state entropy source), gated via `dep:getrandom` so it leaves the
+# tree entirely in the default coding-only build.
 integrations = ["dep:getrandom"]
 
 [dependencies]

--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -80,20 +80,12 @@ pub const NET_TOOLS: &[&str] = &[
     "gh_workflow_logs",
     "gh_fork",
     "gh_create_pr",
-    // Google (Gmail + Calendar)
-    "gmail_list",
-    "gmail_search",
-    "gmail_read",
-    "gmail_list_labels",
-    "calendar_list_events",
-    "calendar_create_event",
-    "calendar_update_event",
-    "calendar_delete_event",
     // Keyless facts
     "wikipedia",
     "weather",
-    // Telegram bridge
-    "tg_send",
+    // Google (Gmail + Calendar) + Telegram are integration-only and listed in
+    // INTEGRATION_NET_TOOLS below, so this list stays consistent with the
+    // coding-only schema (where those tools don't exist).
     // Network-reaching git + brownfield-mission subprocesses
     "git_push",
     "git_clone",
@@ -107,6 +99,27 @@ pub const NET_TOOLS: &[&str] = &[
     "bash",
     "bash_background",
 ];
+
+/// Network-reaching tools that exist **only** in an `integrations` build:
+/// Gmail/Calendar (Google REST) and the Telegram bridge. Kept separate from
+/// [`NET_TOOLS`] so the air-gap proof stays consistent with the advertised
+/// schema in a coding-only build, where these tools are stubbed out entirely.
+/// Empty when the feature is off. The offline-egress test iterates both lists.
+#[cfg(feature = "integrations")]
+pub const INTEGRATION_NET_TOOLS: &[&str] = &[
+    "gmail_list",
+    "gmail_search",
+    "gmail_read",
+    "gmail_list_labels",
+    "calendar_list_events",
+    "calendar_create_event",
+    "calendar_update_event",
+    "calendar_delete_event",
+    "tg_send",
+];
+/// Coding-only build: no Gmail/Calendar/Telegram tools are compiled in.
+#[cfg(not(feature = "integrations"))]
+pub const INTEGRATION_NET_TOOLS: &[&str] = &[];
 
 /// Returns true when offline mode is enabled. Truthy = set, non-empty, and not
 /// literally `"0"` — matching the convention used by `CLAUDETTE_FACELESS`,

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -1,7 +1,9 @@
 //! Claudette — an air-gapped, local-first AI coding agent that drives one
-//! local model (LM Studio or Ollama). It also carries a personal-assistant
-//! surface (notes, calendar, Telegram, voice), gated behind the default-on
-//! `integrations` feature; the coding agent is the core and the headline.
+//! local model (LM Studio or Ollama). The coding agent is the whole product:
+//! the default build carries no cloud code. An optional personal-assistant
+//! surface (Gmail/Calendar, Telegram, voice/tts, morning briefing) lives behind
+//! the off-by-default `integrations` feature — opt in with
+//! `cargo install claudette --features integrations`.
 //!
 //! This crate bundles the agent-loop/session/compaction/permissions kernel
 //! (`src/runtime/*.rs`) and the Claudette tool/REPL/TUI layer (tools, REPL,
@@ -34,9 +36,13 @@ pub mod session;
 #[path = "runtime/usage.rs"]
 pub mod usage;
 
-// ── Claudette secretary layer ────────────────────────────────────────────
+// ── Claudette agent layer ─────────────────────────────────────────────────
 pub mod api;
 pub mod brain_selector;
+// Morning-briefing helper — part of the personal-assistant surface, compiled
+// only into an `integrations` build (the bot consumes it; `--briefing` sets it
+// up). See Cargo.toml `[features]`.
+#[cfg(feature = "integrations")]
 pub mod briefing;
 pub mod clock;
 pub mod codet;
@@ -72,11 +78,17 @@ pub mod theme;
 pub mod tool_groups;
 pub mod tools;
 pub mod transcript;
+// Text-to-speech for Telegram voice replies — only used by `telegram_mode`,
+// so it rides the same `integrations` gate.
+#[cfg(feature = "integrations")]
 pub mod tts;
 pub mod tui;
 pub mod tui_events;
 pub mod tui_executor;
 pub mod tui_worker;
+// Speech-to-text for inbound Telegram voice notes — only used by
+// `telegram_mode`, so it rides the same `integrations` gate.
+#[cfg(feature = "integrations")]
 pub mod voice;
 
 // ── Public re-exports ────────────────────────────────────────────────────

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -20,15 +20,17 @@
 use std::process::ExitCode;
 
 use claudette::{
-    briefing, clock, probe_ollama, run_forge_mission, run_secretary, run_secretary_repl, scheduler,
-    theme, try_load_session, workspace_startup_diagnostics, SessionOptions,
+    probe_ollama, run_forge_mission, run_secretary, run_secretary_repl, theme, try_load_session,
+    workspace_startup_diagnostics, SessionOptions,
 };
 use claudette::{ContentBlock, Session};
-// External-cloud integrations: only compiled into a default-features build.
+// External-cloud integrations: only compiled into an `integrations` build.
 // See Cargo.toml `[features]` and the `dispatch_google_auth` / `dispatch_telegram`
-// helpers below, which carry the coding-only fallback.
+// / `run_briefing_setup` helpers below, which carry the coding-only fallback.
+// `clock` + `scheduler` are here too: their only main.rs use is the real
+// `run_briefing_setup`, which is integrations-only.
 #[cfg(feature = "integrations")]
-use claudette::{google_auth, secrets, telegram_mode};
+use claudette::{briefing, clock, google_auth, scheduler, secrets, telegram_mode};
 
 /// Parsed CLI invocation. Any flag below that doesn't make sense with the
 /// selected mode is quietly ignored (the old tuple contract) — the parser
@@ -587,9 +589,9 @@ fn dispatch_google_auth(_scope: Option<&str>, _revoke: bool) -> ExitCode {
         "{} {}",
         theme::error(theme::ERR_GLYPH),
         theme::error(
-            "--auth-google needs the `integrations` feature — this is a coding-only build \
-             (compiled --no-default-features), so there is no Google code in it. Reinstall \
-             with default features to use Gmail/Calendar."
+            "--auth-google needs the `integrations` feature — this is a coding-only build (the \
+             default), so there is no Google code in it. Reinstall with `--features integrations` \
+             to use Gmail/Calendar."
         )
     );
     ExitCode::FAILURE
@@ -641,9 +643,9 @@ fn dispatch_telegram(_chat_ids: Vec<i64>, _allow_any_chat: bool, _resume: bool) 
         "{} {}",
         theme::error(theme::ERR_GLYPH),
         theme::error(
-            "--telegram needs the `integrations` feature — this is a coding-only build \
-             (compiled --no-default-features), so the Telegram bridge isn't in it. Reinstall \
-             with default features to run the bot."
+            "--telegram needs the `integrations` feature — this is a coding-only build (the \
+             default), so the Telegram bridge isn't in it. Reinstall with `--features \
+             integrations` to run the bot."
         )
     );
     ExitCode::FAILURE
@@ -653,6 +655,11 @@ fn dispatch_telegram(_chat_ids: Vec<i64>, _allow_any_chat: bool, _resume: bool) 
 /// `--briefing` CLI flag. Does not talk to Telegram at all — the running
 /// bot picks the new entry up on its next startup (or immediately if
 /// already running, since tools write to the same jsonl).
+///
+/// The briefing is part of the personal-assistant surface, so the real
+/// implementation is only present in an `integrations` build; the coding-only
+/// build carries the stub below.
+#[cfg(feature = "integrations")]
 fn run_briefing_setup(time: Option<&str>, days: Option<&str>) -> ExitCode {
     let time_str = time.unwrap_or("07:00");
     let days_spec = days.unwrap_or("weekdays").to_lowercase();
@@ -764,6 +771,23 @@ fn run_briefing_setup(time: Option<&str>, days: Option<&str>) -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Coding-only fallback: the morning briefing is part of the assistant surface,
+/// which isn't compiled into a default (no-`integrations`) build. Explain and
+/// exit non-zero rather than silently doing nothing.
+#[cfg(not(feature = "integrations"))]
+fn run_briefing_setup(_time: Option<&str>, _days: Option<&str>) -> ExitCode {
+    eprintln!(
+        "{} {}",
+        theme::error(theme::ERR_GLYPH),
+        theme::error(
+            "--briefing needs the `integrations` feature — this is a coding-only build, so the \
+             morning-briefing helper isn't in it. Reinstall with `--features integrations` to \
+             schedule briefings."
+        )
+    );
+    ExitCode::FAILURE
 }
 
 #[cfg(test)]
@@ -948,6 +972,11 @@ mod tests {
         assert_eq!(a.auth_google_scope, None);
     }
 
+    // Scope keywords (`gmail` / `calendar`) are only recognised when the
+    // `integrations` feature compiles in `google_auth::AuthContext`; the
+    // coding-only build deliberately lets the token fall through as a prompt
+    // word (see the parse loop's `ExpectNext::AuthGoogleScope` arm).
+    #[cfg(feature = "integrations")]
     #[test]
     fn parse_args_auth_google_with_gmail_scope() {
         let a = parse_args(&["--auth-google".into(), "gmail".into()]);
@@ -956,6 +985,17 @@ mod tests {
         assert!(a.prompt_words.is_empty());
     }
 
+    #[cfg(not(feature = "integrations"))]
+    #[test]
+    fn parse_args_auth_google_scope_falls_through_in_coding_only_build() {
+        // No Google scope keywords exist here, so `gmail` is just a prompt word.
+        let a = parse_args(&["--auth-google".into(), "gmail".into()]);
+        assert!(a.auth_google);
+        assert_eq!(a.auth_google_scope, None);
+        assert_eq!(a.prompt_words, vec!["gmail".to_string()]);
+    }
+
+    #[cfg(feature = "integrations")]
     #[test]
     fn parse_args_auth_google_with_calendar_scope_then_revoke() {
         let a = parse_args(&["--auth-google".into(), "calendar".into(), "--revoke".into()]);

--- a/crates/claudette/tests/offline_egress.rs
+++ b/crates/claudette/tests/offline_egress.rs
@@ -14,9 +14,16 @@
 //! zero egress. We point `OLLAMA_HOST` at loopback so the backend stays
 //! allow-listed (the brain/recall path must keep working under offline mode).
 
-use claudette::egress::{self, BLOCK_PREFIX, NET_TOOLS};
+use claudette::egress::{self, BLOCK_PREFIX, INTEGRATION_NET_TOOLS, NET_TOOLS};
 use claudette::secretary_tools_json;
 use claudette::tools::dispatch_tool;
+
+/// Every network-reaching tool present in *this* build: the always-on set plus
+/// the integration-only set (empty in a coding-only build). The air-gap proof
+/// must cover exactly the tools the schema actually advertises.
+fn all_net_tools() -> impl Iterator<Item = &'static str> {
+    NET_TOOLS.iter().chain(INTEGRATION_NET_TOOLS).copied()
+}
 
 /// Serialises the env-mutating tests: `CLAUDETTE_OFFLINE` / `OLLAMA_HOST` are
 /// process-global, so parallel tests in this binary would otherwise race.
@@ -79,7 +86,7 @@ fn every_net_tool_refuses_under_offline() {
     let _lock = ENV_LOCK.lock().unwrap();
     let _env = OfflineEnv::set();
 
-    for &tool in NET_TOOLS {
+    for tool in all_net_tools() {
         match dispatch_tool(tool, offline_probe_input(tool)) {
             Ok(out) => panic!("{tool} reached the network under offline mode (returned Ok): {out}"),
             Err(err) => assert!(
@@ -112,9 +119,9 @@ fn backend_and_loopback_stay_allowed_under_offline() {
 fn net_tools_registry_is_consistent_and_covers_network_families() {
     use std::collections::HashSet;
 
-    // (a) No duplicate entries in the registry.
+    // (a) No duplicate entries in the registry (across both lists).
     let mut seen = HashSet::new();
-    for &t in NET_TOOLS {
+    for t in all_net_tools() {
         assert!(seen.insert(t), "duplicate entry in NET_TOOLS: {t}");
     }
 
@@ -129,7 +136,7 @@ fn net_tools_registry_is_consistent_and_covers_network_families() {
         .filter_map(|t| t.pointer("/function/name").and_then(|v| v.as_str()))
         .map(str::to_string)
         .collect();
-    for &t in NET_TOOLS {
+    for t in all_net_tools() {
         assert!(
             schema_names.contains(t),
             "NET_TOOLS lists '{t}' but it is not in the tool schema (renamed or removed?)"
@@ -142,7 +149,7 @@ fn net_tools_registry_is_consistent_and_covers_network_families() {
     // siblings, so they can't be swept by prefix and are maintained by hand in
     // egress::NET_TOOLS.
     const ALWAYS_NET_PREFIXES: &[&str] = &["gh_", "gmail_", "calendar_", "tg_"];
-    let registry: HashSet<&str> = NET_TOOLS.iter().copied().collect();
+    let registry: HashSet<&str> = all_net_tools().collect();
     for name in &schema_names {
         if ALWAYS_NET_PREFIXES.iter().any(|p| name.starts_with(p)) {
             assert!(


### PR DESCRIPTION
## W5.1 — make `integrations` off-by-default (lean coding agent by default)

Final and substantive slice of **W5.1 "amputate the secretary"**, executing your
Wave-7.1 decision **at the binary level**.

**`cargo install claudette` and the release binaries are now a lean, air-gapped
coding agent** with zero cloud code compiled in. The personal-assistant surface
(Gmail/Calendar, Telegram, voice/tts, morning briefing) moves behind the now
**off-by-default** `integrations` feature. The air-gap is now structural, not a
setting — and the "secretary in a coding-agent costume" identity is resolved.

```
cargo install claudette                          # coding agent (no cloud code)
cargo install claudette --features integrations  # + Gmail/Calendar/Telegram/voice
```

### ⚠️ Distribution change to be aware of
The published **GitHub release binaries become coding-only.** Anyone who wants
Gmail/Calendar/Telegram builds from source with `--features integrations`. The
crates.io source still contains all of it (features only gate compilation). This
is the direct consequence of the option you picked — flagging it explicitly.

### Changes
- `Cargo.toml`: `default = ["integrations"]` → `default = []` (+ rewritten feature doc).
- Gate `voice` / `tts` / `briefing` modules behind `integrations` (voice/tts are Telegram-only; briefing backs `--briefing`).
- `main.rs`: `run_briefing_setup` gains a coding-only stub mirroring the existing `--auth-google` / `--telegram` stubs; fixed two stub messages that wrongly said *"reinstall with default features"* (default is now coding-only).

### Latent breakage this flip exposed (and fixes)
The coding-only build was **never built in CI before** — it's now the default, so CI builds it, which surfaced real pre-existing bugs:
- **egress:** `NET_TOOLS` listed `gmail_*`/`calendar_*`/`tg_send` unconditionally, but those are stubbed out of the coding-only schema → the air-gap proof failed. Split them into a cfg-gated `INTEGRATION_NET_TOOLS`; `offline_egress.rs` now iterates both lists.
- **main.rs:** the two `--auth-google <scope>` parse tests assert integrations-only behaviour → gated them, and added a coding-only test asserting the scope token falls through as a prompt word.

### CI
The existing clippy/test jobs now verify the **lean default** build (the shipped artifact); added an **`--all-features`** pass to each so the optional integrations surface stays compiled + tested and can't rot. (`release.yml` unchanged — it correctly builds/tests the lean shipped artifact; integrations is gated per-PR in `ci.yml`.)

### Verification — both configs green locally
| build | lib | bins | offline_egress | clippy |
|---|---|---|---|---|
| default (lean) | 1034 | 25 | 3 | clean |
| `--all-features` | 1121 | 26 | 3 | clean |

`cargo fmt --all` clean.

### This completes W5.1 ("amputate the secretary")
Across #127 (TradingView scraper), #128 (Space Invaders), and this PR (integrations off-by-default). Remaining W5.1 tail: rename `SecretaryToolExecutor` / `run_secretary` → coding-agent naming (mechanical; separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
