### PR TITLE
refactor(config): canonical home_dir() resolver (Wave D1a)

### DIFF
--- a/crates/claudette/src/doctor.rs
+++ b/crates/claudette/src/doctor.rs
@@ -63,15 +63,8 @@ fn print_fix(cmd: &str) {
     eprintln!("      {} {}", theme::accent("↳ fix:"), theme::dim(cmd));
 }
 
-fn home_dir() -> PathBuf {
-    let raw = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(raw)
-}
-
 fn claudette_home() -> PathBuf {
-    home_dir().join(".claudette")
+    crate::env_config::home_dir().join(".claudette")
 }
 
 /// Entry point — runs every probe and returns the exit code for the CLI.

--- a/crates/claudette/src/env_config.rs
+++ b/crates/claudette/src/env_config.rs
@@ -1,0 +1,58 @@
+//! Centralized environment / configuration accessors for the claudette layer
+//! (Wave D).
+//!
+//! Goal: one source of truth for the env vars read across the crate, so call
+//! sites can't disagree on a default or a fallback chain. This starts with the
+//! home-directory resolver (previously duplicated verbatim in `doctor.rs` and
+//! `transcript.rs`); later D PRs fold in the `CLAUDETTE_WORKSPACE` resolver and
+//! the multi-site numeric/bool knobs.
+//!
+//! Named `env_config` (not `config`) because `config` is already the runtime
+//! settings-schema module (`runtime/config.rs`); these are unrelated concerns.
+//!
+//! Accessors read the environment on each call (rather than caching a struct at
+//! startup) on purpose: several knobs — notably `CLAUDETTE_WORKSPACE` — are
+//! mutated by tests at runtime and re-read mid-process.
+
+use std::path::PathBuf;
+
+/// Canonical home-directory resolver: `USERPROFILE` (Windows) then `HOME`
+/// (Unix), falling back to the current directory. Single source of truth so
+/// call sites can't disagree on the default.
+pub(crate) fn home_dir() -> PathBuf {
+    let raw = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_dir_prefers_userprofile_then_home() {
+        let _guard = crate::test_env_lock();
+        let prev_up = std::env::var("USERPROFILE").ok();
+        let prev_home = std::env::var("HOME").ok();
+
+        std::env::set_var("USERPROFILE", "/from/userprofile");
+        std::env::set_var("HOME", "/from/home");
+        assert_eq!(home_dir(), PathBuf::from("/from/userprofile"));
+
+        std::env::remove_var("USERPROFILE");
+        assert_eq!(home_dir(), PathBuf::from("/from/home"));
+
+        std::env::remove_var("HOME");
+        assert_eq!(home_dir(), PathBuf::from("."));
+
+        match prev_up {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -50,6 +50,7 @@ pub mod commands;
 pub mod diff_preview;
 pub mod doctor;
 pub mod egress;
+pub mod env_config;
 pub mod executor;
 pub mod firstrun;
 pub mod forge;

--- a/crates/claudette/src/transcript.rs
+++ b/crates/claudette/src/transcript.rs
@@ -35,19 +35,14 @@ use serde_json::{json, Value};
 /// uncapped `write_file` content would balloon the log.
 const MAX_RECORDED_INPUT_CHARS: usize = 2_000;
 
-fn home_dir() -> PathBuf {
-    let raw = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(raw)
-}
-
 pub(crate) fn trash_dir() -> PathBuf {
-    home_dir().join(".claudette").join("trash")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("trash")
 }
 
 pub(crate) fn transcript_path() -> PathBuf {
-    home_dir()
+    crate::env_config::home_dir()
         .join(".claudette")
         .join("transcript")
         .join("actions.jsonl")


### PR DESCRIPTION
## Wave D1a — single source of truth for the home directory

`doctor.rs` and `transcript.rs` each carried a **byte-identical** `home_dir()` (`USERPROFILE` → `HOME` → `"."`). This introduces one canonical resolver and deletes both copies, so call sites can't drift on the default. The turn-key starter for Wave D's config centralization.

### ⚠️ Module name deviation (please confirm)
The plan/card named this `src/config.rs`, but **`config` is already taken** — `#[path = "runtime/config.rs"] pub mod config` is the runtime settings-schema loader. I used **`env_config`** instead. It's where the follow-up D PRs (`CLAUDETTE_WORKSPACE` resolver, multi-site knob accessors) will live too. Rename freely in review if you'd prefer `paths`/`appcfg`/etc.

### Behavior
Identical. The accessor reads the environment on each call rather than caching at startup — Wave D guardrail #4, since some knobs (`CLAUDETTE_WORKSPACE`) are mutated by tests at runtime. Env-var names unchanged.

### Verification
`cargo fmt --all` + `cargo clippy --all-targets --no-deps -- -D warnings` (lean) + `--all-features` clippy all clean; new `env_config` unit test (precedence + fallback) and `transcript` tests green.

### Follow-ups (not in this PR)
D1b migrates the remaining ~20 HOME/USERPROFILE read sites (pre-classified — some pass `HOME` to a child process and must stay); D2 the `CLAUDETTE_WORKSPACE` resolver; D3 the typed knob accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)