### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-21
+
 ### Changed
 
 - **The default build is now a lean, air-gapped coding agent.** The
@@ -20,6 +22,10 @@ bumps are non-breaking bugfixes only.
   setting. Opt back in with `cargo install claudette --features integrations`
   (or `cargo build --features integrations`). Previously `integrations` was on
   by default and you opted *out* via `--no-default-features`.
+- **Internal `secretary` → `agent` rename.** The library's public re-exports
+  were renamed to match the coding-agent identity (`AgentToolExecutor`,
+  `agent_system_prompt`, `agent_tools_json`, `run_agent`, …). Behaviour is
+  unchanged; this only affects code that consumed the crate as a library.
 
 ### Removed
 
@@ -2199,7 +2205,9 @@ Initial public release of Claudette as a standalone repository.
 
 ---
 
-[Unreleased]: https://github.com/mrdushidush/claudette/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/mrdushidush/claudette/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/mrdushidush/claudette/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/mrdushidush/claudette/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/mrdushidush/claudette/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/mrdushidush/claudette/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/mrdushidush/claudette/compare/v0.11.0...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "claudette"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudette"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts **v0.15.0** — the first release as a lean, air-gapped coding agent.

## What ships (all already merged to `main`)

- **`integrations` off by default** (#129) — `cargo install claudette` and the
  release binaries now contain **no cloud code** (Gmail/Calendar, Telegram,
  voice/tts, `--briefing`). Opt in with `--features integrations`. The air-gap
  is now structural, not a setting. *(Behavior-changing default → minor bump.)*
- **Removed the TradingView/`markets` scraper** (#127) and the **Space Invaders
  easter egg** (#128).
- **`secretary` → `agent` library rename** (#130) — renamed public re-exports;
  behaviour unchanged.
- Flaky `$HOME`-race test fix (#131).

## Release mechanics

- Version `0.14.0` → `0.15.0` (`Cargo.toml` + `Cargo.lock`).
- CHANGELOG: cut `[0.15.0]`, backfilled the missing `0.14.0` compare link.
- Tag `v0.15.0` after merge triggers `release.yml` (crates.io publish via OIDC
  + 5 prebuilt binaries + GH Release). The `tag-version-match` guard requires
  the bump to land first — hence this PR.

## Verified locally

- fmt clean; clippy `-D warnings` clean (lean **and** `--all-features`).
- Tests green both configs: lean **1034**+25+3, all-features **1121**+26+3.

## Not included (deliberately)

- The **persona system-prompt rewrite** is held (draft #132): a controlled
  brain100 A/B showed it regresses `qwen3.5-4b` 89% → 78% via git-task spirals.
  Revisit separately.
- The crate `description` still reads "…and personal assistant" — left as a
  follow-up to avoid scope-creeping the release.