### PR TITLE
feat(codet): off by default (Wave B, slice 1) — A/B-gate before merge

### DIFF
--- a/crates/claudette/examples/05-code-generation.md
+++ b/crates/claudette/examples/05-code-generation.md
@@ -131,17 +131,18 @@ Fails in tests do NOT re-enter the surgical fix loop — they're reported
 to the user as text. Tests are a quality signal, not a regeneration
 trigger.
 
-## 7. Disabling Codet
+## 7. Codet validation (opt-in)
 
-If the fix loop gets in your way (you just want the raw output, no
-validation):
+Codet's post-write validation (syntax check + auto-fix loop) is **off by
+default** — code writes/edits return the model's output directly. If you want
+the extra validation pass back, opt in:
 
 ```bash
-export CLAUDETTE_VALIDATE_CODE=false
+export CLAUDETTE_VALIDATE_CODE=true   # also accepts 1 / yes / on
 ```
 
-`generate_code` then writes the file and returns. No syntax check, no
-fix loop, no tests.
+With it enabled, `generate_code` (and `edit_file`/`write_file` on code files)
+runs a syntax check and, on failure, a fix loop before returning.
 
 ## 8. Known limitations
 

--- a/crates/claudette/src/codet.rs
+++ b/crates/claudette/src/codet.rs
@@ -62,14 +62,15 @@ pub fn coder_model() -> String {
     crate::model_config::active().coder.model
 }
 
-/// Whether code validation is enabled. Defaults to true; set
-/// `CLAUDETTE_VALIDATE_CODE=false` to disable (useful for debugging
-/// or when the coder model isn't pulled yet).
+/// Whether code validation is enabled. **Off by default (Wave B):** the codet
+/// post-edit second-pass (swap to the coder model, re-validate, auto-fix) added
+/// latency and, per the maintainer, no longer earns its keep on current models
+/// ("codet sucks now"). Opt back in with `CLAUDETTE_VALIDATE_CODE=true`
+/// (also `1` / `yes` / `on`); any other value — or unset — leaves it off.
 #[must_use]
 pub fn validation_enabled() -> bool {
-    std::env::var("CLAUDETTE_VALIDATE_CODE").map_or(true, |v| {
-        !matches!(v.to_lowercase().as_str(), "false" | "0" | "no" | "off")
-    })
+    std::env::var("CLAUDETTE_VALIDATE_CODE")
+        .is_ok_and(|v| matches!(v.to_lowercase().as_str(), "true" | "1" | "yes" | "on"))
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ Two layers enforce it: an HTTP-layer guard in the reqwest path checks the destin
 | `CLAUDETTE_CODER_MODEL` | `qwen3-coder:30b` | Coder model. Set to `qwen2.5-coder:14b` on RAM-constrained hosts. |
 | `CLAUDETTE_CODER_NUM_CTX` | `49152` | Coder context window. Drop to `16384` on 32 GB RAM boxes. |
 | `CLAUDETTE_CODER_NUM_PREDICT` | `12288` | Max output tokens the coder can emit in one call. |
-| `CLAUDETTE_VALIDATE_CODE` | `true` | Enable/disable Codet auto-validation after `generate_code`. |
+| `CLAUDETTE_VALIDATE_CODE` | `false` | Codet auto-validation after code writes/edits. Off by default; set `true`/`1`/`yes`/`on` to opt in. |
 
 ## Forge mode
 


### PR DESCRIPTION
## Wave B, slice 1 — off-gate codet by default

The codet post-write second pass (swap to the coder model, re-validate, run a fix loop) adds latency and, per the maintainer, no longer earns its keep on current models ("codet sucks now"). This flips the default: `validation_enabled()` now returns `false` unless `CLAUDETTE_VALIDATE_CODE` is set to `true`/`1`/`yes`/`on`.

This is the **lowest-risk slice** of Wave B (collapse the 5 edit tools → 1), landed first so the rest can build on it.

### Why it's safe code-wise
- The single gate is `validation_enabled()` (one caller: `validate_code_file`).
- No test asserted default-on; `file_ops` tests already use `.sh` fixtures, so the codet hook is a no-op there regardless.
- Docs updated: `configuration.md` default `true` → `false`; example 05 "Disabling Codet" → "Codet validation (opt-in)".

### ⚠️ BEHAVIORAL — needs your A/B gate
This is model-observable on code writes/edits, so per the goal's hard rule #8 it needs an **A/B battery gate on qwen3.5-4b AND qwen3.6-35b** before merge. I can't run that here (offline, no LM Studio). Recipe is in the goal doc; the OLD baseline (origin/main) is reusable.

### Verification (non-behavioral)
All 1035 lean lib tests pass; `cargo fmt --all` + `cargo clippy --all-targets --no-deps` (lean) + `--all-features` `-D warnings` clean.

### Remaining Wave B (follow-up)
Drop `apply_diff`/`apply_patch` from the model-visible schema and reroute `write_file`'s code path off `generate_code`, so `edit_file` is the one canonical edit tool. That's the architecturally-central part (`generate_code` routing) — kept separate so this clean slice can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)