### PR TITLE
feat(repl): turn-scoped /undo + /diff

### DIFF
--- a/crates/claudette/src/commands.rs
+++ b/crates/claudette/src/commands.rs
@@ -98,10 +98,17 @@ pub enum SlashCommand {
     /// mission is active. Mirrors the `--forge "<prompt>"` CLI flag from
     /// inside the REPL.
     Forge(String),
-    /// One-step undo of the last destructive action: restores the trashed
-    /// file / pre-image recorded in the action transcript
-    /// (`~/.claudette/transcript/actions.jsonl`). Works in REPL and TUI.
-    Undo,
+    /// Undo the last turn's destructive actions from the action transcript
+    /// (`~/.claudette/transcript/actions.jsonl`), restoring each trashed file
+    /// / pre-image. `whole_turn` is the default (`/undo`); `/undo one` sets it
+    /// `false` for the older single-action behavior. Works in REPL and TUI.
+    Undo {
+        whole_turn: bool,
+    },
+    /// Render the cumulative diff of the last turn's file changes — each
+    /// trashed pre-image against the file now on disk — via the same colored
+    /// unified-diff renderer the `[y/N]` gate uses. Read-only.
+    Diff,
     /// Recognised as starting with `/` but unusable: unknown name, missing
     /// required argument, etc. Carries a human-readable error.
     Invalid(String),
@@ -205,7 +212,14 @@ pub fn parse_slash_command(line: &str) -> Option<SlashCommand> {
             None => SlashCommand::Invalid("/coder requires a model name".to_string()),
         },
         "models" => SlashCommand::Models,
-        "undo" => SlashCommand::Undo,
+        "undo" => {
+            let one = arg
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|a| a.eq_ignore_ascii_case("one"));
+            SlashCommand::Undo { whole_turn: !one }
+        }
+        "diff" => SlashCommand::Diff,
         "recall" => match arg.filter(|s| !s.is_empty()) {
             Some(arg) if arg.eq_ignore_ascii_case("reprobe") => SlashCommand::RecallReprobe,
             Some(query) => SlashCommand::Recall(query),
@@ -389,10 +403,26 @@ where
             handle_models(out);
             SlashOutcome::Continue
         }
-        SlashCommand::Undo => {
-            match crate::transcript::undo_last() {
+        SlashCommand::Undo { whole_turn } => {
+            let result = if whole_turn {
+                crate::transcript::undo_last_turn()
+            } else {
+                crate::transcript::undo_last()
+            };
+            match result {
                 Ok(msg) => {
                     let _ = writeln!(out, "{} {}", theme::OK_GLYPH, theme::ok(&msg));
+                }
+                Err(e) => {
+                    let _ = writeln!(out, "{} {}", theme::WARN_GLYPH, theme::warn(&e));
+                }
+            }
+            SlashOutcome::Continue
+        }
+        SlashCommand::Diff => {
+            match crate::transcript::diff_last_turn() {
+                Ok(diff) => {
+                    let _ = writeln!(out, "{diff}");
                 }
                 Err(e) => {
                     let _ = writeln!(out, "{} {}", theme::WARN_GLYPH, theme::warn(&e));
@@ -486,7 +516,12 @@ fn print_help(out: &mut impl Write) {
                 ),
                 (
                     "/undo",
-                    "Restore the last destructive action from ~/.claudette/trash/",
+                    "Undo the last turn's destructive actions (restore from ~/.claudette/trash/)",
+                ),
+                ("/undo one", "Undo just the single most-recent action"),
+                (
+                    "/diff",
+                    "Show the diff of what the last turn changed on disk",
                 ),
             ],
         ),
@@ -1908,6 +1943,32 @@ mod tests {
             parse_slash_command("/cap"),
             Some(SlashCommand::Capabilities)
         );
+    }
+
+    #[test]
+    fn parse_undo_defaults_to_whole_turn_and_one_opts_out() {
+        assert_eq!(
+            parse_slash_command("/undo"),
+            Some(SlashCommand::Undo { whole_turn: true })
+        );
+        assert_eq!(
+            parse_slash_command("/undo one"),
+            Some(SlashCommand::Undo { whole_turn: false })
+        );
+        // Case-insensitive, and anything else keeps the whole-turn default.
+        assert_eq!(
+            parse_slash_command("/undo ONE"),
+            Some(SlashCommand::Undo { whole_turn: false })
+        );
+        assert_eq!(
+            parse_slash_command("/undo everything"),
+            Some(SlashCommand::Undo { whole_turn: true })
+        );
+    }
+
+    #[test]
+    fn parse_diff() {
+        assert_eq!(parse_slash_command("/diff"), Some(SlashCommand::Diff));
     }
 
     #[test]

--- a/crates/claudette/src/diff_preview.rs
+++ b/crates/claudette/src/diff_preview.rs
@@ -38,7 +38,17 @@ fn render_replacement(input: &str, old_key: &str, new_key: &str) -> Option<Vec<S
     let path = v.get("path").and_then(Value::as_str)?;
     let old = v.get(old_key).and_then(Value::as_str)?;
     let new = v.get(new_key).and_then(Value::as_str)?;
+    Some(render_file_change(path, old, new))
+}
 
+/// Render a whole-file before→after change as a single colored hunk: a
+/// `path` header, then the changed middle as `-`/`+` with the common
+/// leading/trailing lines kept as dim context. Shared by the edit-tool
+/// preview (`render_replacement`) and `/diff`'s last-turn rendering
+/// (`transcript::diff_last_turn`), which feeds it a trashed pre-image vs the
+/// file now on disk. Never truncates.
+#[must_use]
+pub fn render_file_change(path: &str, old: &str, new: &str) -> Vec<String> {
     let old_lines: Vec<&str> = old.split('\n').collect();
     let new_lines: Vec<&str> = new.split('\n').collect();
 
@@ -63,7 +73,7 @@ fn render_replacement(input: &str, old_key: &str, new_key: &str) -> Option<Vec<S
     for line in &old_lines[old_lines.len() - suffix..] {
         out.push(theme::dim(&format!("  {line}")).to_string());
     }
-    Some(out)
+    out
 }
 
 /// Render an apply_patch unified diff with per-line coloring: file headers and
@@ -175,6 +185,20 @@ mod tests {
     fn non_edit_tool_returns_none() {
         assert!(render("bash", r#"{"command":"ls"}"#).is_none());
         assert!(render("read_file", r#"{"path":"f"}"#).is_none());
+    }
+
+    /// The `/diff` entry point: a whole-file before→after. A deletion
+    /// (after is empty) shows the removed content as `-` lines.
+    #[test]
+    fn render_file_change_shows_a_deletion_as_removals() {
+        let out = render_file_change("gone.md", "kept line\n", "");
+        let joined = out.join("\n");
+        assert!(joined.contains("gone.md"), "header missing: {joined}");
+        assert!(joined.contains("- kept line"), "removal missing: {joined}");
+        assert!(
+            !joined.contains("+ "),
+            "nothing added on a delete: {joined}"
+        );
     }
 
     #[test]

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -170,6 +170,7 @@ pub fn run_agent(user_input: &str, opts: SessionOptions) -> Result<TurnSummary> 
     // Stash any file paths from the raw user prompt — bypasses the brain's
     // tendency to drop them when constructing tool-call arguments.
     crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(user_input));
+    crate::transcript::begin_turn();
 
     // Sprint 14: even single-shot runs go through the fallback wrapper so
     // brain100 / brownfield benchmarks can measure Auto-preset escalation
@@ -282,6 +283,7 @@ pub(crate) fn run_turn_with_retry(
     // Stash any file paths from the raw user input — covers Telegram (its
     // single call site) plus any future caller of run_turn_with_retry.
     crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(input));
+    crate::transcript::begin_turn();
 
     // Drain any deferred coder lease before the brain runs so the coder
     // doesn't contend with the brain for VRAM. The coalesced-swap design

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -651,6 +651,7 @@ pub fn run_forge_mission(user_input: &str, opts: SessionOptions) -> Result<TurnS
         };
         let mut coder_runtime = build_forge_runtime(session.clone(), &mission, false);
         crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(&coder_input));
+        crate::transcript::begin_turn();
         let _ = crate::brain_selector::run_turn_with_fallback(
             &mut coder_runtime,
             &coder_input,
@@ -1036,6 +1037,7 @@ pub fn run_forge_mission(user_input: &str, opts: SessionOptions) -> Result<TurnS
          in the body that automated review found unresolved issues. Do nothing else."
     };
     crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(submit_input));
+    crate::transcript::begin_turn();
     let submit_summary = crate::brain_selector::run_turn_with_fallback(
         &mut submit_runtime,
         submit_input,

--- a/crates/claudette/src/run/repl.rs
+++ b/crates/claudette/src/run/repl.rs
@@ -147,6 +147,7 @@ pub fn run_agent_repl(opts: SessionOptions) -> Result<()> {
         }
 
         crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(trimmed));
+        crate::transcript::begin_turn();
 
         // Vision: if the line contains image-file path tokens (drag-drop
         // typically pastes them via Windows Terminal), attach them and

--- a/crates/claudette/src/transcript.rs
+++ b/crates/claudette/src/transcript.rs
@@ -22,7 +22,8 @@
 //! Everything stays under `~/.claudette/` — local-only, never uploaded,
 //! consistent with the privacy posture in `PRIVACY.md`.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::fmt::Write as _;
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -97,6 +98,39 @@ pub fn take_pending_undo() -> Option<Value> {
     PENDING_UNDO.with(|p| p.borrow_mut().take())
 }
 
+thread_local! {
+    /// The id of the turn currently in progress, stamped onto every
+    /// transcript line [`record`]ed during it so `/undo` and `/diff` can
+    /// group a whole turn's actions. `None` until the first [`begin_turn`] —
+    /// lines recorded outside any turn carry `turn: null` and the
+    /// turn-scoped ops treat each as its own singleton (falling back to
+    /// single-entry behavior).
+    static CURRENT_TURN_ID: RefCell<Option<String>> = const { RefCell::new(None) };
+    /// Per-process monotonic turn counter — the tie-breaker in the turn id.
+    static TURN_COUNTER: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Open a new turn: mint a fresh turn id so subsequent [`record`] lines are
+/// tagged with it. Called at every turn entry point, alongside
+/// `tools::set_current_turn_paths` (same thread — tools run synchronously on
+/// the worker thread that recorded the turn). The id is
+/// `<unix_ms>-<pid>-<counter>`, globally unique: the transcript is
+/// append-only and outlives the process, so a bare counter would collide
+/// with another session's turns and make "undo the last turn" ambiguous.
+pub fn begin_turn() {
+    let n = TURN_COUNTER.with(|c| {
+        let v = c.get();
+        c.set(v.wrapping_add(1));
+        v
+    });
+    let id = format!("{}-{}-{n}", now_ms(), std::process::id());
+    CURRENT_TURN_ID.with(|t| *t.borrow_mut() = Some(id));
+}
+
+fn current_turn_id() -> Option<String> {
+    CURRENT_TURN_ID.with(|t| t.borrow().clone())
+}
+
 /// Move `original` into the trash instead of deleting it. Returns the trash
 /// path. Falls back to copy+remove when `rename` crosses filesystems.
 /// Leaves an undo ref for [`take_pending_undo`].
@@ -138,6 +172,7 @@ pub fn record(tool: &str, input: &str, undo: Option<Value>) {
     };
     let line = json!({
         "ts": now_ms() as u64,
+        "turn": current_turn_id(),
         "tool": tool,
         "input": capped,
         "undo": undo.unwrap_or(Value::Null),
@@ -158,46 +193,134 @@ pub fn record(tool: &str, input: &str, undo: Option<Value>) {
     }
 }
 
-/// Undo the most recent transcript entry that (a) carries an undo ref and
-/// (b) hasn't already been undone. Restores the trashed/pre-image file back
-/// to its original location (the trash copy is **kept** — recoverability
-/// bias), appends an `undo` entry, and returns a human-readable summary.
-#[allow(clippy::too_many_lines)]
-pub fn undo_last() -> Result<String, String> {
-    let path = transcript_path();
-    let raw = fs::read_to_string(&path)
+/// Read + parse the transcript into one `Value` per line (unparseable lines
+/// dropped). Returns the `nothing to undo` error string when the file is
+/// missing so callers can surface it verbatim.
+fn read_entries() -> Result<Vec<Value>, String> {
+    let raw = fs::read_to_string(transcript_path())
         .map_err(|_| "nothing to undo (no actions recorded yet)".to_string())?;
-
-    let entries: Vec<Value> = raw
+    Ok(raw
         .lines()
         .filter_map(|l| serde_json::from_str(l).ok())
-        .collect();
+        .collect())
+}
 
-    // Entries already reverted by a previous /undo — keyed on the TRASH
-    // PATH, which is collision-free by construction (the `-1`/`-2` suffix
-    // loop in `trash_target_for`). Keying on `ts` broke batch deletes: a
-    // model emitting 3 note_deletes in one assistant message runs them in
-    // a sub-millisecond loop, all sharing one ms timestamp — undoing the
-    // first marked the SIBLINGS as undone too, making them unreachable
-    // (caught by the adversarial review with a standalone repro).
-    let undone: Vec<&str> = entries
+/// Trash paths already reverted by a previous `/undo` — keyed on the TRASH
+/// PATH, which is collision-free by construction (the `-1`/`-2` suffix loop
+/// in `trash_target_for`). Keying on `ts` broke batch deletes: a model
+/// emitting 3 note_deletes in one assistant message runs them in a
+/// sub-millisecond loop, all sharing one ms timestamp — undoing the first
+/// marked the SIBLINGS as undone too, making them unreachable (caught by the
+/// adversarial review with a standalone repro).
+fn undone_trash_set(entries: &[Value]) -> Vec<String> {
+    entries
         .iter()
         .filter(|e| e.get("tool").and_then(Value::as_str) == Some("undo"))
         .filter_map(|e| e.get("undone_trash").and_then(Value::as_str))
-        .collect();
+        .map(str::to_string)
+        .collect()
+}
 
-    let target = entries.iter().rev().find(|e| {
-        e.get("undo")
-            .and_then(|u| u.get("trash"))
-            .and_then(Value::as_str)
-            .is_some_and(|t| !undone.contains(&t))
-    });
+/// True when `entry` carries a recoverable pre-image not yet reverted.
+fn is_recoverable(entry: &Value, undone: &[String]) -> bool {
+    entry
+        .get("undo")
+        .and_then(|u| u.get("trash"))
+        .and_then(Value::as_str)
+        .is_some_and(|t| !undone.iter().any(|u| u == t))
+}
+
+/// Undo the most recent transcript entry that (a) carries an undo ref and
+/// (b) hasn't already been undone — the `/undo one` behavior. Restores the
+/// trashed/pre-image file back to its original location (the trash copy is
+/// **kept** — recoverability bias), appends an `undo` entry, and returns a
+/// human-readable summary.
+pub fn undo_last() -> Result<String, String> {
+    let entries = read_entries()?;
+    let undone = undone_trash_set(&entries);
+    let target = entries.iter().rev().find(|e| is_recoverable(e, &undone));
     let Some(entry) = target else {
         return Err(
             "nothing to undo (no recorded action carries a recoverable pre-image)".to_string(),
         );
     };
+    restore_entry(entry, &transcript_path())
+}
 
+/// Undo every recoverable action of the **last turn** as one step (the
+/// default `/undo`). The last turn is the turn id carried by the most recent
+/// recoverable, not-yet-undone entry; a turn's entries are contiguous in the
+/// append-only log, so we revert that entry and every sibling sharing its
+/// turn id, **newest-first** (correct when a file was edited twice in the
+/// turn — the last restore lands the turn's original pre-image). A `null`
+/// turn id (recorded outside `begin_turn`) groups only with itself, degrading
+/// gracefully to single-entry behavior.
+pub fn undo_last_turn() -> Result<String, String> {
+    let entries = read_entries()?;
+    let undone = undone_trash_set(&entries);
+
+    let Some(last) = entries.iter().rev().find(|e| is_recoverable(e, &undone)) else {
+        return Err(
+            "nothing to undo (no recorded action carries a recoverable pre-image)".to_string(),
+        );
+    };
+    let turn = last.get("turn").and_then(Value::as_str).map(str::to_string);
+
+    // Newest-first group of this turn's still-recoverable entries.
+    let group: Vec<&Value> = match &turn {
+        Some(id) => entries
+            .iter()
+            .rev()
+            .filter(|e| e.get("turn").and_then(Value::as_str) == Some(id.as_str()))
+            .filter(|e| is_recoverable(e, &undone))
+            .collect(),
+        None => vec![last],
+    };
+
+    let path = transcript_path();
+    let mut summaries = Vec::new();
+    let mut errors = Vec::new();
+    for e in group {
+        match restore_entry(e, &path) {
+            Ok(s) => summaries.push(s),
+            Err(err) => errors.push(err),
+        }
+    }
+    if summaries.is_empty() {
+        return Err(errors
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "nothing to undo".to_string()));
+    }
+    let mut out = if summaries.len() == 1 {
+        summaries.remove(0)
+    } else {
+        let mut s = format!("undid the last turn — restored {} files:", summaries.len());
+        for line in &summaries {
+            s.push_str("\n  • ");
+            s.push_str(line);
+        }
+        s
+    };
+    if !errors.is_empty() {
+        let _ = write!(
+            out,
+            "\n  ({} could not be restored: {})",
+            errors.len(),
+            errors.join("; ")
+        );
+    }
+    Ok(out)
+}
+
+/// Restore a single transcript `entry`'s pre-image: the shared core of
+/// `undo_last` (one entry) and `undo_last_turn` (every recoverable entry of a
+/// turn). Re-validates both paths against a tampered `actions.jsonl`, backs
+/// up any newer content at the target first (fail-closed), copies the
+/// pre-image back, and appends an `undo` marker keyed on the collision-free
+/// trash path. `path` is the transcript file to append the marker to.
+#[allow(clippy::too_many_lines)]
+fn restore_entry(entry: &Value, path: &Path) -> Result<String, String> {
     let ts = entry.get("ts").and_then(Value::as_u64).unwrap_or(0);
     let tool = entry
         .get("tool")
@@ -292,7 +415,7 @@ pub fn undo_last() -> Result<String, String> {
     let marker = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&path)
+        .open(path)
         .and_then(|mut f| writeln!(f, "{line}"));
     if let Err(e) = marker {
         eprintln!(
@@ -310,6 +433,71 @@ pub fn undo_last() -> Result<String, String> {
             "restored {original} from trash (undid {tool}; the trash copy at {trash} is kept)"
         ),
     })
+}
+
+/// Render the cumulative diff of the **last turn** — for `/diff`. For each
+/// entry of the most recent turn that carries a pre-image, diffs the trashed
+/// pre-image (before) against the file now on disk (after), via the same
+/// colored renderer the `[y/N]` edit gate uses. Read-only: no restore, no
+/// markers, no shadow-git. A `move_to_trash` deletion shows as an all-`-`
+/// block (the file is gone from disk); an overwrite shows the real hunk.
+///
+/// Limitation: brand-new file *creates* carry no pre-image (nothing was
+/// snapshotted), so they don't appear — `/diff` covers overwrites and
+/// deletes, which is what the recoverability machinery tracks.
+pub fn diff_last_turn() -> Result<String, String> {
+    let entries = fs::read_to_string(transcript_path())
+        .map_err(|_| "no actions recorded yet — nothing to diff".to_string())?
+        .lines()
+        .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+        .collect::<Vec<_>>();
+
+    // Last turn = the turn id on the most recent entry that carries one.
+    let turn = entries
+        .iter()
+        .rev()
+        .find_map(|e| e.get("turn").and_then(Value::as_str).map(str::to_string))
+        .ok_or_else(|| "no turn-tagged actions recorded yet — nothing to diff".to_string())?;
+
+    // That turn's pre-image-bearing entries, in reading (oldest-first) order.
+    let group: Vec<&Value> = entries
+        .iter()
+        .filter(|e| e.get("turn").and_then(Value::as_str) == Some(turn.as_str()))
+        .filter(|e| e.get("undo").and_then(|u| u.get("trash")).is_some())
+        .collect();
+    if group.is_empty() {
+        return Err(
+            "the last turn changed no files with a recoverable pre-image \
+                    (brand-new files aren't tracked by /diff)"
+                .to_string(),
+        );
+    }
+
+    let mut blocks = Vec::new();
+    for e in group {
+        let undo_ref = e.get("undo").cloned().unwrap_or(Value::Null);
+        let (Some(trash), Some(original)) = (
+            undo_ref.get("trash").and_then(Value::as_str),
+            undo_ref.get("original").and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+        // before = the trashed pre-image; after = the file now on disk (empty
+        // when the action deleted it, i.e. move_to_trash left nothing behind).
+        let before = fs::read_to_string(trash).unwrap_or_default();
+        let after = fs::read_to_string(original).unwrap_or_default();
+        if before == after {
+            continue;
+        }
+        blocks.push(crate::diff_preview::render_file_change(original, &before, &after).join("\n"));
+    }
+    if blocks.is_empty() {
+        return Err(
+            "the last turn's changes are no longer on disk (reverted or already undone)"
+                .to_string(),
+        );
+    }
+    Ok(blocks.join("\n\n"))
 }
 
 #[cfg(test)]
@@ -601,6 +789,146 @@ mod tests {
                 take_pending_undo().is_none(),
                 "second take must be empty — no stale undo may leak to the next tool call"
             );
+        });
+    }
+
+    #[test]
+    fn undo_last_turn_restores_every_action_of_the_turn() {
+        with_temp_home(|home| {
+            // One turn deletes two files.
+            begin_turn();
+            let a = write_tmp(home, "a.md", "AAA");
+            let b = write_tmp(home, "b.md", "BBB");
+            let _ = move_to_trash(&a).unwrap();
+            record("note_delete", "a", take_pending_undo());
+            let _ = move_to_trash(&b).unwrap();
+            record("note_delete", "b", take_pending_undo());
+
+            let msg = undo_last_turn().expect("undo whole turn");
+            assert!(a.exists() && b.exists(), "both files restored: {msg}");
+            assert_eq!(fs::read_to_string(&a).unwrap(), "AAA");
+            assert_eq!(fs::read_to_string(&b).unwrap(), "BBB");
+
+            let err = undo_last_turn().unwrap_err();
+            assert!(err.contains("nothing to undo"), "got: {err}");
+        });
+    }
+
+    #[test]
+    fn undo_last_turn_leaves_earlier_turns_intact() {
+        with_temp_home(|home| {
+            begin_turn();
+            let a = write_tmp(home, "a.md", "AAA");
+            let _ = move_to_trash(&a).unwrap();
+            record("note_delete", "a", take_pending_undo());
+
+            begin_turn(); // a distinct, later turn
+            let b = write_tmp(home, "b.md", "BBB");
+            let _ = move_to_trash(&b).unwrap();
+            record("note_delete", "b", take_pending_undo());
+
+            let msg = undo_last_turn().expect("undo last turn");
+            assert!(b.exists(), "last turn's file restored: {msg}");
+            assert!(!a.exists(), "the earlier turn must stay untouched: {msg}");
+
+            // A second whole-turn undo reaches back to the prior turn.
+            let msg2 = undo_last_turn().expect("undo prior turn");
+            assert!(a.exists(), "prior turn now restored: {msg2}");
+        });
+    }
+
+    #[test]
+    fn undo_one_reverts_a_single_action_within_a_multi_action_turn() {
+        with_temp_home(|home| {
+            begin_turn();
+            let a = write_tmp(home, "a.md", "AAA");
+            let b = write_tmp(home, "b.md", "BBB");
+            let _ = move_to_trash(&a).unwrap();
+            record("note_delete", "a", take_pending_undo());
+            let _ = move_to_trash(&b).unwrap();
+            record("note_delete", "b", take_pending_undo());
+
+            // `/undo one` == undo_last: only the most recent action (b).
+            let msg = undo_last().expect("undo one");
+            assert!(b.exists(), "b restored: {msg}");
+            assert!(
+                !a.exists(),
+                "a stays deleted after a single-step undo: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn undo_last_turn_without_turn_ids_falls_back_to_single_entry() {
+        with_temp_home(|home| {
+            // No begin_turn() — entries carry turn: null, so the turn-scoped
+            // undo degrades to reverting just the newest recoverable action.
+            let a = write_tmp(home, "a.md", "AAA");
+            let b = write_tmp(home, "b.md", "BBB");
+            let _ = move_to_trash(&a).unwrap();
+            record("note_delete", "a", take_pending_undo());
+            let _ = move_to_trash(&b).unwrap();
+            record("note_delete", "b", take_pending_undo());
+
+            let msg = undo_last_turn().expect("fallback undo");
+            assert!(b.exists() && !a.exists(), "only the newest restored: {msg}");
+        });
+    }
+
+    #[test]
+    fn diff_last_turn_renders_the_turns_changes() {
+        with_temp_home(|home| {
+            begin_turn();
+            let f = write_tmp(home, "doc.txt", "line one\nOLD\nline three\n");
+            let _ = snapshot_to_trash(&f).unwrap();
+            record("write_file", "doc.txt", take_pending_undo());
+            fs::write(&f, "line one\nNEW\nline three\n").unwrap();
+
+            let diff = diff_last_turn().expect("diff should render");
+            assert!(diff.contains("doc.txt"), "header missing: {diff}");
+            assert!(diff.contains("- OLD"), "removal missing: {diff}");
+            assert!(diff.contains("+ NEW"), "addition missing: {diff}");
+            // Unchanged lines stay dim context, never `-`/`+` markers.
+            assert!(
+                !diff.contains("- line one"),
+                "context wrongly marked: {diff}"
+            );
+        });
+    }
+
+    #[test]
+    fn diff_last_turn_covers_only_the_last_turn() {
+        with_temp_home(|home| {
+            // Turn 1 overwrites f1; turn 2 overwrites f2. /diff shows only f2.
+            begin_turn();
+            let f1 = write_tmp(home, "one.txt", "V1\n");
+            let _ = snapshot_to_trash(&f1).unwrap();
+            record("write_file", "one.txt", take_pending_undo());
+            fs::write(&f1, "V1b\n").unwrap();
+
+            begin_turn();
+            let f2 = write_tmp(home, "two.txt", "V2\n");
+            let _ = snapshot_to_trash(&f2).unwrap();
+            record("write_file", "two.txt", take_pending_undo());
+            fs::write(&f2, "V2b\n").unwrap();
+
+            let diff = diff_last_turn().expect("diff should render");
+            assert!(diff.contains("two.txt"), "last turn's file shown: {diff}");
+            assert!(
+                !diff.contains("one.txt"),
+                "earlier turn must not appear: {diff}"
+            );
+        });
+    }
+
+    #[test]
+    fn diff_last_turn_with_no_pre_images_is_explicit() {
+        with_temp_home(|_| {
+            begin_turn();
+            // A mutating action that carries no pre-image (e.g. todo_add).
+            record("todo_add", "whatever", None);
+            let err = diff_last_turn().unwrap_err();
+            assert!(err.contains("no files"), "got: {err}");
         });
     }
 }

--- a/crates/claudette/src/tui_worker.rs
+++ b/crates/claudette/src/tui_worker.rs
@@ -311,6 +311,7 @@ pub fn spawn_worker(
                     crate::tools::set_current_turn_paths(crate::tools::extract_user_prompt_paths(
                         &text,
                     ));
+                    crate::transcript::begin_turn();
                     let image_pairs: Vec<(String, String)> = images
                         .into_iter()
                         .map(|att| (att.media_type, att.data_b64))


### PR DESCRIPTION
Backlog **#4 [S2]** of the greatest-assistant campaign (`runs/greatest-2026-07-03/PLAN.md`). Non-behavioral, low-risk — David-signed-off in the ranked backlog.

## What
- **`/undo`** now reverts the **whole last turn** atomically. **`/undo one`** keeps the old single-action behavior.
- **`/diff`** (new) renders the cumulative last-turn file changes — each trashed pre-image vs the file now on disk — via the same colored unified-diff renderer the `[y/N]` edit gate uses.
- **No shadow-git, no auto-commit** — pure plumbing on the existing trash/pre-image machinery (opencode's shadow-git failure mode was explicitly rejected in `gap-scan.md`).

## How
- Transcript lines gain a globally-unique `turn` id `<unix_ms>-<pid>-<counter>`, stamped by a new `transcript::begin_turn()` called at every turn entry point (alongside `set_current_turn_paths`). The id outlives the process (the log is append-only across sessions) so "the last turn" is never ambiguous. Lines recorded outside a turn carry `turn: null` and degrade gracefully to single-entry behavior.
- Per-entry restore is factored into a shared `restore_entry()`, used by both `undo_last` (one) and the new `undo_last_turn` (newest-first, so a file edited twice in one turn lands its original pre-image). All the existing tamper-defence (trash-dir containment, read-path validation, fail-closed backup-before-restore) is preserved.
- `diff_preview::render_file_change(path, before, after)` extracted public; `render_replacement` now delegates to it.

**Limitation (documented in code + `/diff` message):** brand-new file *creates* carry no pre-image, so `/diff` covers overwrites and deletes — what the recoverability machinery tracks.

## Gate
- `cargo fmt --all` ✓
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings` ✓
- tests green in **default (lean)** and **--all-features** — 10 new (7 transcript + 1 diff_preview + 2 commands-parse), 0 regressions.
- Non-behavioral (REPL slash surface + transcript plumbing; the model's tool surface and system prompt are untouched) → no battery A/B needed.

Staged the 7 source files only — `MODEL-COMPARISON.md` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)