### PR TITLE
refactor(clippy): drop crate-wide too_many_lines/args allows (Wave C-final)

### DIFF
--- a/crates/claudette/Cargo.toml
+++ b/crates/claudette/Cargo.toml
@@ -117,7 +117,6 @@ pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 missing_panics_doc = "allow"
 missing_errors_doc = "allow"
-too_many_lines = "allow"
 cast_possible_truncation = "allow"
 cast_sign_loss = "allow"
 cast_precision_loss = "allow"
@@ -136,4 +135,3 @@ match_same_arms = "allow"
 uninlined_format_args = "allow"
 # Upstream (forked-runtime) style:
 doc_markdown = "allow"
-too_many_arguments = "allow"

--- a/crates/claudette/examples/brownfield_abcc.rs
+++ b/crates/claudette/examples/brownfield_abcc.rs
@@ -55,6 +55,7 @@ fn run(name: &str, input: &str) {
 /// HTTPS — public clone, no auth needed.
 const NEEDS_TOKEN: &[&str] = &["list", "body", "pr", "status", "mission-submit", "pipeline"];
 
+#[allow(clippy::too_many_lines)]
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let cmd = args.first().map_or("list", String::as_str);

--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -1010,6 +1010,7 @@ impl OllamaApiClient {
     /// spec.)
     ///
     /// Generic over `BufRead` so the unit tests can pass a `Cursor` directly.
+    #[allow(clippy::too_many_lines)]
     fn consume_sse_lines<R: BufRead>(
         &self,
         reader: R,

--- a/crates/claudette/src/codet.rs
+++ b/crates/claudette/src/codet.rs
@@ -443,6 +443,7 @@ fn rust_syntax_check_ok(result: &CommandResult) -> bool {
 // Python validation
 // ────────────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 fn validate_python(path: &Path, references: &[ReferenceFile]) -> CodetResult {
     let mut fixes_applied: u32 = 0;
     let mut attempts_made: u32 = 0;
@@ -848,6 +849,7 @@ struct Patch {
     replace: String,
 }
 
+#[allow(clippy::too_many_lines)]
 fn try_fix_loop(
     path: &Path,
     original_content: &str,

--- a/crates/claudette/src/commands.rs
+++ b/crates/claudette/src/commands.rs
@@ -288,6 +288,7 @@ fn parse_sessions_subcommand(arg: Option<&str>) -> SlashCommand {
 /// `rebuild` is the callback that produces a fresh runtime from a session;
 /// it's used by commands that swap the conversation context (`/clear`,
 /// `/load`, `/reload`, `/compact`, `/preset`, `/brain`).
+#[allow(clippy::too_many_lines)]
 pub fn dispatch_slash_command<C, T, W, R>(
     cmd: SlashCommand,
     runtime: &mut ConversationRuntime<C, T>,
@@ -437,6 +438,7 @@ where
 
 // === Handlers ================================================================
 
+#[allow(clippy::too_many_lines)]
 fn print_help(out: &mut impl Write) {
     // Grouped by purpose so the user can scan visually instead of skimming
     // a 23-line flat list. The first section header doubles as the title.

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -173,6 +173,7 @@ DOCS:
     SECURITY.md            Vulnerability reporting
 ";
 
+#[allow(clippy::too_many_lines)]
 fn main() -> ExitCode {
     // Load env vars from .env files. ONLY the canonical ~/.claudette/.env
     // is auto-loaded — we explicitly do NOT walk CWD or its parents, because

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -459,6 +459,7 @@ fn forge_phase0_preflight(mission: &crate::missions::Mission) -> Result<Option<(
 /// turns are part of the same session log when `--resume` was passed; a
 /// one-off forge invocation without `--resume` doesn't clobber the REPL
 /// session.
+#[allow(clippy::too_many_lines)]
 pub fn run_forge_mission(user_input: &str, opts: SessionOptions) -> Result<TurnSummary> {
     // ── Auto-bootstrap ──────────────────────────────────────────────────
     // If no mission is active, try to bootstrap an ephemeral one rooted at

--- a/crates/claudette/src/run/repl.rs
+++ b/crates/claudette/src/run/repl.rs
@@ -18,6 +18,7 @@ use crate::theme;
 /// `commands.rs`) and never reach the model. Exits on EOF, the `/exit`
 /// command, or the bare words `exit`/`quit`/`:q` (kept for muscle memory).
 /// Always autosaves after every model turn when `opts.autosave` is set.
+#[allow(clippy::too_many_lines)]
 pub fn run_agent_repl(opts: SessionOptions) -> Result<()> {
     theme::init();
 

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -317,6 +317,7 @@ where
     /// Same as [`Self::run_turn`] but the user message also carries N image
     /// attachments (`(media_type, base64_data)` pairs). Used by the TUI's
     /// clipboard-paste / `@path` flow.
+    #[allow(clippy::too_many_lines)]
     pub fn run_turn_with_images(
         &mut self,
         user_input: impl Into<String>,

--- a/crates/claudette/src/runtime/hooks.rs
+++ b/crates/claudette/src/runtime/hooks.rs
@@ -149,6 +149,7 @@ impl HookRunner {
         HookRunResult::allow(messages)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn run_command(
         &self,
         command: &str,

--- a/crates/claudette/src/scheduler.rs
+++ b/crates/claudette/src/scheduler.rs
@@ -468,6 +468,7 @@ impl Scheduler {
     /// Load entries from `path`, apply per-entry catch-up policy, return a
     /// vector of immediate firings the consumer should dispatch before the
     /// next poll. Creates an empty jsonl if the file doesn't exist.
+    #[allow(clippy::too_many_lines)]
     pub fn load(path: PathBuf, clock: Arc<dyn Clock>) -> Result<(Self, Vec<Firing>), String> {
         let mut scheduler = Self::new(path.clone(), clock.clone());
         let raw = match std::fs::read_to_string(&path) {

--- a/crates/claudette/src/security_review.rs
+++ b/crates/claudette/src/security_review.rs
@@ -300,6 +300,7 @@ fn javascript_url(lower: &str) -> bool {
 /// Apply every rule to a single added line. Returns `(severity, rule, message)`
 /// for each match. Case-sensitive where the construct is (JS APIs), with a
 /// lowercased copy for keyword checks.
+#[allow(clippy::too_many_lines)]
 fn classify(line: &str) -> Vec<(Severity, &'static str, &'static str)> {
     use Severity::{High, Medium};
     let l = line;

--- a/crates/claudette/src/telegram_mode.rs
+++ b/crates/claudette/src/telegram_mode.rs
@@ -89,6 +89,7 @@ const PARAGRAPH_MERGE_THRESHOLD: usize = 80;
 /// function returns `Err` early otherwise — **default-deny** prevents a
 /// "ran the bot without thinking and exposed it to every username-guesser"
 /// footgun.
+#[allow(clippy::too_many_lines)]
 pub fn run_telegram_bot(
     allowed_chat_ids: Vec<i64>,
     allow_any_chat: bool,

--- a/crates/claudette/src/tools/git.rs
+++ b/crates/claudette/src/tools/git.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 
 use crate::test_runner::run_command_with_timeout;
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn schemas() -> Vec<Value> {
     vec![
         json!({

--- a/crates/claudette/src/tools/github.rs
+++ b/crates/claudette/src/tools/github.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 
 use super::{external_http_client, extract_str, parse_json_input, wrap_untrusted};
 
+#[allow(clippy::too_many_lines)]
 pub(super) fn schemas() -> Vec<Value> {
     vec![
         json!({
@@ -696,6 +697,7 @@ fn run_gh_pr_status(input: &str) -> Result<String, String> {
 /// last 20 issue-comments + check-runs summary in one tool call. Folds
 /// the gh_pr_status use case (everything that tool returned is in here
 /// too, just under different keys for clarity).
+#[allow(clippy::too_many_lines)]
 fn run_gh_pr_view(input: &str) -> Result<String, String> {
     let v = parse_json_input(input, "gh_pr_view")?;
     let owner = extract_str(&v, "owner", "gh_pr_view")?;

--- a/crates/claudette/src/tools/mission.rs
+++ b/crates/claudette/src/tools/mission.rs
@@ -401,6 +401,7 @@ fn run_mission_attach(input: &str) -> Result<String, String> {
 
 // ─── mission_submit (capstone) ───────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 fn run_mission_submit(input: &str) -> Result<String, String> {
     // Submitting pushes to origin and opens a PR via the GitHub API — both
     // are network egress. Refuse up front under offline mode rather than doing

--- a/crates/claudette/src/tools/notes.rs
+++ b/crates/claudette/src/tools/notes.rs
@@ -195,6 +195,7 @@ fn run_note_create(input: &str) -> Result<String, String> {
     Ok(result.to_string())
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_note_list(input: &str) -> Result<String, String> {
     let v: Value = serde_json::from_str(input).unwrap_or(json!({}));
     let filter_tag = v

--- a/crates/claudette/src/tools/repomap.rs
+++ b/crates/claudette/src/tools/repomap.rs
@@ -95,6 +95,7 @@ struct Symbol {
     sig: String,
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_repo_map(input: &str) -> Result<String, String> {
     let v: Value = serde_json::from_str(input)
         .map_err(|e| format!("repo_map: invalid JSON ({e}): {input}"))?;

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -204,6 +204,7 @@ fn run_glob_search(input: &str) -> Result<String, String> {
     .to_string())
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_grep_search(input: &str) -> Result<String, String> {
     let v: Value = serde_json::from_str(input)
         .map_err(|e| format!("grep_search: invalid JSON ({e}): {input}"))?;

--- a/crates/claudette/src/transcript.rs
+++ b/crates/claudette/src/transcript.rs
@@ -162,6 +162,7 @@ pub fn record(tool: &str, input: &str, undo: Option<Value>) {
 /// (b) hasn't already been undone. Restores the trashed/pre-image file back
 /// to its original location (the trash copy is **kept** — recoverability
 /// bias), appends an `undo` entry, and returns a human-readable summary.
+#[allow(clippy::too_many_lines)]
 pub fn undo_last() -> Result<String, String> {
     let path = transcript_path();
     let raw = fs::read_to_string(&path)

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -275,6 +275,7 @@ impl Default for App {
 }
 
 impl App {
+    #[allow(clippy::too_many_lines)]
     fn handle_tui_event(&mut self, event: TuiEvent) {
         match event {
             TuiEvent::Token(delta) => self.streaming_text.push_str(&delta),
@@ -721,6 +722,7 @@ pub fn run_tui(session: Session) -> Result<()> {
 // Event loop
 // ─────────────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     tui_rx: &Receiver<TuiEvent>,

--- a/crates/claudette/src/tui/render.rs
+++ b/crates/claudette/src/tui/render.rs
@@ -589,6 +589,7 @@ fn render_todos_tab(f: &mut Frame, app: &App, area: Rect) {
 // HW tab
 // ─────────────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_lines)]
 fn render_hw_tab(f: &mut Frame, app: &App, area: Rect) {
     let hw = &app.hw;
     let mut lines: Vec<Line> = Vec::new();


### PR DESCRIPTION
## Wave C-final — kill the blanket clippy allows

**Stacked on #150 (C5).** Now that run.rs is split (3,955 → 625), this removes the crate-wide `too_many_lines = "allow"` and `too_many_arguments = "allow"` from `Cargo.toml [lints.clippy]`.

The crate's genuinely-long functions (TUI renderers, tool dispatchers, parsers, the forge loop, `run_agent_repl`, `run_forge_mission`) now each carry an explicit **local** `#[allow(clippy::too_many_lines)]` — **25 sites across 21 files** — plus one `#[allow(clippy::too_many_arguments)]` on the runtime hooks builder (8 args).

**Why:** the blanket silently absorbed *every* oversized function, including new ones. With it gone, a function creeping past 100 lines now fires the lint and forces a conscious split-or-allow decision. The existing long functions are acknowledged explicitly rather than hidden.

Pure lint-config change — no code behavior. `cargo fmt --all` + clippy `--all-targets` (lean + `--all-features`) `-D warnings` clean; `cargo test --lib` **1035 passed**.

### This completes Wave C 🎉
C1–C6 + C-final: **run.rs 3,955 → 625 lines (−84%)**, now a thin assembler over `run/` submodules (`compaction_policy`, `recall_index`, `cli_prompter`, `runtime_build`, `repl`, `forge_run`), every `run::X` path preserved via re-export, and the blanket size-lint allow retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)