### PR TITLE
docs: add a Roadmap section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ cargo build --release -p claudette
 
 ---
 
+## Roadmap
+
+Where Claudette is headed, and where help is most welcome:
+
+- **Broaden "Claudette Certified" coverage.** Battery-test more local models so `--doctor` can recommend the best fit for any GPU. Benching a model we haven't covered is the single most useful contribution — [no Rust required](https://github.com/mrdushidush/claudette/labels/good%20first%20issue).
+- **A leaner core.** Fold the overlapping edit tools into one canonical `edit_file` and keep trimming the dependency tree, for a smaller, faster single binary.
+- **Small-model reliability.** Keep hardening the agent loop against tool-call spirals so the 4B / 8 GB default stays dependable.
+- **More reach.** Editor integrations and deployment recipes (Pi / VPS / home-server) beyond today's VS Code extension and docker-compose.
+
+Newcomer-friendly tasks carry the [`good first issue`](https://github.com/mrdushidush/claudette/labels/good%20first%20issue) label; broader direction lives in the [issues](https://github.com/mrdushidush/claudette/issues). This is a roadmap, not a promise — priorities shift with what users hit.
+
+---
+
 ## Contributing
 
 Bugs and PRs welcome - see [CONTRIBUTING.md](CONTRIBUTING.md). Conventional Commits (`feat:`, `fix:`, `docs:`, …). Security issues go through the private advisory flow in [SECURITY.md](SECURITY.md), not a public issue. Contributions are dual-licensed MIT OR Apache-2.0.


### PR DESCRIPTION
Adds a short **## Roadmap** to the README, between Build-from-source and Contributing.

## Why
Wave G of the post-v0.15.0 cleanup, and a direct response to the traction read: visitors arrive (X drives real traffic) but **conversion has plateaued — 11★, 0 forks, 0 open issues**. A repo with no roadmap and no issues reads as "nothing to do / maybe dead" to a drive-by. A Roadmap gives direction and an on-ramp.

## What
Four honest, directional bullets — Certified-model coverage, leaner core (edit-tool consolidation + dep trimming), small-model reliability (the spiral-hardening line), more reach — plus links to the `good first issue` label and issues. Explicitly framed as "a roadmap, not a promise."

Pairs with a set of `good first issue`s opened alongside it (starting with "bench an uncovered local model — no Rust required").