### PR TITLE
docs: truth-pass — forge routing, compaction/max-fix defaults, stale names & anchors

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -78,8 +78,8 @@ Each outbound connection below is **off by default** until you opt in, and is **
 | `huggingface.co` | First-time voice setup downloading Whisper | The model file fetch (no content). One-time per model. |
 | Microsoft Edge TTS endpoint | `/voice on` in `--telegram` mode | The reply text being spoken aloud. Routed through the `edge-tts` python package, not Claudette directly. |
 | `accounts.google.com`, `*.googleapis.com` | `claudette --auth-google`, then any `calendar_*` / `gmail_*` tool call | OAuth handshake; then calendar/gmail content read or written **by your request**. |
-| `api.open-meteo.com`, `geocoding-api.open-meteo.com` | `weather_forecast` tool call | A place name. No API key required by open-meteo. |
-| `en.wikipedia.org` | `wikipedia_search` tool call | The search query. |
+| `api.open-meteo.com`, `geocoding-api.open-meteo.com` | `weather` tool call | A place name. No API key required by open-meteo. |
+| `en.wikipedia.org` | `wikipedia` tool call | The search query. |
 | `api.search.brave.com` | `web_search` tool, requires `BRAVE_API_KEY` | The search query. |
 | `api.github.com`, `github.com` | `github` tool group, requires `GITHUB_TOKEN` | Whatever the model calls the API for (issues, PRs, etc.) |
 

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -447,7 +447,7 @@ fn forge_phase0_preflight(mission: &crate::missions::Mission) -> Result<Option<(
 ///    against the original request. Returns `{score, pass, feedback}`.
 ///    On parse failure, treated as pass (advisory mode).
 /// 4. **Fix-loop** — if Verifier `pass=false` and `round < max_fix_rounds()`,
-///    re-runs Coder with the Verifier's feedback prepended. Default two
+///    re-runs Coder with the Verifier's feedback prepended. Default three
 ///    rounds; override with `CLAUDETTE_MAX_FIX_ROUNDS` (clamped to 10).
 /// 5. **Submitter** — final Coder turn with `should_submit=true` that only
 ///    calls `mission_submit` (PR opens here, not earlier).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ The `gmail`, `calendar`, and `telegram` groups are compiled **only** into an `in
 1. **Planner** — tool-less brain turn (`Role::Planner` from `~/.claudettes-forge/models.toml`) decomposes the user's request into a 3–5 step numbered plan, prepended to the Coder's input.
 2. **Coder (round 0)** — full forge runtime (`files`, `search`, `git`, `advanced`, `github` groups enabled) with `should_submit=false`. Brain commits its change but the system prompt forbids `mission_submit`/`git_push`.
 3. **Verifier** — tool-less brain turn (`Role::Verifier`) reads `git diff HEAD` and emits one-line JSON: `{"score": <1-10>, "pass": <bool>, "feedback": "<reason>"}`. Resilient to code fences and trailing prose.
-4. **Fix-loop** — if `pass=false` and `round < MAX_FIX_ROUNDS` (2), re-runs the Coder with the Verifier's feedback prepended to the prompt.
+4. **Fix-loop** — if `pass=false` and `round < MAX_FIX_ROUNDS` (3), re-runs the Coder with the Verifier's feedback prepended to the prompt.
 5. **Submitter** — final Coder turn with `should_submit=true` that just calls `mission_submit`. PR opens here, never earlier.
 
 Persona overlay: `personas/codex7.md` is baked into the binary via `include_str!` and parsed at startup. Its `voice` one-liner + backstory prose are appended to the forge-mode system prompt so the brain adopts a consistent style.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,8 +14,8 @@ Claudette intentionally does **not** auto-load `.env` from the current working d
 | `CLAUDETTE_MODEL` | `qwen3.5:4b` (Auto preset) | Brain model override. |
 | `CLAUDETTE_NUM_CTX` | `16384` | Brain context window in tokens. |
 | `CLAUDETTE_NUM_PREDICT` | `6144` | Max output tokens per request. |
-| `CLAUDETTE_COMPACT_THRESHOLD` | `1000000` | Auto-compaction trigger (estimated tokens). Default makes auto-compact a no-op for typical 16K–128K context windows; set to `12000` (or a fraction of your `num_ctx`) on tight contexts. |
-| `CLAUDETTE_SOFT_COMPACT_THRESHOLD` | unset | Optional intermediate compaction tier. Fires below the hard threshold and preserves 12 recent messages instead of 4 — useful on long real-world sessions with 35B+ brains where the hard 1M default never triggers but turns pay hundreds of K input tokens. Set e.g. `200000`. |
+| `CLAUDETTE_COMPACT_THRESHOLD` | `num_ctx / 2` (adaptive) | Auto-compaction trigger (estimated tokens). Unset → half the active brain's `num_ctx`, clamped to `[4000, 1000000]`, so a real 16K–128K window compacts *before* it overflows. Pin an exact value like `12000` to override; the `1000000` cap is only the ceiling for enormous windows. |
+| `CLAUDETTE_SOFT_COMPACT_THRESHOLD` | unset | Optional intermediate compaction tier. Fires below the hard threshold and preserves 12 recent messages instead of 4 — useful on long real-world sessions with 35B+ brains where you want gentler compaction before the hard `num_ctx / 2` threshold fires. Set e.g. `200000`. |
 | `CLAUDETTE_MAX_ITERATIONS` | `40` | Per-turn (model → tool → result) loop ceiling. Lower it (e.g. `15`) to fail-fast on small-model spirals; raise it for legitimate long tool chains. |
 | `CLAUDETTE_SESSION` | `~/.claudette/sessions/last.json` | Override the session file path. |
 | `CLAUDETTE_MEMORY` | `~/.claudette/CLAUDETTE.MD` | Override the path Claudette loads user-memory from. |
@@ -64,7 +64,7 @@ Two layers enforce it: an HTTP-layer guard in the reqwest path checks the destin
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `CLAUDETTE_MAX_FIX_ROUNDS` | `2` | Cap on Coder→Verifier fix-loop rounds in `--forge`. Default 2 is the empirical sweet spot for local 8b coders. Raise to 4–6 if you've pinned a stronger Verifier model and want it to keep pushing back. Clamped at 10. |
+| `CLAUDETTE_MAX_FIX_ROUNDS` | `3` | Cap on Coder→Verifier fix-loop rounds in `--forge`. Default 3 is the empirical sweet spot for local 8b coders. Raise to 4–6 if you've pinned a stronger Verifier model and want it to keep pushing back. Clamped at 10. |
 | `CLAUDETTE_FORGE_ABORT_WINDOW_SECS` | `3` | Grace window (seconds) to Ctrl-C out of a forge run before it starts working. Set `0` to skip the pause in CI / scripted runs. Clamped at 30. |
 
 ## Tokens (per-tool)

--- a/docs/forge.md
+++ b/docs/forge.md
@@ -153,25 +153,28 @@ Forge phases can dispatch different roles to different models. The
 overlay lives at `~/.claudettes-forge/models.toml`:
 
 ```toml
-[Planner]
+[planner]
 model = "qwen3.5:9b"
 
-[Coder]
+[coder]
 model = "qwen3-coder:30b"
 
-[Verifier]
+[verifier]
 model = "qwen3.5:9b"
-
-[Submitter]
-model = "qwen3.5:4b"
 ```
+
+The section headers are **lowercase** (`[planner]`, `[coder]`,
+`[verifier]`) — the loader matches them case-sensitively and silently
+ignores unknown keys, so a capitalized `[Planner]` routes nothing.
 
 | Role | Phase | Default fallback |
 |------|-------|------------------|
-| `Planner` | Planner turn | claudette's active brain |
-| `Coder` | Coder + fix-loop turns | claudette's active brain |
-| `Verifier` | Verifier turn | claudette's active brain |
-| `Submitter` | Final `mission_submit` turn | claudette's active brain |
+| `planner` | Planner turn | claudette's active brain |
+| `coder` | Coder + fix-loop turns | claudette's active brain |
+| `verifier` | Verifier turn | claudette's active brain |
+
+The **Submitter** phase is not separately routable — it runs as the
+final Coder turn, so it uses whatever the `coder` role resolves to.
 
 Missing roles silently fall back to claudette's currently-active brain
 (the one `current_model()` resolves at runtime — i.e. `CLAUDETTE_MODEL`
@@ -184,7 +187,6 @@ Env-var overrides also exist:
 - `CLAUDETTES_FORGE_PLANNER_MODEL`
 - `CLAUDETTES_FORGE_CODER_MODEL`
 - `CLAUDETTES_FORGE_VERIFIER_MODEL`
-- `CLAUDETTES_FORGE_SUBMITTER_MODEL`
 
 Env vars take precedence over `models.toml` when both are set.
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -9,7 +9,7 @@
 | Disk | ~3 GB (brain only) — or ~8 GB with the lightweight 7b coder | ~27 GB (3.5 brain + fallback + 30b coder) / ~24 GB (single qwen3.6-35b-a3b serving both roles) | NVMe SSD |
 | OS | Windows 10+, Linux, macOS | Windows 11 / Ubuntu 24.04 / macOS 14+ | Windows 11 Pro |
 
-> **Which model should I pick?** See [Recommended models](../README.md#recommended-models) in the README for the per-tier hierarchy. TL;DR: `qwen3.5:4b` for the smallest setup; **`qwen3.6-35b-a3b` (via LM Studio) for the best brain by a wide margin** when you have 16 GB+ VRAM or 32 GB RAM with CPU-MoE offload.
+> **Which model should I pick?** See [Which model should I run?](../README.md#-which-model-should-i-run) in the README for the per-tier hierarchy. TL;DR: `qwen3.5:4b` for the smallest setup; **`qwen3.6-35b-a3b` (via LM Studio) for the best brain by a wide margin** when you have 16 GB+ VRAM or 32 GB RAM with CPU-MoE offload.
 
 ## Model footprint
 

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -52,10 +52,10 @@ To skip the Auto-preset dance entirely (no fallback, no stuck-signal escalation)
 ## Forge mode knobs
 
 ```bash
-export CLAUDETTE_MAX_FIX_ROUNDS=4                # default 2, clamped at 10
+export CLAUDETTE_MAX_FIX_ROUNDS=4                # default 3, clamped at 10
 ```
 
-The default of 2 is tuned for local 8b coder models. If you've routed Verifier to a stronger model via `~/.claudettes-forge/models.toml`, raising this often pays off — the Verifier catches subtler defects and the Coder still has room to fix them. Above 6 you're usually fighting a context-budget problem, not a quality problem.
+The default of 3 is tuned for local 8b coder models. If you've routed Verifier to a stronger model via `~/.claudettes-forge/models.toml`, raising this often pays off — the Verifier catches subtler defects and the Coder still has room to fix them. Above 6 you're usually fighting a context-budget problem, not a quality problem.
 
 Per-role model routing lives in `~/.claudettes-forge/models.toml`:
 
@@ -93,7 +93,7 @@ export CLAUDETTE_SOFT_COMPACT_THRESHOLD=12000    # earlier "preserve 12 turns" c
 export CLAUDETTE_MAX_ITERATIONS=80               # per-turn tool-call ceiling
 ```
 
-The default compaction threshold of 1M tokens is effectively "off" — it exists for the 128K+ contexts most local-model setups never reach. Set `CLAUDETTE_COMPACT_THRESHOLD` to roughly two-thirds of your `num_ctx` for predictable behavior on tighter contexts.
+The default compaction threshold is adaptive — half the active brain's `num_ctx` (clamped to `[4000, 1000000]`) — so a real 16K–128K window compacts before it overflows. The `1M` value is only the upper cap for enormous windows. Set `CLAUDETTE_COMPACT_THRESHOLD` explicitly to pin a specific trigger (e.g. two-thirds of your `num_ctx`) instead of the `num_ctx / 2` default.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,7 +71,7 @@ Add `--offline` (or set `CLAUDETTE_OFFLINE=1`) to any of these to **enforce**
 the air-gap — every outbound call except the local model backend + loopback is
 hard-blocked, so the brain and recall keep working but web search, mail, GitHub,
 Telegram, and remote git all refuse. `claudette --offline --doctor` prints the
-exact allow-list. See [Air-gapped by design](../README.md#-air-gapped-by-design).
+exact allow-list. See [Air-gapped, and enforced](../README.md#-air-gapped-and-enforced).
 
 ## The TUI in 60 seconds
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,5 +77,5 @@ The REPL prompter is interactive. The TUI shows a confirmation modal over the ch
 - **Autosave** after every REPL turn to `~/.claudette/sessions/last.json`.
 - **Resume** with `--resume` or `-r`.
 - **Named sessions** via `/save <name>` and `/load <name>` (stored at `~/.claudette/sessions/<name>.json`).
-- **Auto-compaction** is effectively off by default (1 M estimated tokens) — opt in for tight context windows via `CLAUDETTE_COMPACT_THRESHOLD=12000`. When it does fire, it summarises old turns, keeps recent ones verbatim, and preserves tool-result anchoring.
+- **Auto-compaction** triggers adaptively at half the active brain's `num_ctx` by default (clamped to `[4000, 1000000]` estimated tokens), so a real 16K–128K window compacts before it overflows — pin an exact trigger via `CLAUDETTE_COMPACT_THRESHOLD=12000`. When it fires, it summarises old turns, keeps recent ones verbatim, and preserves tool-result anchoring.
 - **Sliding-window truncator** acts as a safety net inside the API client.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ binary has no cloud code, so it errors with a one-line reinstall hint instead.
 /cost                Lifetime token usage.
 /tools               List all tools grouped by capability.
 /model               Show the active brain model.
-/models              Alias for /model.
+/models              Show the current model config.
 /preset fast|auto|smart  Switch model preset.
 /brain <model>       Pin the brain model (or "auto" to re-enable fallback).
 /memory              Show CLAUDETTE.MD contents.
@@ -67,7 +67,7 @@ Three additional commands are **Telegram-only** (they have no effect in the REPL
 | Tier | Behaviour | Example tools |
 |------|-----------|---------------|
 | **ReadOnly** | Auto-allowed | time, note_list, file reads, git status, all external APIs |
-| **WorkspaceWrite** | Auto-allowed | note_create, note_update, todo_add, web_search, github comment |
+| **WorkspaceWrite** | Auto-allowed | note_create, todo_add, web_search, github comment |
 | **DangerFullAccess** | Prompts `[y/N]` every time | bash, edit_file, git add/commit/push/checkout, cross-org PRs |
 
 The REPL prompter is interactive. The TUI shows a confirmation modal over the chat — `y` allows; `n`, `Esc`, or `Enter` denies (deny is the default); long inputs scroll with `↑`/`↓` and are never truncated. Telegram bot denies DangerFullAccess by default (no TTY to confirm with).


### PR DESCRIPTION
## What & why

A **docs-truth pass** fixing every user-facing doc claim the 2026-07 roast found
contradicting the source. Nothing behavioral — docs + one stale in-code comment.

> **Stacked on #171** (`refactor/retire-codet-coder-subsystem`). Five of the six
> touched files are also edited by #171, so this PR is based on that branch to
> keep the history linear and conflict-free. **Merge order: #171 first, then this.**
> GitHub will retarget the base to `main` automatically once #171 lands (or
> rebase `git rebase --onto main refactor/retire-codet-coder-subsystem`).

## Findings fixed

**HIGH**
- **H-B (R3-H1)** — `forge.md` `models.toml` example used **capitalized** section
  headers (`[Planner]`/`[Coder]`/`[Verifier]`). The loader
  (`forge/models_toml.rs`) deserializes case-sensitive **lowercase** serde fields
  and silently ignores unknown keys, so a user copy-pasting the example got **zero
  role routing**. Lowercased to `[planner]`/`[coder]`/`[verifier]` (matches the
  already-correct `power-user.md`) + added a one-line "headers are lowercase" note.

**MEDIUM**
- **M-B (R3-M1)** — compaction-default docs (`configuration.md`, `power-user.md`,
  `usage.md`) claimed a static `1M` threshold "effectively off." The real default
  is adaptive: `(num_ctx / 2).clamp(4000, 1_000_000)` (`compaction_policy.rs:78`),
  which fires on every real 16K–128K window. Corrected all three; `1M` is now
  described as the upper cap it actually is.
- **M-C (R3-M2)** — `forge.md` documented a **Submitter** model-routing role
  (`[Submitter]` TOML key, table row, `CLAUDETTES_FORGE_SUBMITTER_MODEL` env var).
  There is **no `Role::Submitter`**, no `submitter` serde field, and no `SUBMITTER`
  env prefix — the "Submitter" is a *pipeline phase* that runs on the **coder**
  model. Removed the three routing claims; kept the accurate phase description.
- **M-D (R3-M3 / DT-1)** — `CLAUDETTE_MAX_FIX_ROUNDS` default is **3**
  (`forge_run.rs:29 DEFAULT_MAX_FIX_ROUNDS = 3`), but `configuration.md`,
  `power-user.md`, `architecture.md`, and the `forge_run.rs` doc-comment all said
  **2**. Fixed everywhere (also the root cause of the eval-battery I3 failure).

**LOW**
- **R3-L1** — `PRIVACY.md` egress table: `weather_forecast`→`weather`,
  `wikipedia_search`→`wikipedia` (the registered tool names in `tools/facts.rs`).
- **R3-L2** — `usage.md` WorkspaceWrite example listed `note_update`; no such tool
  exists (`notes.rs` = create/list/read/delete). Removed.
- **R3-L3** — `usage.md` called `/models` an "Alias for /model"; they are distinct
  commands (`SlashCommand::Model` vs `::Models`, separate handlers). Corrected to
  its real help text.
- **R3-L4 / L5** — dead README anchors: `quickstart.md`
  `#-air-gapped-by-design`→`#-air-gapped-and-enforced`; `hardware.md`
  `#recommended-models`→`#-which-model-should-i-run` (verified against the actual
  README headings).

## Verification

Every fix was checked against source ground truth before editing (loader fields,
`Role` enum, `compact_threshold()`, `DEFAULT_MAX_FIX_ROUNDS`, tool-name registration,
slash-command dispatch, README heading anchors) — no doc was "fixed" to an unverified
value. `cargo fmt --all --check` clean; lib builds clean (the only source change is a
one-word doc-comment). A repo-wide sweep confirms no residual stale patterns in
shipped docs (remaining hits are in frozen `docs/archive/` snapshots and internal
roast/plan artifacts, intentionally left).
