### PR TITLE
fix(egress): refuse run_tests/diagnostics under offline mode (roast H1)

### DIFF
--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -47,9 +47,11 @@ pub const BLOCK_PREFIX: &str = "blocked by offline mode (--offline / CLAUDETTE_O
 
 /// Canonical registry of every tool whose normal operation reaches the network
 /// and is therefore gated under offline mode — plus the raw-shell escape hatch
-/// (`bash` / `bash_background`), which is *not* network-by-default but is
-/// refused wholesale because its egress is unguardable. All are gated by
-/// [`guard`] / [`guard_subprocess`] / the bash offline-refusal. This is the
+/// (`bash` / `bash_background`) and the build/test toolchain runners
+/// (`run_tests` / `diagnostics`), which are *not* network-by-default but are
+/// refused wholesale because their egress is unguardable (arbitrary shell /
+/// build-script / test-code execution). All are gated by [`guard`] /
+/// [`guard_subprocess`] / the bash + toolchain offline-refusals. This is the
 /// single source of truth the no-egress integration test
 /// (`tests/offline_egress.rs`) iterates: it drives each tool through
 /// `dispatch_tool` with `CLAUDETTE_OFFLINE=1` and asserts every one refuses
@@ -98,6 +100,14 @@ pub const NET_TOOLS: &[&str] = &[
     // (roast 2026-06-21, Wave 1.1)
     "bash",
     "bash_background",
+    // Build/test toolchain runners. `run_tests` / `diagnostics` shell out to
+    // cargo / npm / pytest / go, which compile and execute arbitrary build
+    // scripts, test bodies, and proc-macros and may fetch uncached dependencies
+    // from a package registry — the SAME unguardable egress vector as `bash`
+    // (the guard cannot inspect what a build script does). Refused wholesale
+    // under offline mode. (roast 2026-06-30, H1)
+    "run_tests",
+    "diagnostics",
 ];
 
 /// Network-reaching tools that exist **only** in an `integrations` build:

--- a/crates/claudette/src/tools/quality.rs
+++ b/crates/claudette/src/tools/quality.rs
@@ -125,7 +125,42 @@ fn detect_framework(start: &Path) -> Option<Framework> {
     None
 }
 
+/// Roast 2026-06-30 (H1): refuse the build/test toolchain runners under
+/// `--offline`. `run_tests` / `diagnostics` shell out to cargo/npm/pytest/go,
+/// which compile and execute arbitrary build scripts, test bodies, and
+/// proc-macros and may fetch uncached dependencies over the network — the SAME
+/// unguardable egress vector `bash` is refused for (the air-gap guard cannot
+/// inspect what a build script does). The only honest offline posture is to
+/// refuse the whole tool. Returns the uniform [`crate::egress::BLOCK_PREFIX`]
+/// refusal so the air-gap proof (`tests/offline_egress.rs`) recognises it.
+///
+/// `offline` is passed in (rather than read from the env here) so the policy is
+/// unit-testable without mutating process-global state; production call sites
+/// pass [`crate::egress::is_offline`] and call this *before* parsing input so
+/// the refusal is argument-independent and fires before any subprocess spawn.
+fn refuse_toolchain_under_offline(
+    tool: &str,
+    toolchain: &str,
+    offline: bool,
+) -> Result<(), String> {
+    if offline {
+        return Err(format!(
+            "{}: {tool} is disabled under offline mode — it runs {toolchain}, which compiles \
+             and executes arbitrary build scripts, test code, and proc-macros and may fetch \
+             dependencies over the network in ways the air-gap guard cannot inspect. Disable \
+             offline mode to run the project toolchain.",
+            crate::egress::BLOCK_PREFIX
+        ));
+    }
+    Ok(())
+}
+
 fn run_tests(input: &str) -> Result<String, String> {
+    refuse_toolchain_under_offline(
+        "run_tests",
+        "the project test suite (cargo/npm/pytest/go test)",
+        crate::egress::is_offline(),
+    )?;
     let v = parse_json_input(input, "run_tests")?;
     let cwd = crate::missions::active_cwd();
     let requested = v.get("framework").and_then(Value::as_str).unwrap_or("auto");
@@ -281,6 +316,24 @@ impl BuildTestOutcome {
 /// return a [`BuildTestOutcome`]. `timeout_secs` bounds *each* sub-step.
 /// Never panics; an undetectable framework yields `ran=false`.
 pub(crate) fn run_build_and_tests(dir: &Path, timeout_secs: u64) -> BuildTestOutcome {
+    // Air-gap (roast 2026-06-30, H1): the build/test toolchain executes
+    // arbitrary build scripts and test code and may fetch dependencies — the
+    // same unguardable egress vector the dispatched run_tests/diagnostics tools
+    // are refused for. Under offline mode the forge Verifier skips it rather
+    // than run the toolchain. Advisory (build_ok/tests_ok stay None), so it
+    // never flips a pass to a hard fail — verification is simply incomplete.
+    if crate::egress::is_offline() {
+        return BuildTestOutcome {
+            ran: false,
+            build_ok: None,
+            tests_ok: None,
+            summary: "build+test verification skipped under offline mode \
+                      (--offline / CLAUDETTE_OFFLINE) — the project toolchain executes \
+                      arbitrary build/test code and is not run while air-gapped"
+                .to_string(),
+            framework: "none",
+        };
+    }
     let Some(framework) = detect_framework(dir) else {
         return BuildTestOutcome {
             ran: false,
@@ -523,6 +576,11 @@ fn detect_diag_tool(start: &Path) -> Option<DiagTool> {
 }
 
 fn run_diagnostics(input: &str) -> Result<String, String> {
+    refuse_toolchain_under_offline(
+        "diagnostics",
+        "the project typechecker/linter (cargo check/clippy, tsc, mypy, ruff)",
+        crate::egress::is_offline(),
+    )?;
     let v = parse_json_input(input, "diagnostics")?;
     let cwd = crate::missions::active_cwd();
     let requested = v.get("tool").and_then(Value::as_str).unwrap_or("auto");
@@ -996,6 +1054,28 @@ mod tests {
             .filter_map(|v| v.pointer("/function/name").and_then(Value::as_str))
             .collect();
         assert_eq!(names, ["run_tests", "diagnostics"]);
+    }
+
+    #[test]
+    fn refuse_toolchain_under_offline_blocks_only_when_offline() {
+        // Off → no-op, the tool proceeds.
+        assert!(
+            refuse_toolchain_under_offline("run_tests", "the test suite", false).is_ok(),
+            "offline OFF must not block the toolchain runners"
+        );
+        // On → refused with the uniform air-gap prefix the proof asserts on.
+        let err = refuse_toolchain_under_offline("run_tests", "the test suite", true).unwrap_err();
+        assert!(
+            err.starts_with(crate::egress::BLOCK_PREFIX),
+            "must use the shared air-gap prefix: {err}"
+        );
+        assert!(err.contains("run_tests"), "names the refused tool: {err}");
+        assert!(
+            err.contains("offline mode"),
+            "explains why it was refused: {err}"
+        );
+        // diagnostics shares the same policy.
+        assert!(refuse_toolchain_under_offline("diagnostics", "the linter", true).is_err());
     }
 
     #[test]

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -163,10 +163,14 @@ pub(super) fn dispatch(name: &str, input: &str) -> Option<Result<String, String>
 /// UNGUARDABLE egress vector, since a curl/scp/ssh/python/nc denylist leaks by
 /// construction — so the only honest air-gap posture is to refuse the whole
 /// tool while offline rather than pretend a substring filter closes the hole.
-/// The structured tools (edit_file, search, git_* locals, the build/test
-/// runners) keep coding offline-capable. Returns the uniform `BLOCK_PREFIX`
-/// refusal so the air-gap proof (`tests/offline_egress.rs`) recognises it.
-/// Called *before* input parsing so a refusal fires regardless of arguments.
+/// The structured tools (edit_file, search, git_* locals) keep coding
+/// offline-capable; the build/test runners (`run_tests` / `diagnostics`) are
+/// refused too, for the same unguardable-egress reason — they execute arbitrary
+/// build scripts / test code (roast 2026-06-30, H1; see
+/// `quality::refuse_toolchain_under_offline`). Returns the uniform
+/// `BLOCK_PREFIX` refusal so the air-gap proof (`tests/offline_egress.rs`)
+/// recognises it. Called *before* input parsing so a refusal fires regardless
+/// of arguments.
 fn refuse_bash_under_offline(tool: &str) -> Result<(), String> {
     if crate::egress::is_offline() {
         return Err(format!(


### PR DESCRIPTION
## Roast finding H1 (HIGH, confirmed)

`--offline` blocks `bash` as "unguardable egress" but leaves `run_tests`/`diagnostics` wide open. Both shell out to `cargo`/`npm`/`pytest`/`go`, which **compile and execute arbitrary `build.rs` / test bodies / proc-macros** and fetch uncached dependencies from a package registry — the *identical* unguardable vector `bash` is refused for. A model that can `write_file` (allowed offline) could plant a socket-opening test and call `run_tests` to exfiltrate, breaking the air-gap guarantee the product leads with. `egress.rs` `NET_TOOLS` omitted both, so the "CI-proven zero-egress" proof never exercised them.

## Fix

- **Refuse `run_tests` + `diagnostics` wholesale under offline mode**, matching the existing `bash` posture (`quality::refuse_toolchain_under_offline`, fired *before* input parsing / framework detection so it's argument-independent and never spawns a subprocess).
- **Add both to `egress::NET_TOOLS`** so `tests/offline_egress.rs` drives them through `dispatch_tool` under `CLAUDETTE_OFFLINE=1` and asserts the uniform `BLOCK_PREFIX` refusal — turning the closed hole into a CI-proven guarantee.
- **Skip the forge Verifier's internal `run_build_and_tests` gate under offline** (advisory — `build_ok`/`tests_ok` stay `None`, so it never flips a pass to a hard fail; verification is simply marked incomplete).
- Fixed the now-false comment in `shell.rs` ("the build/test runners keep coding offline-capable").
- The refusal policy takes `offline: bool` so it's unit-tested without mutating process-global env (deliberately avoids adding to the disjoint-env-lock flakiness flagged as roast finding F).

## Tests

- `tests/offline_egress.rs` — `every_net_tool_refuses_under_offline` now covers `run_tests`/`diagnostics`; registry-consistency test confirms they're in the advertised schema. ✅
- New `refuse_toolchain_under_offline_blocks_only_when_offline` unit test. ✅
- Full suite: **1069 pass, 0 fail**; `cargo fmt` clean; `cargo clippy --all-targets --all-features -D warnings` clean.

## ⚠️ Behavioral note for the merge decision

This is a deliberate **posture change**: a genuinely air-gapped user can no longer run `run_tests`/`diagnostics` while `--offline` is set (they'd disable offline mode to run the toolchain). That matches the honest "we can't inspect what a build script does" stance already applied to `bash`. The alternative — running `cargo --offline --frozen` + network sandboxing — only closes the dependency-fetch half and can't contain arbitrary build/test code cross-platform, so refusal is the consistent choice. Flagging so you can veto if you'd rather keep offline test-running.

Part of the 2026-06-30 roast remediation (sprint 1: air-gap honesty). Report: `runs/roast-2026-06-30/REPORT.md`.