### PR TITLE
docs: document the integrations feature flag in install/quickstart/usage (roast H3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ ollama pull qwen3.5:4b        # 3.4 GB model, one-time download
 claudette "what time is it?"
 ```
 
+**Want the cloud integrations** (Telegram bot, Gmail, Google Calendar, voice in/out, morning briefing)? They reach third-party services, so they are **not** in the default coding-only build — install with `cargo install claudette --features integrations` (or add `--features integrations` to a `cargo build`). Without it, `--telegram`, `--auth-google`, and `--briefing` print a one-line "reinstall with `--features integrations`" notice instead of running.
+
 Prefer not to pipe curl into a shell? Grab a [prebuilt release](https://github.com/mrdushidush/claudette/releases/latest) - each ships a SHA256. No GPU? The 4B model runs on plain CPU. Full setup and first flows → [docs/quickstart.md](docs/quickstart.md).
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,14 @@ The `qwen3.5:4b` brain handles every tool-using flow on its own. Prefer LM
 Studio or a bigger model? See [configuration.md](configuration.md) and
 [hardware.md](hardware.md).
 
+> **Integrations are opt-in at build time.** The default install is a lean,
+> air-gapped coding agent with **no cloud code**. The Telegram bot, Gmail,
+> Google Calendar, and the voice / morning-briefing helpers live behind the
+> `integrations` feature — install with `cargo install claudette --features
+> integrations` if you want them. The `--telegram`, `--auth-google`, and
+> `--briefing` flows below all need that build; without it they print a
+> one-line "reinstall with `--features integrations`" notice.
+
 ## 2. Verify (30 sec)
 
 ```bash
@@ -54,7 +62,7 @@ different command:
 claudette                            # interactive REPL
 claudette --tui                      # fullscreen TUI
 claudette "your prompt here"         # one-shot, prints reply and exits
-claudette --telegram --chat any      # Telegram bot
+claudette --telegram --chat any      # Telegram bot (needs --features integrations)
 claudette --resume                   # resume last session
 claudette --offline "..."            # enforced air-gap: block all cloud egress
 ```
@@ -184,7 +192,7 @@ claudette
 > what's the status of PR #5?
 ```
 
-### Google Calendar + Gmail (needs OAuth)
+### Google Calendar + Gmail (needs `--features integrations` + OAuth)
 
 Walkthrough: [google_setup.md](google_setup.md).
 
@@ -195,7 +203,7 @@ claudette
 > what's on my calendar tomorrow?
 ```
 
-### Telegram bot with voice
+### Telegram bot with voice (needs `--features integrations`)
 
 Get a token from `@BotFather`, set `TELEGRAM_BOT_TOKEN`, pull a Whisper model
 under `~/.claudette/models/ggml-large-v3-turbo.bin`:
@@ -207,7 +215,7 @@ claudette --telegram --chat any   # accept all chats; for production use --chat 
 Send a voice note — Claudette transcribes it (Whisper), runs the turn, replies
 in text. Type `/voice` for spoken replies too.
 
-### Morning briefing
+### Morning briefing (needs `--features integrations`)
 
 ```bash
 claudette --briefing                       # 07:00 weekdays: calendar + weather + email

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,17 +4,21 @@
 
 Run `claudette --help` for the authoritative reference.
 
+Flags marked **(integrations)** need a build with `--features integrations`
+(`cargo install claudette --features integrations`). The default coding-only
+binary has no cloud code, so it errors with a one-line reinstall hint instead.
+
 | Flag | Effect |
 |------|--------|
 | `--resume`, `-r` | Continue the most recent saved session. |
-| `--telegram`, `-t` | Run as a Telegram bot (needs `TELEGRAM_BOT_TOKEN`). |
+| `--telegram`, `-t` | **(integrations)** Run as a Telegram bot (needs `TELEGRAM_BOT_TOKEN`). |
 | `--tui` | Launch the fullscreen TUI. |
 | `--forge "<prompt>"` | Run forge-mode (Planner → Coder → Verifier pipeline) against the active brownfield mission. Requires an active mission — start one with `/brownfield <repo>` or `mission_start` first. |
 | `--chat <id>` | Restrict Telegram bot to a specific chat ID. Repeatable, or set `CLAUDETTE_TELEGRAM_CHAT` to a comma-separated list. The bot **default-denies** when no allowlist is provided. |
 | `--chat any` | Explicit accept-all: serve every incoming Telegram chat. Required to start the bot with no allowlist. Prints a loud warning. |
-| `--auth-google [scope]` | Run the loopback OAuth flow. Scope is `calendar` (default) or `gmail`. Stores tokens under `~/.claudette/secrets/`. |
+| `--auth-google [scope]` | **(integrations)** Run the loopback OAuth flow. Scope is `calendar` (default) or `gmail`. Stores tokens under `~/.claudette/secrets/`. |
 | `--revoke` | Pair with `--auth-google` to revoke consent and delete the local token file. |
-| `--briefing` | Write a recurring morning-briefing schedule entry and exit. |
+| `--briefing` | **(integrations)** Write a recurring morning-briefing schedule entry and exit. |
 | `--time HH:MM` | Modifier for `--briefing`. Default `07:00`. |
 | `--days <spec>` | Modifier for `--briefing`. One of `weekdays` (default), `daily`, or a single weekday name. |
 | `--help`, `-h` | Show the flag reference and exit. |


### PR DESCRIPTION
**Sprint 2 of the 2026-06-30 roast remediation — docs-vs-binary truth pass (PR 2/2).**
Finding: **H3** in `runs/roast-2026-06-30/REPORT.md`.

The roast found the README headlines Telegram / Gmail / Calendar / voice, but those are compiled **out** of the shipped binary (`Cargo.toml` `default = []`; `release.yml` builds with no `--features integrations`; `main.rs` errors *"Reinstall with `--features integrations`"*). A grep of every `*.md` for `--features` hit **only CHANGELOG** — the flag a user needs appeared in no install / quickstart / usage doc.

### What changed (docs only)
- **README — Install:** new note that the cloud integrations (Telegram bot, Gmail, Google Calendar, voice, morning briefing) reach third-party services and are **not** in the default coding-only build — install with `cargo install claudette --features integrations`; without it `--telegram` / `--auth-google` / `--briefing` print a one-line reinstall notice.
- **quickstart.md:** the same note in step 1, plus annotations on the entry-point comment and the *Calendar/Gmail*, *Telegram*, and *Morning briefing* section headings.
- **usage.md:** an **(integrations)** legend above the flag table, and the `--telegram` / `--auth-google` / `--briefing` rows tagged.

This is the "demote/document" half of H3; the README feature bullets and the architecture table's `integrations`-build-only markers land in PR 1/2 (#159).

### Gate
`cargo fmt --all --check` ✅ · `cargo clippy --all-targets --all-features --no-deps -- -D warnings` ✅ · `cargo test --lib --bins --tests --all-features` ✅ (no Rust changed — docs-only).

> CI note: the shared `cargo deny` job is red on **RUSTSEC-2026-0190 (anyhow 1.0.102 unsound)** — pre-existing, red on `main` too, waiting on dependabot **#152** (anyhow → 1.0.103). Not introduced by this PR.

Branched off `main`, independent of #159 (not stacked; no shared file regions).