### PR TITLE
refactor(config): route home-dir resolution through env_config::home_dir() (roast Theme C)

### DIFF
--- a/crates/claudette/src/brain_selector.rs
+++ b/crates/claudette/src/brain_selector.rs
@@ -257,10 +257,7 @@ struct FallbackEvent<'a> {
 /// Path for the fallback event log: `~/.claudette/fallback.jsonl`.
 #[must_use]
 pub fn fallback_log_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
+    crate::env_config::home_dir()
         .join(".claudette")
         .join("fallback.jsonl")
 }

--- a/crates/claudette/src/forge/models_toml.rs
+++ b/crates/claudette/src/forge/models_toml.rs
@@ -112,10 +112,7 @@ pub fn default_model_map() -> ModelMap {
 /// Default TOML path: `~/.claudettes-forge/models.toml`.
 #[must_use]
 pub fn default_toml_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
+    crate::env_config::home_dir()
         .join(".claudettes-forge")
         .join("models.toml")
 }

--- a/crates/claudette/src/google_auth.rs
+++ b/crates/claudette/src/google_auth.rs
@@ -107,10 +107,9 @@ struct ClientCreds {
 }
 
 fn secrets_dir() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("secrets")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("secrets")
 }
 
 fn tokens_path(ctx: AuthContext) -> PathBuf {

--- a/crates/claudette/src/memory.rs
+++ b/crates/claudette/src/memory.rs
@@ -29,10 +29,7 @@ pub fn default_memory_path() -> PathBuf {
             return PathBuf::from(custom);
         }
     }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    let dir = PathBuf::from(home).join(".claudette");
+    let dir = crate::env_config::home_dir().join(".claudette");
     let canonical = dir.join("CLAUDETTE.MD");
     if canonical.exists() {
         return canonical;

--- a/crates/claudette/src/missions.rs
+++ b/crates/claudette/src/missions.rs
@@ -69,10 +69,9 @@ fn active_slot() -> &'static Mutex<Option<Mission>> {
 /// `crate::secrets::secrets_dir` and `tools::git::missions_root`.
 #[must_use]
 pub fn missions_root() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("missions")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("missions")
 }
 
 /// Validate a mission slug. Same rules as `git_clone`'s dest validator:

--- a/crates/claudette/src/model_config.rs
+++ b/crates/claudette/src/model_config.rs
@@ -283,10 +283,9 @@ fn env_u32(key: &str) -> Option<u32> {
 /// Default path for the TOML overlay: `~/.claudette/models.toml`.
 #[must_use]
 pub fn default_toml_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("models.toml")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("models.toml")
 }
 
 // ─── Process-global active state ────────────────────────────────────────────

--- a/crates/claudette/src/recall.rs
+++ b/crates/claudette/src/recall.rs
@@ -147,10 +147,9 @@ pub fn default_recall_db_path() -> PathBuf {
             return PathBuf::from(p);
         }
     }
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("recall.sqlite")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("recall.sqlite")
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -111,10 +111,9 @@ pub fn default_session_path() -> PathBuf {
 /// Resolve the directory holding all session JSON files. `pub(crate)` so the
 /// slash-command dispatcher can list / save / load named sessions under it.
 pub(crate) fn sessions_dir() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("sessions")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("sessions")
 }
 
 /// Try to load a saved session from the default path. Returns

--- a/crates/claudette/src/scheduler.rs
+++ b/crates/claudette/src/scheduler.rs
@@ -812,10 +812,7 @@ static GLOBAL: OnceLock<Mutex<Scheduler>> = OnceLock::new();
 
 /// Default path for the persistent schedule file: `~/.claudette/schedule.jsonl`.
 pub fn default_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
+    crate::env_config::home_dir()
         .join(".claudette")
         .join("schedule.jsonl")
 }

--- a/crates/claudette/src/secrets.rs
+++ b/crates/claudette/src/secrets.rs
@@ -106,10 +106,9 @@ fn harden_windows_acl(path: &Path) {
 
 /// Resolve the secrets directory: `~/.claudette/secrets/`.
 fn secrets_dir() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("secrets")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("secrets")
 }
 
 /// Read a secret by logical name (e.g. `"github"`, `"telegram"`).

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -331,10 +331,7 @@ fn run_load_workspace_rules() -> String {
 // ────────────────────────────────────────────────────────────────────────────
 
 pub(super) fn user_home() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home)
+    crate::env_config::home_dir()
 }
 
 pub(super) fn claudette_home() -> PathBuf {

--- a/crates/claudette/src/tools/git.rs
+++ b/crates/claudette/src/tools/git.rs
@@ -530,10 +530,7 @@ fn run_git_checkout(input: &str) -> Result<String, String> {
 /// Resolve `~/.claudette/missions/`. Mirrors the home-resolution pattern in
 /// `crate::secrets::secrets_dir`.
 fn missions_root() -> std::path::PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(home)
+    crate::env_config::home_dir()
         .join(".claudette")
         .join("missions")
 }

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -411,10 +411,9 @@ impl App {
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn notes_dir() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("notes")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("notes")
 }
 
 fn scan_notes(tag_filter: Option<&str>) -> Vec<NoteEntry> {
@@ -485,10 +484,9 @@ fn parse_note(content: &str) -> NoteEntry {
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn todos_path() -> PathBuf {
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".claudette").join("todos.json")
+    crate::env_config::home_dir()
+        .join(".claudette")
+        .join("todos.json")
 }
 
 fn load_todos() -> Vec<TodoItem> {

--- a/crates/claudette/src/voice.rs
+++ b/crates/claudette/src/voice.rs
@@ -124,10 +124,8 @@ fn whisper_bin_from(value: Option<&str>) -> String {
 /// Path to the GGML model file.
 fn whisper_model() -> PathBuf {
     let env_override = std::env::var("CLAUDETTE_WHISPER_MODEL").ok();
-    let home = std::env::var("USERPROFILE")
-        .or_else(|_| std::env::var("HOME"))
-        .unwrap_or_else(|_| ".".to_string());
-    whisper_model_from(env_override.as_deref(), &home)
+    let home = crate::env_config::home_dir();
+    whisper_model_from(env_override.as_deref(), &home.to_string_lossy())
 }
 
 /// Pure predicate behind [`whisper_model`]. See [`whisper_bin_from`].


### PR DESCRIPTION
## What & why

Sprint 3 (Wave D config consistency) of the **2026-06-30 roast** remediation — Theme C. See `runs/roast-2026-06-30/REPORT.md`.

Fifteen prod call sites each re-implemented the **same** home-directory resolution inline:

```rust
let home = std::env::var("USERPROFILE")
    .or_else(|_| std::env::var("HOME"))
    .unwrap_or_else(|_| ".".to_string());
PathBuf::from(home).join(".claudette").join("…")
```

`env_config::home_dir()` (added in Wave D1a, #143) already exists as the single source of truth for exactly this chain. This routes all fifteen through it, so the fallback can't drift between storage paths.

## Sites migrated (14 files)
`brain_selector`, `forge/models_toml`, `google_auth`, `memory`, `missions` (`missions_root`), `model_config`, `recall`, `run` (`sessions_dir`), `scheduler`, `secrets`, `tools` (`user_home`), `tools/git`, `tui` (`notes_dir` + `todos_path`), `voice`.

## Deliberately NOT touched (trap sites — different semantics)
- `main.rs` — `if let Ok(home) = var(…)` is a **conditional is-set test**, not a resolver; `home_dir()`'s `"."` fallback would run the block unconditionally.
- `missions.rs::path_under_permitted_roots` — `.ok().map(PathBuf::from)` → `Option`, **no `"."` fallback** (a `"."` permitted-root would be wrong).
- reversed **HOME-first** tilde helpers in `fuzzy_apply` / `patch` / `shell` tests (order is deliberate).
- example crates — can't reach the `pub(crate)` helper.

## Safety
Pure refactor — **no behavior change, no test-count change**. Each replacement preserves the exact directory suffix (verified in the diff). `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test --lib --bins --tests --all-features` all green.

> CI note: the shared `cargo deny` job is red on every branch pending dependabot #152 (anyhow→1.0.103) — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)