### PR TITLE
fix(config): unify safety-boolean parsing + close the fail-open destructive-git guard (roast Theme C)

### DIFF
--- a/crates/claudette/src/codet.rs
+++ b/crates/claudette/src/codet.rs
@@ -69,8 +69,7 @@ pub fn coder_model() -> String {
 /// (also `1` / `yes` / `on`); any other value — or unset — leaves it off.
 #[must_use]
 pub fn validation_enabled() -> bool {
-    std::env::var("CLAUDETTE_VALIDATE_CODE")
-        .is_ok_and(|v| matches!(v.to_lowercase().as_str(), "true" | "1" | "yes" | "on"))
+    crate::env_config::is_enabled("CLAUDETTE_VALIDATE_CODE")
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/claudette/src/env_config.rs
+++ b/crates/claudette/src/env_config.rs
@@ -26,6 +26,31 @@ pub(crate) fn home_dir() -> PathBuf {
     PathBuf::from(raw)
 }
 
+/// Canonical truthy test for a boolean-knob *value*: `1` / `true` / `yes` /
+/// `on`, matched **case-insensitively** (`TRUE`, `On`, `YES` all count). Any
+/// other value — including `0`, `false`, `""`, or garbage — is false.
+///
+/// This is the single source of truth for how every `CLAUDETTE_*` boolean knob
+/// interprets its value, so call sites can't disagree (some used a bare
+/// `== "1"`, some `var_os().is_some()` which was *fail-open*, some the truthy
+/// set). Case-insensitivity makes it a strict superset of the strictest prior
+/// parser (`codet::validation_enabled`), so folding a knob in never *narrows*
+/// what it accepted.
+pub(crate) fn is_truthy(value: &str) -> bool {
+    matches!(
+        value.to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Whether the named env var is set to a canonical truthy value (see
+/// [`is_truthy`]). Fail-SAFE: an unset var, or a var set to any non-truthy
+/// value, is false — so a knob that guards a dangerous capability stays
+/// guarded unless the user explicitly opts in.
+pub(crate) fn is_enabled(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| is_truthy(&v))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -53,6 +78,47 @@ mod tests {
         match prev_home {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn is_truthy_accepts_canonical_set_case_insensitively() {
+        // No env mutation — pure value test, so no lock / flakiness.
+        for v in ["1", "true", "yes", "on", "TRUE", "Yes", "On", "tRuE"] {
+            assert!(is_truthy(v), "'{v}' should be truthy");
+        }
+    }
+
+    #[test]
+    fn is_truthy_rejects_falsey_and_garbage() {
+        for v in [
+            "0", "false", "no", "off", "", " ", "2", "enable", "1 ", "yeah", "FALSE",
+        ] {
+            assert!(!is_truthy(v), "'{v}' should not be truthy");
+        }
+    }
+
+    #[test]
+    fn is_enabled_reads_env_fail_safe() {
+        let _guard = crate::test_env_lock();
+        // Deliberately NOT a `CLAUDETTE_*` name: the `every_env_var_is_documented`
+        // guard scans src/ for that prefix, and this synthetic probe isn't a
+        // real, user-facing knob.
+        let key = "ENVCFG_IS_ENABLED_PROBE_XYZZY";
+        let prev = std::env::var(key).ok();
+
+        std::env::remove_var(key);
+        assert!(!is_enabled(key), "unset var must be fail-safe (false)");
+
+        std::env::set_var(key, "TRUE");
+        assert!(is_enabled(key), "case-insensitive truthy must enable");
+
+        std::env::set_var(key, "0");
+        assert!(!is_enabled(key), "'0' must not enable");
+
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
         }
     }
 }

--- a/crates/claudette/src/prompt.rs
+++ b/crates/claudette/src/prompt.rs
@@ -29,10 +29,7 @@ pub fn agent_system_prompt() -> Vec<String> {
 /// persona overlay is best-effort and never load-bearing.
 #[must_use]
 pub fn faceless_mode_enabled() -> bool {
-    matches!(
-        std::env::var("CLAUDETTE_FACELESS").as_deref(),
-        Ok("1" | "true" | "yes" | "on")
-    )
+    crate::env_config::is_enabled("CLAUDETTE_FACELESS")
 }
 
 /// Bundled Eva persona — the assistant-mode voice. Baked into the binary so

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -197,12 +197,11 @@ pub fn run_agent(user_input: &str, opts: SessionOptions) -> Result<TurnSummary> 
     Ok(summary)
 }
 
-/// True for the canonical truthy env values. Shared by the forge gate knobs.
+/// True for the canonical truthy env values (case-insensitive). Shared by the
+/// forge gate knobs. Thin shim over the crate-wide [`crate::env_config::is_enabled`]
+/// so run/forge call sites keep a short local name.
 fn env_flag_enabled(name: &str) -> bool {
-    matches!(
-        std::env::var(name).as_deref(),
-        Ok("1" | "true" | "yes" | "on")
-    )
+    crate::env_config::is_enabled(name)
 }
 
 /// Opt-in: run the *interactive secretary* (REPL / one-shot / TUI) in

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -67,10 +67,7 @@ fn max_fix_rounds() -> u32 {
 /// throwaway repos. Off by default; affects forge phases only (secretary/TUI
 /// keep the normal WorkspaceWrite+prompt policy).
 pub(crate) fn forge_auto_approve_enabled() -> bool {
-    matches!(
-        std::env::var("CLAUDETTE_FORGE_AUTO_APPROVE").as_deref(),
-        Ok("1" | "true" | "yes" | "on")
-    )
+    env_flag_enabled("CLAUDETTE_FORGE_AUTO_APPROVE")
 }
 
 fn security_override_enabled() -> bool {

--- a/crates/claudette/src/security_review.rs
+++ b/crates/claudette/src/security_review.rs
@@ -65,10 +65,7 @@ impl fmt::Display for Finding {
 /// True when the security-review stage is enabled.
 #[must_use]
 pub fn enabled() -> bool {
-    matches!(
-        std::env::var("CLAUDETTE_FORGE_SECURITY_REVIEW").as_deref(),
-        Ok("1" | "true" | "yes" | "on")
-    )
+    crate::env_config::is_enabled("CLAUDETTE_FORGE_SECURITY_REVIEW")
 }
 
 /// Scan a unified diff and return findings for every added line that

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -839,7 +839,7 @@ pub(super) fn path_under_workspace(path: &Path) -> bool {
 /// against. Returns the denial reason when `path` is sensitive, else `None`.
 /// Opt out wholesale with `CLAUDETTE_ALLOW_SECRET_READS=1`.
 fn sensitive_read_denial(path: &Path, home: &Path) -> Option<String> {
-    if std::env::var("CLAUDETTE_ALLOW_SECRET_READS").as_deref() == Ok("1") {
+    if crate::env_config::is_enabled("CLAUDETTE_ALLOW_SECRET_READS") {
         return None;
     }
 

--- a/crates/claudette/src/tools/search.rs
+++ b/crates/claudette/src/tools/search.rs
@@ -640,7 +640,7 @@ struct FetchTarget {
 /// resolved at connect time skipped the guard. On success the validated
 /// addresses are returned so the caller can pin the connection to them.
 fn validate_fetch_target(url: &str) -> Result<FetchTarget, String> {
-    if std::env::var("CLAUDETTE_WEB_FETCH_ALLOW_PRIVATE").as_deref() == Ok("1") {
+    if crate::env_config::is_enabled("CLAUDETTE_WEB_FETCH_ALLOW_PRIVATE") {
         // Opted into LAN fetches: skip both the block-list and IP pinning (the
         // point is to reach arbitrary user-controlled hosts).
         return Ok(FetchTarget {

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -248,7 +248,11 @@ fn run_bash(input: &str) -> Result<String, String> {
 
 /// Refuse a destructive git command that would discard uncommitted tracked work.
 fn destructive_git_guard(command: &str, cwd: &Path) -> Result<(), String> {
-    if std::env::var_os("CLAUDETTE_ALLOW_DESTRUCTIVE_GIT").is_some() {
+    // Fail-SAFE: only a canonical truthy value bypasses the guard. A previous
+    // `var_os(...).is_some()` check was fail-OPEN — `=0` / `=false` / `""` all
+    // disabled the data-loss guard despite the docs saying "=1". (roast
+    // 2026-06-30 Theme C)
+    if crate::env_config::is_enabled("CLAUDETTE_ALLOW_DESTRUCTIVE_GIT") {
         return Ok(());
     }
     let Some((op, work_dir)) = scan_destructive_git(command) else {
@@ -840,8 +844,13 @@ mod tests {
 
     #[test]
     fn guard_refuses_reset_hard_on_dirty_tree_but_allows_clean() {
-        // Skip if git is unavailable or the override is set in the env.
-        if std::env::var_os("CLAUDETTE_ALLOW_DESTRUCTIVE_GIT").is_some() {
+        // Hold the env lock so the sibling fail-safe test (which mutates
+        // CLAUDETTE_ALLOW_DESTRUCTIVE_GIT) can't flip the guard mid-assertion.
+        let _lock = crate::test_env_lock();
+        // Skip if git is unavailable or the override is *enabled* in the env
+        // (matches the guard's own fail-safe check — a falsey value no longer
+        // bypasses the guard, so the test can still run).
+        if crate::env_config::is_enabled("CLAUDETTE_ALLOW_DESTRUCTIVE_GIT") {
             return;
         }
         let git_ok = std::process::Command::new("git")
@@ -890,6 +899,72 @@ mod tests {
         // A non-destructive command on the same dirty tree still passes.
         assert!(destructive_git_guard("git status", &dir).is_ok());
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn destructive_git_guard_is_fail_safe_not_fail_open() {
+        // Regression for roast 2026-06-30 Theme C: the guard used to check
+        // `var_os(...).is_some()`, so ANY value — `=0`, `=false`, `""` —
+        // disabled the data-loss guard (fail-OPEN) despite the docs saying
+        // "=1". It must now bypass ONLY on a canonical truthy value.
+        let _lock = crate::test_env_lock();
+        let key = "CLAUDETTE_ALLOW_DESTRUCTIVE_GIT";
+        let prev = std::env::var(key).ok();
+
+        let git_ok = std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_ok_and(|o| o.status.success());
+        if !git_ok {
+            return;
+        }
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let dir = std::env::temp_dir().join(format!("claudette-gitguard-failsafe-{nanos}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&dir)
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-qm", "init"]);
+        // Make the tree dirty so the guard has something to protect.
+        std::fs::write(dir.join("a.txt"), "two\n").unwrap();
+        assert!(git_tracked_dirty(&dir).iter().any(|f| f == "a.txt"));
+
+        // Falsey / empty values must NOT bypass — the guard stays active.
+        for v in ["0", "false", "off", ""] {
+            std::env::set_var(key, v);
+            assert!(
+                destructive_git_guard("git reset --hard origin/main", &dir).is_err(),
+                "value '{v}' must NOT bypass the guard (fail-open regression)"
+            );
+        }
+
+        // Canonical truthy values (case-insensitive) bypass as documented.
+        for v in ["1", "true", "TRUE", "yes", "on"] {
+            std::env::set_var(key, v);
+            assert!(
+                destructive_git_guard("git reset --hard origin/main", &dir).is_ok(),
+                "value '{v}' should bypass the guard"
+            );
+        }
+
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## What & why

Sprint 3 (Wave D config consistency) of the **2026-06-30 roast** remediation — Theme C (config consistency / fail-safe defaults). See `runs/roast-2026-06-30/REPORT.md`.

The `CLAUDETTE_*` boolean knobs each parsed their value **differently**, and one was outright **fail-open**:

| Knob | Old parse | Failure mode |
|------|-----------|--------------|
| `CLAUDETTE_ALLOW_DESTRUCTIVE_GIT` | `var_os(...).is_some()` | 🔴 **FAIL-OPEN** — `=0` / `=false` / `""` all *disabled* the data-loss guard despite docs saying "=1" |
| `CLAUDETTE_ALLOW_SECRET_READS` | `== "1"` | fail-safe, but `=true`/`=yes` silently ignored |
| `CLAUDETTE_WEB_FETCH_ALLOW_PRIVATE` | `== "1"` | fail-safe, but `=true`/`=yes` silently ignored |
| forge gates + `CLAUDETTE_AUTO_APPROVE` / `FORGE_AUTO_APPROVE` | case-**sensitive** `1\|true\|yes\|on` | `TRUE` ignored |
| `CLAUDETTE_VALIDATE_CODE` | case-**insensitive** `1\|true\|yes\|on` | (correct, just not shared) |

## The fix — one parser

New single source of truth in `env_config`:
- `is_truthy(value)` — canonical `1|true|yes|on`, **case-insensitive** (a strict superset of the most-lenient prior parser, so no knob narrows what it accepted).
- `is_enabled(name)` — reads the env var **fail-SAFE** via `is_truthy` (unset / falsey / garbage ⇒ off).

Every plain-boolean knob now routes through it: the destructive-git guard (prod + the test's skip check), `ALLOW_SECRET_READS`, `WEB_FETCH_ALLOW_PRIVATE`, `VALIDATE_CODE`, the run/forge `env_flag_enabled` shim (`AUTO_APPROVE` + all forge gates), `FORGE_AUTO_APPROVE`, `FACELESS`, `FORGE_SECURITY_REVIEW`.

**Left alone:** `CLAUDETTE_ALLOW_REMOTE_OLLAMA` (`api.rs`) carries different, more-lenient semantics (any non-empty, non-`"0"` value counts as consent) — not a plain boolean, so out of scope per the goal.

## ⚠️ Behavioral tightening — for your merge-time call

Routing `CLAUDETTE_ALLOW_DESTRUCTIVE_GIT` through `is_enabled` **tightens** behavior: a user who set it to a **falsey** value (`0`/`false`/empty) now correctly gets the guard **back**. Fail-open → fail-safe. This is the security fix, not a regression — but it *is* a behavior change, so flagging it loud for your review. `=1` (the documented value) is unaffected.

## Tests
- Pure `is_truthy` value tests (accepts `1/true/yes/on/TRUE/…`, rejects `0/false/""/garbage`) — no env-mutation lock, so no flakiness.
- `is_enabled` fail-safe env-read smoke test.
- `destructive_git_guard_is_fail_safe_not_fail_open` — proves falsey values no longer bypass the guard while canonical truthy values still do (existing guard test given the env lock so the two don't race).

`cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test --lib --bins --tests --all-features` all green (1160 tests).

> CI note: the shared `cargo deny` job is red on every branch pending dependabot #152 (anyhow→1.0.103) — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)