### PR TITLE
deps: bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Bumps `quinn-proto` `0.11.14` → `0.11.15` in `Cargo.lock` to resolve **[RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185)** (high, 7.5) — *remote memory exhaustion from unbounded out-of-order stream reassembly*, published 2026-06-22.

## Why now

The advisory landed yesterday and immediately started failing the `cargo audit (RustSec advisories)` gate on **every** branch (including `main`), blocking all other PRs. `quinn-proto` is a stale transitive entry in the lockfile — `cargo tree -i quinn-proto` finds nothing reachable from the `claudette` crate across any feature/target — so this is a **lockfile-only patch bump with zero code or build impact**.

## Test

CI's own `cargo audit` job is the test: it goes green with the bump.