### PR TITLE
fix: ban production unwraps crate-wide (Wave F.1)

### DIFF
--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -15,6 +15,11 @@
 //! paths resolve without rewriting.
 
 #![recursion_limit = "256"]
+// Production code must not panic via `.unwrap()` — the binary builds with
+// `panic = "abort"`, so a stray unwrap is a hard process crash, not a catchable
+// error. `cfg_attr(not(test), …)` keeps the ban off `#[cfg(test)]` code, where
+// `.unwrap()` is idiomatic. (Wave F.1 — production unwrap audit.)
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 // ── Embedded runtime kernel ──────────────────────────────────────────────
 #[path = "runtime/compact.rs"]

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -17,6 +17,10 @@
 //! single-shot mode only saves when --resume is passed, so a one-off
 //! invocation can't clobber a long REPL conversation.
 
+// Production code must not panic via `.unwrap()` (the binary builds with
+// `panic = "abort"`). Test code is exempt. (Wave F.1 — production unwrap audit.)
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
+
 use std::process::ExitCode;
 
 use claudette::{

--- a/crates/claudette/src/scheduler.rs
+++ b/crates/claudette/src/scheduler.rs
@@ -270,7 +270,8 @@ fn parse_every(rest: &str, clock: &dyn Clock) -> Result<ParsedSchedule, String> 
         "day" => build_daily_from_time(t, clock),
         "weekday" => build_weekdays_from_time(t, clock),
         day if parse_weekday(day).is_some() => {
-            let dow = parse_weekday(day).unwrap();
+            let dow = parse_weekday(day)
+                .expect("match guard already verified parse_weekday(day).is_some()");
             build_weekly_from_time(dow, t, clock)
         }
         other => {

--- a/crates/claudette/src/tools/quality.rs
+++ b/crates/claudette/src/tools/quality.rs
@@ -175,9 +175,9 @@ fn invoke(framework: Framework, filter: Option<&str>, cwd: &Path) -> CommandResu
             // the project's package.json `test` script for everything else.
             let pattern = filter.map(|f| format!("--testNamePattern={f}"));
             let mut args: Vec<&str> = vec!["test"];
-            if pattern.is_some() {
+            if let Some(p) = pattern.as_deref() {
                 args.push("--");
-                args.push(pattern.as_deref().unwrap());
+                args.push(p);
             }
             run_command_with_timeout("npm", &args, TEST_TIMEOUT_SECS, Some(cwd))
         }


### PR DESCRIPTION
## Wave F.1 — production unwrap audit

`panic = "abort"` means any production `.unwrap()` is a hard process crash, not a catchable error. The goal doc flagged `tools/repomap.rs` (57) and `tools/file_ops.rs` (27) as the top offenders out of ~667 total — but those raw counts are dominated by test code.

Audited with clippy itself (`cargo clippy --lib/--bins -W clippy::unwrap_used`, which compiles **without** `cfg(test)` so the `#[cfg(test)] mod tests` blocks are excluded). The real production surface across the whole crate — lean, `--bins`, and `--all-features` — is **2 unwraps**:

| Site | Why it was safe | Fix |
|------|-----------------|-----|
| `scheduler.rs:273` | `parse_weekday(day).unwrap()` inside a match arm whose guard already checked `.is_some()` | `.expect()` documenting the invariant |
| `quality.rs:180` | `pattern.as_deref().unwrap()` guarded by `if pattern.is_some()` | restructured to `if let Some(p)` — unwrap gone |

Both fixes are behavior-identical.

### Lock it in
`#![cfg_attr(not(test), deny(clippy::unwrap_used))]` in `lib.rs` and `main.rs` bans **new** production unwraps crate-wide, while leaving `#[cfg(test)]` code (where `.unwrap()` is idiomatic) untouched. This crate-wide ban is affordable precisely because the production surface was already this clean — repomap/file_ops's unwraps are all in their test modules.

### Verification
`cargo fmt --all` + `cargo clippy --all-targets --no-deps -- -D warnings` (lean) + `--all-features` clippy all clean; `cargo test --lib --bins` green (1035 + 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)