### PR TITLE
docs(tui): demote the TUI to experimental/demo-only in help text + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Prefer not to pipe curl into a shell? Grab a [prebuilt release](https://github.c
 |------|---------|-----|
 | **REPL** | `claudette` | Conversational shell; autosaves every turn |
 | **One-shot** | `claudette "..."` | Print a reply and exit; pipe-friendly |
-| **TUI** | `claudette --tui` | Fullscreen UI, 5 tabs, live tool panel |
+| **TUI** _(experimental)_ | `claudette --tui` | Demo-only fullscreen UI, 5 tabs; known rendering rough edges — the REPL is the daily driver |
 | **Telegram** | `claudette --telegram` | Voice-capable chat from your phone |
 
 - **80+ tools across 21 opt-in groups.** The model turns a group on (`enable_tools("git")`) only when it needs it, so the base schema stays ~200 tokens however many tools exist. Point Claudette at a repo and the coding core - files, search, tests - is pre-enabled.

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -99,8 +99,10 @@ MODES (pick one; default is interactive REPL):
     --resume, -r         Continue the most recent saved session. Works in
                          REPL and single-shot.
     --telegram, -t       Run as a Telegram bot. Requires TELEGRAM_BOT_TOKEN.
-    --tui                Launch the fullscreen ratatui TUI (Chat / Tools /
-                         Notes / Todos / HW tabs).
+    --tui                [experimental] Launch the fullscreen ratatui TUI
+                         (Chat / Tools / Notes / Todos / HW tabs). Demo-only:
+                         has known rendering rough edges (doubled text, tool
+                         pane, footer). The REPL is the supported daily driver.
     --forge \"<prompt>\"   Run the prompt in forge-mode inside the active
                          brownfield mission. Errors if no mission is active —
                          start one with /brownfield <repo> first. v0a runs a
@@ -161,7 +163,7 @@ EXAMPLES:
     claudette                            # start the REPL
     claudette \"what time is it?\"         # one-shot
     claudette -r                         # resume last session
-    claudette --tui                      # fullscreen TUI
+    claudette --tui                      # fullscreen TUI (experimental/demo-only)
     claudette --auth-google calendar     # OAuth once
     claudette --briefing --time 08:30    # weekday briefings at 08:30
     claudette --telegram --chat 12345    # bot restricted to one chat
@@ -439,7 +441,7 @@ fn main() -> ExitCode {
 /// Supported flags:
 /// - `--resume` / `-r` — resume saved session
 /// - `--telegram` / `-t` — run as Telegram bot
-/// - `--tui` — launch the ratatui TUI
+/// - `--tui` — launch the ratatui TUI (experimental / demo-only)
 /// - `--chat <id>` — restrict to this chat ID (repeatable)
 /// - `--auth-google` — run the Google OAuth loopback flow and save tokens
 /// - `--revoke` — paired with `--auth-google`, revokes tokens and deletes

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -10,7 +10,7 @@ we're honest about what Claudette is, what it isn't, and where it has room to gr
 
 | Tool | Language | Local models | Primary UI | Agent style | Target use case |
 |---|---|---|---|---|---|
-| **Claudette** | Rust (single crate) | Ollama or LM Studio | REPL + CLI + TUI + **Telegram bot** | Agent loop + tiered-brain fallback (4B→9B) | Local-first coding agent + personal assistant |
+| **Claudette** | Rust (single crate) | Ollama or LM Studio | REPL + CLI + **Telegram bot** _(+ experimental TUI)_ | Agent loop + tiered-brain fallback (4B→9B) | Local-first coding agent + personal assistant |
 | **opencode** (SST) | Go | Yes, 75+ models | Terminal TUI + VS Code ext | Plan + Build agents | Coding agent replacing Claude Code |
 | **Aider** | Python | Yes, any LLM | Terminal REPL | Repo-mapped pair programming | Coding with deep git integration |
 | **OpenHands** | Python + Docker | Yes, via Ollama | Web UI + Docker sandbox | Autonomous agent with browser + shell | Full SWE-agent, SWE-bench 53%+ |


### PR DESCRIPTION
**Campaign item 2.1** — you approved the verdict **demote, not fix**. The ratatui TUI has known rendering rough edges (doubled text, mangled Tools pane, wrong footer) and nobody dailies it; the REPL is the product. Rather than keep a flagship-looking surface that's known-broken and undocumented as such, this labels it honestly everywhere it's surfaced and steers users to the REPL.

**Docs + `--help` text only — no renderer changes**, zero behavioral change to the agent (not battery-relevant).

### Changes
- **`main.rs` `HELP_TEXT`**: the `--tui` entry now leads with `[experimental]` and a demo-only note that names the known issues and points at the REPL as the supported daily driver.
- **`main.rs` `EXAMPLES` + `parse_args` rustdoc**: `--tui` tagged experimental/demo-only.
- **`README.md`** "What it does" table: the TUI row is marked _(experimental)_ / demo-only.
- **`docs/comparison.md`** matrix: TUI moved to a parenthetical `(+ experimental TUI)` so REPL/CLI/Telegram read as the real interfaces.

### Notes
- The `--tui` token stays present in `HELP_TEXT`, so the flag-coverage test (`HELP_TEXT.contains("--tui")`) still passes.
- Archived docs under `docs/archive/**` are left as historical record. `docs/architecture.md` keeps its factual `tui.rs` module description (contributor-facing, not a promotion).
- Verified locally: `cargo fmt --all --check`, `clippy --all-targets --no-deps -D warnings` (default **and** `--all-features`), and the binary tests (which cover `HELP_TEXT`) all green. Full lib + all-features test matrix runs here in CI.

Closes the daily-driver ambition for the TUI until real demand surfaces (campaign backlog #3).