### PR TITLE
Fix flaky grep/glob $HOME race in tools tests

### DIFF
--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -2135,6 +2135,13 @@ mod tests {
 
     #[test]
     fn glob_search_matches_files_under_home() {
+        // Hold the global env lock for the whole test: it creates a path under
+        // $HOME (via files_dir) and then dispatches a tool that re-validates
+        // $HOME, so it must not run while another test swaps HOME (with_temp_home
+        // and the runtime/prompt test both take this same lock). Without it the
+        // path created under the real HOME fails validation against a swapped
+        // HOME, and grep/glob returns Err — the flaky failure seen in CI.
+        let _env = crate::test_env_lock();
         // Seed three files inside the sandbox; glob a recursive .txt match.
         let dir = temp_seed_dir(
             "glob",
@@ -2192,6 +2199,8 @@ mod tests {
 
     #[test]
     fn grep_search_finds_substring_match() {
+        // See glob_search_matches_files_under_home: serialise against HOME swaps.
+        let _env = crate::test_env_lock();
         let dir = temp_seed_dir(
             "grep",
             &[
@@ -2231,6 +2240,8 @@ mod tests {
 
     #[test]
     fn grep_search_skips_hidden_directories() {
+        // See glob_search_matches_files_under_home: serialise against HOME swaps.
+        let _env = crate::test_env_lock();
         let dir = temp_seed_dir("grep-hidden", &[(".secret/inside.md", "FINDME")]);
         let input = json!({
             "pattern": "FINDME",


### PR DESCRIPTION
## Fix the flaky grep/glob `$HOME` race in tools tests

The `grep_search_skips_hidden_directories` test flaked on **two consecutive PRs**
(#129 test job, #130 coverage job), failing with an `Err` from `grep_search`.

### Root cause
Three tests — `grep_search_skips_hidden_directories`,
`grep_search_finds_substring_match`, `glob_search_matches_files_under_home` —
create a path under `$HOME` (via `temp_seed_dir` → `files_dir()`) and then
`dispatch_tool(...)`, which **re-validates the path is under `$HOME`** (read
again at dispatch time). They did **not** hold the global test env lock.

Meanwhile, other tests swap `HOME`: `with_temp_home` and the `runtime/prompt`
discovery test — **both already take `crate::test_env_lock()`**. When one of
those ran concurrently and swapped `HOME` between the *create* and the
*validate*, the seed path (under the real HOME) failed validation against the
swapped HOME → `grep_search` returned `Err` → the `.expect(...)` panicked.

That's why it was intermittent and never reproduced locally — pure scheduling luck.

### Fix
Have the three `temp_seed_dir` tests acquire `crate::test_env_lock()` for their
whole duration, making them mutually exclusive with every HOME-mutating test
(all of which already use that same lock). **Test-only — no shipped-code change.**

### Verification
- `cargo clippy` clean (default **and** `--all-features`).
- Full lib suite green across repeated runs (1034 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
