### PR TITLE
refactor(run): extract recall_index submodule (Wave C2)

### DIFF
--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -39,6 +39,15 @@ pub use compaction_policy::{
 };
 pub(crate) use compaction_policy::{pick_compact_plan, CompactionOutcome};
 
+// Cross-session recall hooks (post-turn indexing + startup embed probe).
+// Extracted to `run/recall_index.rs` (Wave C2); re-exported so external
+// `run::X` callers keep resolving.
+mod recall_index;
+pub use recall_index::reprobe_recall;
+pub(crate) use recall_index::{
+    index_turn_for_recall, probe_recall_at_startup, recall_disabled, recall_index_allowed,
+};
+
 /// Resolve the model name the runtime is currently using. Sprint 14: this
 /// now delegates to `model_config::active().brain.model`, so once a
 /// `/preset` or `/brain` slash command mutates the active config, every
@@ -2377,73 +2386,6 @@ pub(crate) fn build_permission_policy() -> PermissionPolicy {
         .with_tool_requirement("mission_submit", DangerFullAccess)
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Cross-session recall hooks
-// ────────────────────────────────────────────────────────────────────────────
-
-/// Whether the post-turn recall indexing is disabled. Off-by-default
-/// privacy/perf escape hatch: `CLAUDETTE_RECALL_DISABLE=1`. Anything else
-/// (unset, "0", garbage) leaves indexing enabled.
-pub(crate) fn recall_disabled() -> bool {
-    matches!(
-        std::env::var("CLAUDETTE_RECALL_DISABLE").as_deref(),
-        Ok("1")
-    )
-}
-
-/// Sticky session-scoped flag: once recall indexing fails (e.g. LM Studio
-/// has no embed model loaded), every subsequent turn would re-fail with
-/// identical noise. After the first failure we set this and silently skip
-/// the indexing call until the process restarts. The user gets ONE warning
-/// at the first failure with instructions for fixing it (load the model
-/// or set `CLAUDETTE_RECALL_DISABLE=1`).
-static RECALL_INDEX_BROKEN: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-pub(crate) fn recall_index_allowed() -> bool {
-    !recall_disabled() && !RECALL_INDEX_BROKEN.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-pub(crate) fn mark_recall_index_broken() {
-    RECALL_INDEX_BROKEN.store(true, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// Clear the sticky `RECALL_INDEX_BROKEN` flag and re-run the startup
-/// embed probe. Exposed via the `/recall reprobe` slash command so the
-/// user can recover from a mid-session embed failure (e.g. LM Studio
-/// just loaded the embed model) without restarting the process. Returns
-/// the probe's own `Result` so the slash handler can format a success/
-/// failure message.
-pub fn reprobe_recall() -> Result<(), String> {
-    RECALL_INDEX_BROKEN.store(false, std::sync::atomic::Ordering::Relaxed);
-    crate::recall::probe()
-}
-
-/// Pre-flight the recall embedder by running a tiny embed call at REPL/TUI
-/// startup. On failure (e.g. LM Studio's "No models loaded" 400), set the
-/// sticky-disable flag and print one clear warn line. Silent on success so
-/// healthy startups stay quiet.
-///
-/// Called once per process. Honors `CLAUDETTE_RECALL_DISABLE=1` — if recall
-/// is already opted out, the probe is a no-op (we don't want to wake the
-/// store at all in privacy mode).
-pub(crate) fn probe_recall_at_startup() {
-    if recall_disabled() {
-        return;
-    }
-    if let Err(e) = crate::recall::probe() {
-        mark_recall_index_broken();
-        eprintln!(
-            "{} {}",
-            theme::warn(theme::WARN_GLYPH),
-            theme::warn(&format!(
-                "recall: probe failed — {e}. Indexing disabled for this session \
-                 (load an embed model and restart, or set CLAUDETTE_RECALL_DISABLE=1 to silence)."
-            ))
-        );
-    }
-}
-
 /// Render a one-line startup banner for the outcome of
 /// `try_rehydrate_active_mission()`. Quiet on `None` (no pointer file) so
 /// fresh sessions stay clean; loud on `Rehydrated` and `Cleared` so the
@@ -2477,124 +2419,6 @@ pub(crate) fn print_rehydrate_outcome(outcome: crate::missions::RehydrateOutcome
                 ))
             );
         }
-    }
-}
-
-/// Extract the (user, assistant) snippets for one turn — pure CPU,
-/// returns owned strings so callers can enqueue them onto the async
-/// indexer channel without holding a borrow on the runtime. Empty
-/// snippets stay empty (the indexer thread skips them).
-///
-/// Why we pass `user_input` directly instead of walking back to find the
-/// "latest user message": on retries, the runtime injects a synthetic
-/// nudge user-message into the session (see [`run_turn_with_retry`]). The
-/// raw `trimmed` REPL line is what the human actually typed, so we
-/// index that and skip the synthetic.
-fn extract_turn_snippets<C, T>(
-    user_input: &str,
-    runtime: &ConversationRuntime<C, T>,
-) -> (String, String)
-where
-    C: crate::ApiClient,
-    T: crate::ToolExecutor,
-{
-    use crate::ContentBlock;
-    let user_text = user_input.trim().to_string();
-    let mut asst_text = String::new();
-    if let Some(msg) = runtime
-        .session()
-        .messages
-        .iter()
-        .rev()
-        .find(|m| matches!(m.role, crate::MessageRole::Assistant))
-    {
-        for block in &msg.blocks {
-            if let ContentBlock::Text { text: t } = block {
-                if !asst_text.is_empty() {
-                    asst_text.push('\n');
-                }
-                asst_text.push_str(t);
-            }
-        }
-    }
-    (user_text, asst_text)
-}
-
-/// One job for the background recall indexer.
-struct IndexJob {
-    role: crate::recall::Role,
-    snippet: String,
-}
-
-/// Lazily-spawned mpsc channel for the recall indexer thread. The Sender
-/// is cloned on every push; the Receiver is owned by the one worker
-/// thread spawned on first use. Channel-close (last Sender dropped at
-/// process exit) terminates the thread cleanly.
-fn recall_index_sender() -> &'static std::sync::mpsc::Sender<IndexJob> {
-    use std::sync::OnceLock;
-    static SENDER: OnceLock<std::sync::mpsc::Sender<IndexJob>> = OnceLock::new();
-    SENDER.get_or_init(|| {
-        let (tx, rx) = std::sync::mpsc::channel::<IndexJob>();
-        std::thread::Builder::new()
-            .name("recall-indexer".to_string())
-            .spawn(move || {
-                // Drain until the channel closes. Each failed embed call
-                // sets the sticky-disable flag and logs once; subsequent
-                // jobs that slip through (in flight before the flag flipped)
-                // also fail-fast on the same flag check.
-                while let Ok(job) = rx.recv() {
-                    if !recall_index_allowed() {
-                        continue;
-                    }
-                    if job.snippet.trim().is_empty() {
-                        continue;
-                    }
-                    if let Err(e) = crate::recall::global_index(job.role, &job.snippet) {
-                        mark_recall_index_broken();
-                        eprintln!(
-                            "{} {}",
-                            theme::warn(theme::WARN_GLYPH),
-                            theme::warn(&format!(
-                                "recall: {e} — disabling recall indexing for this session \
-                                 (run /recall reprobe to retry after loading the embed model)"
-                            ))
-                        );
-                    }
-                }
-            })
-            .expect("spawn recall-indexer thread");
-        tx
-    })
-}
-
-/// Enqueue this turn's (user, assistant) snippets for async indexing.
-/// Cheap (one channel push per snippet) — the embed call itself happens
-/// on the background thread spawned by [`recall_index_sender`]. This is
-/// the foreground entry point the REPL/TUI/Telegram all hit after a
-/// successful turn.
-///
-/// Pre-2026-05-15 the embed call ran synchronously here, blocking the
-/// REPL ~100 ms typical and seconds on a cold embed model. Moving it
-/// behind a channel restores per-turn latency to what the user sees on
-/// the streamed brain text.
-pub(crate) fn index_turn_for_recall<C, T>(user_input: &str, runtime: &ConversationRuntime<C, T>)
-where
-    C: crate::ApiClient,
-    T: crate::ToolExecutor,
-{
-    let (user_text, asst_text) = extract_turn_snippets(user_input, runtime);
-    let tx = recall_index_sender();
-    if !user_text.is_empty() {
-        let _ = tx.send(IndexJob {
-            role: crate::recall::Role::User,
-            snippet: user_text,
-        });
-    }
-    if !asst_text.trim().is_empty() {
-        let _ = tx.send(IndexJob {
-            role: crate::recall::Role::Assistant,
-            snippet: asst_text,
-        });
     }
 }
 

--- a/crates/claudette/src/run/recall_index.rs
+++ b/crates/claudette/src/run/recall_index.rs
@@ -1,0 +1,190 @@
+//! Cross-session recall hooks (Wave C2 — split out of run.rs).
+//!
+//! The post-turn recall indexer (a background mpsc thread that embeds each
+//! turn's user/assistant snippets), the startup embed probe, and the sticky
+//! "indexing broke" flag. Foreground entry point: `index_turn_for_recall`; the
+//! runtime-mutating REPL calls it after each successful turn.
+
+use crate::theme;
+use crate::ConversationRuntime;
+
+/// Whether the post-turn recall indexing is disabled. Off-by-default
+/// privacy/perf escape hatch: `CLAUDETTE_RECALL_DISABLE=1`. Anything else
+/// (unset, "0", garbage) leaves indexing enabled.
+pub(crate) fn recall_disabled() -> bool {
+    matches!(
+        std::env::var("CLAUDETTE_RECALL_DISABLE").as_deref(),
+        Ok("1")
+    )
+}
+
+/// Sticky session-scoped flag: once recall indexing fails (e.g. LM Studio
+/// has no embed model loaded), every subsequent turn would re-fail with
+/// identical noise. After the first failure we set this and silently skip
+/// the indexing call until the process restarts. The user gets ONE warning
+/// at the first failure with instructions for fixing it (load the model
+/// or set `CLAUDETTE_RECALL_DISABLE=1`).
+static RECALL_INDEX_BROKEN: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub(crate) fn recall_index_allowed() -> bool {
+    !recall_disabled() && !RECALL_INDEX_BROKEN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+pub(crate) fn mark_recall_index_broken() {
+    RECALL_INDEX_BROKEN.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Clear the sticky `RECALL_INDEX_BROKEN` flag and re-run the startup
+/// embed probe. Exposed via the `/recall reprobe` slash command so the
+/// user can recover from a mid-session embed failure (e.g. LM Studio
+/// just loaded the embed model) without restarting the process. Returns
+/// the probe's own `Result` so the slash handler can format a success/
+/// failure message.
+pub fn reprobe_recall() -> Result<(), String> {
+    RECALL_INDEX_BROKEN.store(false, std::sync::atomic::Ordering::Relaxed);
+    crate::recall::probe()
+}
+
+/// Pre-flight the recall embedder by running a tiny embed call at REPL/TUI
+/// startup. On failure (e.g. LM Studio's "No models loaded" 400), set the
+/// sticky-disable flag and print one clear warn line. Silent on success so
+/// healthy startups stay quiet.
+///
+/// Called once per process. Honors `CLAUDETTE_RECALL_DISABLE=1` — if recall
+/// is already opted out, the probe is a no-op (we don't want to wake the
+/// store at all in privacy mode).
+pub(crate) fn probe_recall_at_startup() {
+    if recall_disabled() {
+        return;
+    }
+    if let Err(e) = crate::recall::probe() {
+        mark_recall_index_broken();
+        eprintln!(
+            "{} {}",
+            theme::warn(theme::WARN_GLYPH),
+            theme::warn(&format!(
+                "recall: probe failed — {e}. Indexing disabled for this session \
+                 (load an embed model and restart, or set CLAUDETTE_RECALL_DISABLE=1 to silence)."
+            ))
+        );
+    }
+}
+
+/// Extract the (user, assistant) snippets for one turn — pure CPU,
+/// returns owned strings so callers can enqueue them onto the async
+/// indexer channel without holding a borrow on the runtime. Empty
+/// snippets stay empty (the indexer thread skips them).
+///
+/// Why we pass `user_input` directly instead of walking back to find the
+/// "latest user message": on retries, the runtime injects a synthetic
+/// nudge user-message into the session (see [`run_turn_with_retry`]). The
+/// raw `trimmed` REPL line is what the human actually typed, so we
+/// index that and skip the synthetic.
+fn extract_turn_snippets<C, T>(
+    user_input: &str,
+    runtime: &ConversationRuntime<C, T>,
+) -> (String, String)
+where
+    C: crate::ApiClient,
+    T: crate::ToolExecutor,
+{
+    use crate::ContentBlock;
+    let user_text = user_input.trim().to_string();
+    let mut asst_text = String::new();
+    if let Some(msg) = runtime
+        .session()
+        .messages
+        .iter()
+        .rev()
+        .find(|m| matches!(m.role, crate::MessageRole::Assistant))
+    {
+        for block in &msg.blocks {
+            if let ContentBlock::Text { text: t } = block {
+                if !asst_text.is_empty() {
+                    asst_text.push('\n');
+                }
+                asst_text.push_str(t);
+            }
+        }
+    }
+    (user_text, asst_text)
+}
+
+/// One job for the background recall indexer.
+struct IndexJob {
+    role: crate::recall::Role,
+    snippet: String,
+}
+
+/// Lazily-spawned mpsc channel for the recall indexer thread. The Sender
+/// is cloned on every push; the Receiver is owned by the one worker
+/// thread spawned on first use. Channel-close (last Sender dropped at
+/// process exit) terminates the thread cleanly.
+fn recall_index_sender() -> &'static std::sync::mpsc::Sender<IndexJob> {
+    use std::sync::OnceLock;
+    static SENDER: OnceLock<std::sync::mpsc::Sender<IndexJob>> = OnceLock::new();
+    SENDER.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel::<IndexJob>();
+        std::thread::Builder::new()
+            .name("recall-indexer".to_string())
+            .spawn(move || {
+                // Drain until the channel closes. Each failed embed call
+                // sets the sticky-disable flag and logs once; subsequent
+                // jobs that slip through (in flight before the flag flipped)
+                // also fail-fast on the same flag check.
+                while let Ok(job) = rx.recv() {
+                    if !recall_index_allowed() {
+                        continue;
+                    }
+                    if job.snippet.trim().is_empty() {
+                        continue;
+                    }
+                    if let Err(e) = crate::recall::global_index(job.role, &job.snippet) {
+                        mark_recall_index_broken();
+                        eprintln!(
+                            "{} {}",
+                            theme::warn(theme::WARN_GLYPH),
+                            theme::warn(&format!(
+                                "recall: {e} — disabling recall indexing for this session \
+                                 (run /recall reprobe to retry after loading the embed model)"
+                            ))
+                        );
+                    }
+                }
+            })
+            .expect("spawn recall-indexer thread");
+        tx
+    })
+}
+
+/// Enqueue this turn's (user, assistant) snippets for async indexing.
+/// Cheap (one channel push per snippet) — the embed call itself happens
+/// on the background thread spawned by [`recall_index_sender`]. This is
+/// the foreground entry point the REPL/TUI/Telegram all hit after a
+/// successful turn.
+///
+/// Pre-2026-05-15 the embed call ran synchronously here, blocking the
+/// REPL ~100 ms typical and seconds on a cold embed model. Moving it
+/// behind a channel restores per-turn latency to what the user sees on
+/// the streamed brain text.
+pub(crate) fn index_turn_for_recall<C, T>(user_input: &str, runtime: &ConversationRuntime<C, T>)
+where
+    C: crate::ApiClient,
+    T: crate::ToolExecutor,
+{
+    let (user_text, asst_text) = extract_turn_snippets(user_input, runtime);
+    let tx = recall_index_sender();
+    if !user_text.is_empty() {
+        let _ = tx.send(IndexJob {
+            role: crate::recall::Role::User,
+            snippet: user_text,
+        });
+    }
+    if !asst_text.trim().is_empty() {
+        let _ = tx.send(IndexJob {
+            role: crate::recall::Role::Assistant,
+            snippet: asst_text,
+        });
+    }
+}


### PR DESCRIPTION
## Wave C2 — second cut of the run.rs split

**Stacked on #145 (C1)** — base is `c1-compaction-policy`, so this diff shows only C2. (GitHub auto-retargets to `main` when C1 merges.)

Moves the cross-session **recall cluster** into `src/run/recall_index.rs` (run.rs 3,619 → **3,436**): `recall_disabled`, `RECALL_INDEX_BROKEN`, `recall_index_allowed`, `mark_recall_index_broken`, `reprobe_recall`, `probe_recall_at_startup`, `extract_turn_snippets`, `IndexJob`, `recall_index_sender`, `index_turn_for_recall`.

### Two-region move
`print_rehydrate_outcome` sits *in the middle* of the cluster but is mission-rehydrate code, not recall — it **stays** in run.rs (and remains an external `run::` item). So this lifts two regions (recall-control + recall-indexing) around it. (The codev plan's original 6-item C2 list missed this; corrected there.)

### Behavior-identical — pure code movement (no A/B)
- Re-exports preserve every `run::X` path: `pub` for `reprobe_recall`; `pub(crate)` for `index_turn_for_recall` / `probe_recall_at_startup` / `recall_disabled` / `recall_index_allowed` (used by commands.rs, tui_worker, and run.rs's own REPL).
- Internal-only items (`extract_turn_snippets`, `recall_index_sender`, `IndexJob`, `mark_recall_index_broken`, `RECALL_INDEX_BROKEN`) stay private to the submodule.
- Submodule needs only `use crate::theme` + `use crate::ConversationRuntime`; the generic indexing fns (`<C, T>`) carry their bounds verbatim.

### Verification
Whole-crate `cargo build` green; `cargo fmt --all` + clippy (lean + `--all-features`) `-D warnings` clean; `cargo test --lib` **1035 passed** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)