### PR TITLE
deps: bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (published 2026-07-06): invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` in crossbeam-epoch <= 0.9.19. We carry crossbeam-epoch 0.9.18 transitively (via crossbeam-deque). The advisory landed in the RustSec DB *after* the last green CI run, so:

- **main is currently red** (run 28965813361, the #169 merge push) on `cargo audit` + `cargo deny` — both required checks.
- **#168 is blocked** by the same advisory; its own `ignore` bump is innocent.

## What

Lockfile-only: `cargo update -p crossbeam-epoch` → 0.9.18 → 0.9.20 (semver-patch, transitive). No source changes.

Verified locally: `cargo audit` clean (305 deps, 1159 advisories), `cargo check --all-features` green.

## Merge order (strict:true)

1. Merge **this PR** first → main goes green again.
2. "Update branch" on **#168** → its audit/deny re-run green → merge.

## Non-blocking observations from the deny log (no action needed now)

- `warning[unnecessary-skip]`: `getrandom` skip in deny.toml applies to a crate with only one version left.
- `warning[unmatched-skip]`: `wit-bindgen` skip no longer matches anything.

Both are stale deny.toml skip entries worth pruning in the next housekeeping pass (candidate for the finishing-run roast item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)