### PR TITLE
Rename the user-facing identity: coding agent, not personal secretary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Changed
+
+- **Claudette now introduces itself as a coding agent, not a "personal
+  secretary."** The `get_capabilities` self-report, `--help`, the REPL banner,
+  the `/tools` header, the Telegram `/start` greeting, and the `web_fetch`
+  User-Agent all describe a "local-first AI coding agent." This finishes the
+  user-visible side of the identity cleanup the `secretary`→`agent` code rename
+  began. (The internal system prompt is unchanged — a coding-agent system
+  prompt measurably regressed the small `qwen3.5-4b` brain on git-inspection
+  tasks, so it was deliberately left alone.)
+
+### Fixed
+
+- **The read-only git inspectors (`git_status`/`git_diff`/`git_log`) are now
+  loop-broken like the other navigation tools.** Previously they were a blind
+  spot: an exact-repeat call was re-executed and re-bloated the context. They
+  now dedup identical repeats and count toward the search budget, while a real
+  mutation (`git_add`/`git_commit`/`git_checkout`) still clears the dedup set so
+  a legitimate re-check after a change is kept.
+
 ## [0.15.0] - 2026-06-21
 
 ### Changed

--- a/crates/claudette/examples/02-tool-groups.md
+++ b/crates/claudette/examples/02-tool-groups.md
@@ -56,10 +56,10 @@ advertisable tool — core plus every optional group with the
 
 ```
 > /tools
-✨ secretary tools (core 17 + 12 optional groups)
+✨ agent tools (core 17 + 12 optional groups)
   ⚡ core (always loaded)
     • get_current_time: Returns the current date, time, weekday, and timezone.
-    • get_capabilities: Show the secretary's config, available tools, and limits.
+    • get_capabilities: Show claudette's config, available tools, and limits.
     • note_create, note_list, note_read, note_delete
     • todo_add, todo_list, todo_set_status, todo_delete
     • read_file, write_file, list_dir

--- a/crates/claudette/src/commands.rs
+++ b/crates/claudette/src/commands.rs
@@ -470,7 +470,7 @@ fn print_help(out: &mut impl Write) {
         (
             "tools & memory",
             &[
-                ("/tools", "List the secretary's tools"),
+                ("/tools", "List claudette's tools"),
                 ("/memory (mem)", "Show CLAUDETTE.MD memory in use"),
                 ("/reload", "Re-read CLAUDETTE.MD without losing history"),
                 (
@@ -1097,7 +1097,7 @@ fn handle_tools(out: &mut impl Write) {
         out,
         "{} {} {}",
         theme::SPARKLES,
-        theme::accent("secretary tools"),
+        theme::accent("agent tools"),
         theme::dim(&format!(
             "(core {} + {} optional groups)",
             registry.core_tool_names().len(),
@@ -1211,7 +1211,7 @@ fn handle_memory(out: &mut impl Write) {
             let _ = writeln!(
                 out,
                 "  {}",
-                theme::dim("(no memory file — create one to give the secretary background)")
+                theme::dim("(no memory file — create one to give the agent background)")
             );
         }
     }

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -83,7 +83,7 @@ struct CliArgs {
 /// CLI flag table is synced to this block. Keep lines under 80 columns so
 /// it fits an 80-wide terminal without wrapping awkwardly.
 const HELP_TEXT: &str = "\
-claudette — a local-first AI personal secretary, powered by Ollama.
+claudette — a local-first AI coding agent, powered by Ollama.
 
 USAGE:
     claudette [FLAGS] [PROMPT...]

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -1775,7 +1775,7 @@ pub fn run_agent_repl(opts: SessionOptions) -> Result<()> {
         "{} {} {}",
         theme::ROBOT,
         theme::brand("claudette"),
-        theme::dim("— your local secretary")
+        theme::dim("— your local coding agent")
     );
     eprintln!(
         "{} {}",

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -841,10 +841,26 @@ fn search_budget_nudge(n: usize) -> String {
 /// useful work. These are the calls the loop-breaker dedups; a repeat returns
 /// [`duplicate_call_body`] instead of re-running the tool. Mutating tools are
 /// deliberately excluded — re-reading after an edit is legitimate.
+///
+/// The read-only git inspectors (`git_status`/`git_diff`/`git_log`) belong here
+/// too: they return identical bytes when nothing has changed, and a small brain
+/// nudged to "investigate the repo state" will re-issue them turn after turn
+/// (measured 2026-06-21: the coding-agent persona drove qwen3.5-4b from iter≈3
+/// to the iter=40 cap on "show git status", regressing brain100 89%→78%). They
+/// are nav, not mutation, so an intervening real mutation still clears `seen_nav`
+/// (line ~496) and a legitimate re-check after an edit/commit is NOT suppressed.
 fn is_navigation_tool(name: &str) -> bool {
     matches!(
         name,
-        "read_file" | "grep_search" | "glob_search" | "list_dir" | "semantic_grep" | "repo_map"
+        "read_file"
+            | "grep_search"
+            | "glob_search"
+            | "list_dir"
+            | "semantic_grep"
+            | "repo_map"
+            | "git_status"
+            | "git_diff"
+            | "git_log"
     )
 }
 
@@ -1344,6 +1360,12 @@ mod tests {
             "glob_search",
             "list_dir",
             "semantic_grep",
+            "repo_map",
+            // Read-only git inspectors: identical bytes on re-run, the small-brain
+            // git-spiral that hit the iteration cap (2026-06-21 persona regression).
+            "git_status",
+            "git_diff",
+            "git_log",
         ] {
             assert!(super::is_navigation_tool(nav), "{nav} should be navigation");
         }
@@ -1351,7 +1373,11 @@ mod tests {
             "edit_file",
             "apply_diff",
             "bash",
+            // Mutating git tools stay non-nav: re-running them after a change is
+            // legitimate, and a mutation must clear the nav dedup set.
             "git_commit",
+            "git_add",
+            "git_checkout",
             "write_file",
             "add",
         ] {
@@ -1424,6 +1450,85 @@ mod tests {
         );
         assert_eq!(summary.iterations, 3);
         // Second tool_result is the suppressed duplicate (is_error = true).
+        let dup = runtime
+            .session()
+            .messages
+            .iter()
+            .find_map(|m| {
+                m.blocks.iter().find_map(|b| match b {
+                    ContentBlock::ToolResult {
+                        output, is_error, ..
+                    } if *is_error => Some(output.clone()),
+                    _ => None,
+                })
+            })
+            .expect("a suppressed duplicate tool_result should exist");
+        assert!(dup.contains("duplicate call suppressed"), "got: {dup}");
+    }
+
+    #[test]
+    fn duplicate_git_status_is_suppressed_not_re_executed() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        // The git-tool spiral (2026-06-21 persona regression): the brain
+        // re-issues the IDENTICAL git_status twice while "investigating the
+        // repo state", then answers. Before git_* were classified as
+        // navigation this looped uncounted to the iteration cap. Now the loop
+        // must execute it once, suppress the exact repeat, and finish.
+        struct GitSpiralApi {
+            calls: usize,
+        }
+        impl ApiClient for GitSpiralApi {
+            fn stream(
+                &mut self,
+                _request: &ApiRequest<'_>,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                self.calls += 1;
+                match self.calls {
+                    1 | 2 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("gs-{}", self.calls),
+                            name: "git_status".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Ok(vec![
+                        AssistantEvent::TextDelta("clean".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                }
+            }
+        }
+
+        let exec_count = Rc::new(Cell::new(0usize));
+        let ec = Rc::clone(&exec_count);
+        let tool_executor = StaticToolExecutor::new().register("git_status", move |_input| {
+            ec.set(ec.get() + 1);
+            Ok("On branch main\nnothing to commit, working tree clean".to_string())
+        });
+        let permission_policy = PermissionPolicy::new(PermissionMode::WorkspaceWrite)
+            .with_tool_requirement("git_status", PermissionMode::ReadOnly);
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            GitSpiralApi { calls: 0 },
+            tool_executor,
+            permission_policy,
+            vec!["sys".to_string()],
+        );
+
+        let summary = runtime
+            .run_turn("show me the git status", None)
+            .expect("loop should finish");
+
+        assert_eq!(
+            exec_count.get(),
+            1,
+            "git_status must execute once; the identical repeat is suppressed"
+        );
+        assert_eq!(summary.iterations, 3);
         let dup = runtime
             .session()
             .messages

--- a/crates/claudette/src/telegram_mode.rs
+++ b/crates/claudette/src/telegram_mode.rs
@@ -496,7 +496,7 @@ pub fn run_telegram_bot(
                 } else if text.starts_with('/') {
                     let reply = match text.as_str() {
                         "/start" => Some(
-                            "Hello! I'm Claudette, your AI personal secretary. \
+                            "Hello! I'm Claudette, your local-first AI coding agent. \
                                  Send me any message and I'll help you out."
                                 .to_string(),
                         ),

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -198,7 +198,7 @@ fn build_tools_json() -> Value {
             "type": "function",
             "function": {
                 "name": "get_capabilities",
-                "description": "Show the secretary's config, available tools, and limits. Use for 'what can you do' questions.",
+                "description": "Show claudette's config, available tools, and limits. Use for 'what can you do' questions.",
                 "parameters": { "type": "object", "properties": {}, "required": [] }
             }
         },
@@ -402,7 +402,7 @@ fn run_get_capabilities() -> String {
 
     json!({
         "name": "Claudette",
-        "kind": "personal AI secretary",
+        "kind": "local-first AI coding agent",
         "model": crate::run::current_model(),
         "runtime": "crate::ConversationRuntime over Ollama /api/chat",
         "context_window": {
@@ -420,7 +420,7 @@ fn run_get_capabilities() -> String {
         "sandbox": {
             "read": "user $HOME (/home/<user> or C:\\Users\\<user>) — symlinks/junctions resolved as such, system dirs not blocked but ACL-protected anyway",
             "write": files_dir().display().to_string(),
-            "rationale": "writes are sandboxed to ~/.claudette/files/ so the secretary cannot overwrite the user's real documents by accident or hallucination",
+            "rationale": "writes are sandboxed to ~/.claudette/files/ so the agent cannot overwrite the user's real documents by accident or hallucination",
         },
         "storage": {
             "notes": notes::notes_dir().display().to_string(),

--- a/crates/claudette/src/tools/git.rs
+++ b/crates/claudette/src/tools/git.rs
@@ -285,7 +285,7 @@ fn reject_destructive(args: &[&str]) -> Result<(), String> {
             if arg == b {
                 return Err(format!(
                     "git: destructive flag `{arg}` is blocked for safety. \
-                     If you really need it, run git manually outside the secretary."
+                     If you really need it, run git manually outside claudette."
                 ));
             }
         }

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -530,7 +530,7 @@ fn run_web_fetch(input: &str) -> Result<String, String> {
 
     let resp = client
         .get(url)
-        .header("User-Agent", "claudette/1.0 (Claudette personal secretary)")
+        .header("User-Agent", "claudette/1.0 (Claudette coding agent)")
         .header("Accept", "text/html,application/xhtml+xml,text/plain")
         .send()
         .map_err(|e| format!("web_fetch: request failed: {e}"))?;


### PR DESCRIPTION
Replaces the **user-facing** \"personal secretary\" identity with \"local-first AI coding agent\" — finishing the visible side of the `secretary`→`agent` rename (#130 renamed only the Rust identifiers; the strings users actually see still said \"personal secretary\" on `main`).

## What changes (all user-visible strings)
- `get_capabilities` self-report (`tools.rs`)
- `--help` tagline (`main.rs`)
- REPL banner (`run.rs`)
- `/tools` header (`commands.rs`)
- Telegram `/start` greeting (`telegram_mode.rs`)
- `web_fetch` User-Agent (`tools/search.rs`)
- the `git` manual-fallback hint (`tools/git.rs`) + a doc example

## What does NOT change — and why
**The internal system prompt (`prompt.rs`) is deliberately left as-is.** A coding-agent system prompt was the original scope of this PR, but a controlled brain100 A/B showed it **regresses `qwen3.5-4b` ~5pt** (91%→84–86%): the small brain over-investigates git/read tasks under the "coding agent" identity and spirals to the iteration cap. Four structural loop-guard attempts (exact-dedup, a brevity directive, a consecutive-nav cap, a no-progress cap) could not close the gap — the spiral kept finding paths around each guard (varied args, `bash`-git interleaving, permission-denied calls).

These visible strings never enter the system prompt, so they carry no behavioural risk. **Validated:** a visible-strings-only A/B scored **93% vs the secretary's 91%** on `qwen3.5-4b` — net neutral (the lone flip is the known nondeterministic large-file read; the rest is run-to-run noise).

## Stacking
Stacked on #134 (read-only git-tool dedup); the `conversation.rs` hunk here is that commit. Merge #134 first, or merge this and #134 resolves automatically.

Supersedes this PR's original full-persona scope. The dropped system-prompt experiment is preserved in the battery run logs (`runs/persona-ab-2026-06-22/`).