### PR TITLE
fix(shell): harden bash_background job files (0600 + redaction)

### DIFF
--- a/crates/claudette/src/secrets.rs
+++ b/crates/claudette/src/secrets.rs
@@ -58,6 +58,34 @@ pub(crate) fn write_secret_file(path: &Path, contents: &[u8]) -> std::io::Result
     }
 }
 
+/// Create (or truncate) a file restricted to the current user and return the
+/// open write handle. Unix: `OpenOptions::mode(0o600)` so the restrictive mode
+/// comes from the create syscall (no umask race). Windows: create then
+/// best-effort `icacls` tighten (mirrors [`write_secret_file`]).
+///
+/// Use this — rather than [`write_secret_file`] — when a *child process* writes
+/// the bytes through the returned handle (e.g. the background-job stdout/stderr
+/// capture files), so we hold the file but not its contents.
+pub(crate) fn create_private_file(path: &Path) -> std::io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::os::unix::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        let f = std::fs::File::create(path)?;
+        harden_windows_acl(path);
+        Ok(f)
+    }
+}
+
 /// Restrict a freshly-written secret file to the current user on Windows via
 /// the built-in `icacls`: remove inherited ACEs (`/inheritance:r`) and grant
 /// the current account Full control (`/grant:r`). The crate forbids
@@ -259,6 +287,36 @@ mod tests {
         assert!(path.ends_with("github.token"));
         let path = secret_file_path("TELEGRAM");
         assert!(path.ends_with("telegram.token"));
+    }
+
+    #[test]
+    fn create_private_file_writes_and_truncates() {
+        use std::io::Write;
+        let path = std::env::temp_dir().join(format!(
+            "claudette-priv-{}-{}.tmp",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos())
+        ));
+        {
+            let mut f = create_private_file(&path).expect("create");
+            f.write_all(b"first-longer-contents").expect("write");
+        }
+        // A second create truncates (no stale bytes leak through).
+        {
+            let mut f = create_private_file(&path).expect("recreate");
+            f.write_all(b"x").expect("write");
+        }
+        let body = std::fs::read_to_string(&path).unwrap_or_default();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "must be owner read/write only, got {mode:o}");
+        }
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(body, "x", "create must truncate prior contents");
     }
 
     #[test]

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -10,9 +10,11 @@
 //! are auto-allowed.
 //!
 //! Background-job storage layout (`~/.claudette/jobs/`):
-//!   <id>.meta — JSON {job_id, pid, cmd, cwd, started_at}
-//!   <id>.out  — captured stdout
-//!   <id>.err  — captured stderr
+//!   <id>.meta — JSON {job_id, pid, cmd, cwd, started_at}. `cmd` is redacted
+//!               before it is written (roast 2026-06-30); the file is created
+//!               0600 / icacls-tightened like the secret store.
+//!   <id>.out  — captured stdout (0600). The child writes raw bytes; `bash_tail`
+//!   <id>.err  — captured stderr (0600). redacts each line on the way back out.
 //!   <id>.done — written by the reaper thread on child exit:
 //!               first line = exit code, second line = ended_at RFC3339.
 //!   No index.json — listings derive from <id>.meta globs at query time,
@@ -527,9 +529,14 @@ fn run_bash_background(input: &str) -> Result<String, String> {
     let job_id = new_job_id();
     let (meta_path, out_path, err_path, done_path) = job_paths(&job_id);
 
-    let out_file = fs::File::create(&out_path)
+    // 0600 on Unix / icacls-tightened on Windows (roast 2026-06-30): the
+    // child writes raw stdout/stderr here — a leaked AWS key in `env` output or
+    // a token in a build log would otherwise land under the default umask,
+    // readable by co-tenant users. The `bash_tail` reader redacts on the way
+    // back out; this closes the at-rest half.
+    let out_file = crate::secrets::create_private_file(&out_path)
         .map_err(|e| format!("bash_background: open {} failed: {e}", out_path.display()))?;
-    let err_file = fs::File::create(&err_path)
+    let err_file = crate::secrets::create_private_file(&err_path)
         .map_err(|e| format!("bash_background: open {} failed: {e}", err_path.display()))?;
 
     // Same platform-specific shell selection as the sync `bash` tool —
@@ -558,13 +565,20 @@ fn run_bash_background(input: &str) -> Result<String, String> {
     let meta = JobMeta {
         job_id: job_id.clone(),
         pid,
-        cmd: command.to_string(),
+        // Redact before persisting (roast 2026-06-30): the command can carry a
+        // PAT (`git push https://x-access-token:<PAT>@…`) and bash_status echoes
+        // meta.cmd back to the model. Mask it at rest and on the way out.
+        cmd: crate::redact::redact(command).into_owned(),
         cwd: cwd.display().to_string(),
         started_at: chrono::Local::now().to_rfc3339(),
     };
-    fs::write(
+    // 0600 / icacls — the meta file holds the (now redacted) command and pid;
+    // keep it owner-only like the secret store rather than umask-default.
+    crate::secrets::write_secret_file(
         &meta_path,
-        serde_json::to_string_pretty(&meta).unwrap_or_default(),
+        serde_json::to_string_pretty(&meta)
+            .unwrap_or_default()
+            .as_bytes(),
     )
     .map_err(|e| format!("bash_background: write meta failed: {e}"))?;
 
@@ -690,12 +704,54 @@ fn tail_file(path: &Path, n: usize) -> Vec<String> {
     let s = fs::read_to_string(path).unwrap_or_default();
     let all: Vec<&str> = s.lines().collect();
     let start = all.len().saturating_sub(n);
-    all[start..].iter().map(|s| (*s).to_string()).collect()
+    // Redact each surfaced line (roast 2026-06-30): the child wrote raw
+    // stdout/stderr to disk, so a token echoed by a build/log command would
+    // otherwise reach the model (and any transcript) verbatim.
+    all[start..]
+        .iter()
+        .map(|s| crate::redact::redact(s).into_owned())
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tail_file_redacts_surfaced_secrets() {
+        // The child writes raw stdout to disk; bash_tail must redact what it
+        // surfaces to the model so a leaked key/token never round-trips.
+        let path = std::env::temp_dir().join(format!(
+            "claudette-tailtest-{}-{}.out",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos())
+        ));
+        std::fs::write(
+            &path,
+            "starting build\nexport AWS=AKIAIOSFODNN7EXAMPLE\n\
+             remote https://ghp_ABCDEFGHIJKLMNOP0123456789@github.com/x/y\ndone\n",
+        )
+        .expect("write tmp out");
+        let lines = tail_file(&path, 100);
+        let _ = std::fs::remove_file(&path);
+        let joined = lines.join("\n");
+        assert!(
+            !joined.contains("AKIAIOSFODNN7EXAMPLE"),
+            "leaked aws key: {joined}"
+        );
+        assert!(
+            !joined.contains("ghp_ABCDEFGHIJKLMNOP"),
+            "leaked github token: {joined}"
+        );
+        assert!(joined.contains("<redacted:aws-key>"), "got: {joined}");
+        assert!(joined.contains("<redacted:github-token>"), "got: {joined}");
+        assert!(
+            joined.contains("starting build") && joined.contains("done"),
+            "non-secret lines must survive: {joined}"
+        );
+    }
 
     #[test]
     fn bash_rejects_missing_command() {


### PR DESCRIPTION
## Roast finding (MEDIUM, confirmed)

`bash_background` persisted the **raw command + stdout + stderr** to `~/.claudette/jobs/<id>.{meta,out,err}` under the default umask (world-readable on a multi-user host), **unredacted** — while the sibling `transcript.rs` redacts before append and `secrets.rs` writes with `0600`/`icacls`. A token in the command (`git push https://x-access-token:<PAT>@…`) or a key dumped by `env` / a build log into stdout landed plaintext at rest, readable by co-tenant users. `bash_status` then echoed `meta.cmd` verbatim back to the model.

## Fix — at-rest perms + redaction on both ends

- **meta / out / err created owner-only.** `meta` via `secrets::write_secret_file`; the child-written `out`/`err` via a new `secrets::create_private_file` that returns an open `0600` (Unix) / icacls-tightened (Windows) `File` handle (the child writes the bytes, so `write_secret_file` doesn't fit).
- **`JobMeta.cmd` is redacted before it's written**, so `bash_status` can't surface a secret embedded in the command.
- **`bash_tail` redacts each surfaced line.** The child writes raw bytes to disk (we can't redact at write time), so this is the on-the-way-out half that pairs with the at-rest `0600`.

## Tests
- `tail_file_redacts_surfaced_secrets` — AWS key + GitHub token in captured output come back as `<redacted:…>`, non-secret lines preserved.
- `create_private_file_writes_and_truncates` — asserts mode `0600` on Unix + truncation.
- Existing `bash_background_status_tail_round_trip` still passes (the hardening doesn't break the live spawn path).
- Full suite **1070 pass, 0 fail**; fmt + clippy `--all-targets --all-features -D warnings` clean.

Independent of the redaction-modernization PR (#155) — uses the existing `redact::redact`; they compose once both land (better token coverage flows through automatically). Part of the 2026-06-30 roast remediation (sprint 1: air-gap honesty). Report: `runs/roast-2026-06-30/REPORT.md`.