### PR TITLE
fix(quality): stop run_tests/diagnostics auto-detect at the workspace root (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`run_tests` / `diagnostics` no longer escape the workspace root.** When
+  `CLAUDETTE_WORKSPACE` is set, framework/diagnostics auto-detect stops walking
+  up at the workspace boundary instead of ascending into an enclosing project.
+  Previously a markerless folder (e.g. a plain `test.js` with no `package.json`)
+  sitting inside a larger repo would silently detect and run the *ancestor*
+  project's suite. When nothing is detected within the workspace, the existing
+  "could not auto-detect … pass `framework` explicitly" error is returned.
+  (#176)
+
 ## [0.16.0] - 2026-07-09
 
 ### Added

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -312,7 +312,8 @@ pub(crate) fn run_turn_with_retry(
 /// counter that grows monotonically.
 ///
 /// **Tiered behaviour (P3, 2026-05-04 queue):**
-/// - At/above [`compact_threshold`] (1M default): hard compact, preserves
+/// - At/above [`compact_threshold`] (adaptive: `num_ctx`/2, capped at 1M —
+///   see `run/compaction_policy.rs`): hard compact, preserves
 ///   `HARD_COMPACT_PRESERVE` recent messages.
 /// - At/above [`soft_compact_threshold`] but below the hard threshold:
 ///   soft compact, preserves `SOFT_COMPACT_PRESERVE` recent messages.

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -682,6 +682,29 @@ fn parse_workspace_env() -> Vec<PathBuf> {
         .collect()
 }
 
+/// The deepest `CLAUDETTE_WORKSPACE` root that contains (or equals) `start`,
+/// or `None` when the env var is unset/empty or `start` is not under any
+/// declared root.
+///
+/// Used to bound the upward marker-file walk in `run_tests` / `diagnostics`
+/// so auto-detect can never ascend above the workspace the user pointed
+/// Claudette at and end up testing an *enclosing* project (issue #176).
+/// "Deepest" so nested workspace roots pick the innermost boundary. Paths are
+/// normalised (`.` / `..` collapsed) but not canonicalised — the same lexical
+/// envelope the read/write validators use.
+///
+/// Returning `None` when `start` is outside every declared root deliberately
+/// leaves the walk unbounded there, matching pre-#176 behavior (the var-unset
+/// and var-set-but-cwd-elsewhere cases are out of scope for the fix).
+pub(super) fn workspace_boundary_for(start: &Path) -> Option<PathBuf> {
+    let start = normalize_path(start);
+    parse_workspace_env()
+        .into_iter()
+        .map(|root| normalize_path(&root))
+        .filter(|root| start.starts_with(root))
+        .max_by_key(|root| root.components().count())
+}
+
 /// Top-level convenience for `main`: build `WorkspaceRoots::from_env()`
 /// and return its [`WorkspaceRoots::startup_diagnostics`] output. Exposed
 /// at the crate root so the binary can print warnings before the runtime

--- a/crates/claudette/src/tools/quality.rs
+++ b/crates/claudette/src/tools/quality.rs
@@ -14,7 +14,7 @@
 //! per-framework using cheap line-level regexes. Raw stdout/stderr is
 //! also returned for unrecognised cases.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value};
 
@@ -102,12 +102,39 @@ impl Framework {
     }
 }
 
+/// The directories to probe for a project marker: `start` and its ancestors,
+/// walking up toward the filesystem root but **never ascending above the
+/// `CLAUDETTE_WORKSPACE` boundary** that contains `start` (issue #176). When
+/// no workspace root contains `start` (the var is unset, or the cwd sits
+/// outside the declared workspace) the walk is unbounded — preserving the
+/// pre-#176 behavior that is explicitly out of scope for the fix.
+///
+/// Shared by both `detect_framework` and `detect_diag_tool` so the boundary
+/// rule lives in exactly one place.
+fn marker_search_dirs(start: &Path) -> Vec<PathBuf> {
+    let start = super::normalize_path(start);
+    let boundary = super::workspace_boundary_for(&start);
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let mut current: Option<&Path> = Some(&start);
+    while let Some(dir) = current {
+        dirs.push(dir.to_path_buf());
+        // Stop once we have probed the workspace root itself: the user
+        // pointed Claudette here, so an ancestor project above it is not ours
+        // to test.
+        if boundary.as_deref() == Some(dir) {
+            break;
+        }
+        current = dir.parent();
+    }
+    dirs
+}
+
 /// Walk up from `start` looking for the marker file that identifies a
 /// framework. Returns the first match (closest to the leaf) so monorepos
-/// with sub-projects pick the right one based on cwd.
+/// with sub-projects pick the right one based on cwd. Bounded at the
+/// workspace root — see [`marker_search_dirs`].
 fn detect_framework(start: &Path) -> Option<Framework> {
-    let mut current: Option<&Path> = Some(start);
-    while let Some(dir) = current {
+    for dir in marker_search_dirs(start) {
         if dir.join("Cargo.toml").exists() {
             return Some(Framework::Cargo);
         }
@@ -120,7 +147,6 @@ fn detect_framework(start: &Path) -> Option<Framework> {
         if dir.join("go.mod").exists() {
             return Some(Framework::Go);
         }
-        current = dir.parent();
     }
     None
 }
@@ -555,9 +581,9 @@ impl DiagTool {
 /// Preference order on Python is ruff > mypy because ruff is faster
 /// and increasingly the project standard; Rust prefers cargo-check
 /// because clippy needs an explicit opt-in (it's slower and noisier).
+/// Bounded at the workspace root — see [`marker_search_dirs`].
 fn detect_diag_tool(start: &Path) -> Option<DiagTool> {
-    let mut current: Option<&Path> = Some(start);
-    while let Some(dir) = current {
+    for dir in marker_search_dirs(start) {
         if dir.join("Cargo.toml").exists() {
             return Some(DiagTool::CargoCheck);
         }
@@ -570,7 +596,6 @@ fn detect_diag_tool(start: &Path) -> Option<DiagTool> {
         if dir.join("mypy.ini").exists() {
             return Some(DiagTool::Mypy);
         }
-        current = dir.parent();
     }
     None
 }
@@ -1247,6 +1272,148 @@ not json at all
         // "doesn't panic and returns *something*".
         let _ = detect_framework(&root);
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // ─── #176: workspace-boundary on the marker walk ──────────────────
+    //
+    // These build an isolated `above/ws/sub/leaf` tree and set
+    // `CLAUDETTE_WORKSPACE=<ws>` so the walk must stop at `ws` and never
+    // reach a marker planted in `above`. `detect_framework` /
+    // `detect_diag_tool` read the env at call time (via
+    // `workspace_boundary_for`), so each detector is exercised inside the
+    // env lock and the env is restored before we assert (no lock poisoning
+    // on a failing assert).
+
+    /// Unique isolated tree root for a boundary test.
+    fn boundary_tmp(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "claudette-ws176-{tag}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos())
+        ))
+    }
+
+    /// Run `detect_framework(start)` with `CLAUDETTE_WORKSPACE` set to `ws`
+    /// (or unset when `None`), restoring the prior value before returning so
+    /// the assertion runs outside the env lock.
+    fn framework_with_ws(ws: Option<&Path>, start: &Path) -> Option<Framework> {
+        let _guard = crate::test_env_lock();
+        let prev = std::env::var("CLAUDETTE_WORKSPACE").ok();
+        match ws {
+            Some(p) => std::env::set_var("CLAUDETTE_WORKSPACE", p),
+            None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+        }
+        let result = detect_framework(start);
+        match prev {
+            Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+            None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+        }
+        result
+    }
+
+    #[test]
+    fn detect_framework_ignores_marker_above_workspace_root() {
+        // above/ (Cargo.toml) / ws / sub / leaf — workspace is `ws`, so the
+        // Cargo.toml above it must NOT be found (issue #176 core case).
+        let root = boundary_tmp("above");
+        let ws = root.join("ws");
+        let leaf = ws.join("sub").join("leaf");
+        std::fs::create_dir_all(&leaf).expect("mkdir");
+        std::fs::write(root.join("Cargo.toml"), "[package]\nname=\"x\"\n").expect("write toml");
+
+        let f = framework_with_ws(Some(&ws), &leaf);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(f, None, "marker above the workspace root must be ignored");
+    }
+
+    #[test]
+    fn detect_framework_finds_marker_at_workspace_root() {
+        // A marker at the workspace root itself is still found from a subdir.
+        let root = boundary_tmp("atroot");
+        let ws = root.join("ws");
+        let leaf = ws.join("sub").join("leaf");
+        std::fs::create_dir_all(&leaf).expect("mkdir");
+        std::fs::write(ws.join("package.json"), "{}\n").expect("write package.json");
+
+        let f = framework_with_ws(Some(&ws), &leaf);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(
+            f,
+            Some(Framework::Npm),
+            "marker at the workspace root is found"
+        );
+    }
+
+    #[test]
+    fn detect_framework_none_when_no_marker_inside_workspace() {
+        // The C3 fixture shape: workspace == cwd, a plain JS folder with no
+        // package.json, sitting inside a larger project. Auto-detect must
+        // return None (→ the "could not auto-detect" error) rather than the
+        // enclosing project's framework.
+        let root = boundary_tmp("nomarker");
+        let ws = root.join("ws");
+        std::fs::create_dir_all(&ws).expect("mkdir");
+        // Enclosing project marker above the workspace — must be ignored.
+        std::fs::write(root.join("Cargo.toml"), "[package]\nname=\"x\"\n").expect("write toml");
+        std::fs::write(ws.join("test.js"), "// no framework marker\n").expect("write test.js");
+
+        let f = framework_with_ws(Some(&ws), &ws);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(f, None, "no marker inside the workspace must yield None");
+    }
+
+    #[test]
+    fn detect_framework_unbounded_when_workspace_unset() {
+        // Behavior unchanged when CLAUDETTE_WORKSPACE is unset: the walk still
+        // ascends past the leaf to find an ancestor marker (out of scope for
+        // #176, verified here so the fix can't silently over-reach).
+        let root = boundary_tmp("unset");
+        let proj = root.join("proj");
+        let leaf = proj.join("sub").join("leaf");
+        std::fs::create_dir_all(&leaf).expect("mkdir");
+        std::fs::write(proj.join("go.mod"), "module x\n").expect("write go.mod");
+
+        let f = framework_with_ws(None, &leaf);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(
+            f,
+            Some(Framework::Go),
+            "unset workspace keeps the unbounded walk"
+        );
+    }
+
+    #[test]
+    fn detect_diag_tool_stops_at_workspace_root() {
+        // Same boundary rule for the diagnostics detector: a Cargo.toml above
+        // the workspace is ignored; a tsconfig.json at the root is found.
+        let root = boundary_tmp("diag");
+        let ws = root.join("ws");
+        let leaf = ws.join("sub").join("leaf");
+        std::fs::create_dir_all(&leaf).expect("mkdir");
+        std::fs::write(root.join("Cargo.toml"), "[package]\nname=\"x\"\n").expect("write toml");
+        std::fs::write(ws.join("tsconfig.json"), "{}\n").expect("write tsconfig");
+
+        let guard = crate::test_env_lock();
+        let prev = std::env::var("CLAUDETTE_WORKSPACE").ok();
+        std::env::set_var("CLAUDETTE_WORKSPACE", &ws);
+        let t = detect_diag_tool(&leaf);
+        match prev {
+            Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+            None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+        }
+        drop(guard);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(
+            t,
+            Some(DiagTool::Tsc),
+            "diag detector stops at ws root (tsconfig), ignores Cargo.toml above"
+        );
     }
 
     // Placate the type-check on the cwd type used by run_tests under the


### PR DESCRIPTION
## The defect

`detect_framework` and `detect_diag_tool` (`crates/claudette/src/tools/quality.rs`) walked up from the cwd looking for a project marker (`Cargo.toml`, `package.json`, `pyproject.toml`, `go.mod`, …) **with no boundary at the workspace root**. A markerless folder — e.g. a plain `test.js` with no `package.json` — sitting inside an unrelated repo silently detected the *ancestor* project and ran **its** suite.

This is exactly what the v0.16.0 eval's C3 fixture hit: `battery/work/C3` (two files, 5 tests, no `package.json`) lives under `D:\dev\claudette\…`, so with `CLAUDETTE_WORKSPACE` pointing at the fixture, `run_tests` walked up and reported claudette's **own 1,034-test suite**. Deterministic across runs, and latent since 2026-05-30 (the eval verifier only scored it PASS by coincidence — it greps for the digit `5`, which "1,052"/"1,034" happen to contain). Safety-adjacent: the agent tests a project it was never pointed at.

## The fix

Stop the upward walk at the workspace boundary — the same boundary philosophy as `validate_write_path` / `validate_edit_path`.

- New shared helper `tools::workspace_boundary_for(start)` returns the **deepest** `CLAUDETTE_WORKSPACE` root that contains `start` (normalised, not canonicalised — the same lexical envelope the read/write validators use), or `None` when the var is unset or `start` is outside every declared root.
- Both detectors now share one bounded walk, `quality::marker_search_dirs`, which yields `start` and its ancestors but **never ascends above** that boundary.
- When nothing is detected *within* the workspace, the **existing** `run_tests: could not auto-detect … Pass 'framework' explicitly.` error is returned unchanged (no new error text — it already suggests the override).

**Boundary semantics:** with `CLAUDETTE_WORKSPACE` set and cwd at/under a workspace root, the walk stops at that root (monorepo sub-projects still resolve correctly — a marker *at or below* the root is found; one *above* it is not). Behaviour is **unchanged** when `CLAUDETTE_WORKSPACE` is unset, and when it's set but cwd sits outside every declared root — both out of scope per the issue.

## Behavioral (model-facing) → A/B gated

The issue calls this behavioral for the model in the no-marker-inside-workspace case. Battery A/B on both champions vs the post-codet-retirement baseline (`runs/greatest-2026-07-03/battery-{4b,35b}-codet`), run against a **combined W1 + #138-Kotlin build** (disjoint surfaces — run_tests detection vs repo_map patterns — so one run gates both):

| Model | Baseline | New (combined) | Verdict |
|-------|----------|----------------|---------|
| qwen3.5-4b | 96/100 | 93/100 | ✅ no regression |
| qwen3.6-35b-a3b@q3_k_xl | 88/100 raw (~93 adj) | 93/100 | ✅ no regression |

**No regression on either champion — every failure falls in a known-benign class (stale-corpus path / phrasing / network-permission fail-safe) and none touches `run_tests` or `repo_map`.** The 4b delta (96→93) is model-variance in frozen-corpus tasks (e.g. #35/#48 correctly report `src/` moved to `crates/`; #75/#80 phrasing) — the run also *recovered* baseline fail #41. The 35b run scored *above* baseline (88→93), recovering 7 baseline fails while adding only 2 known-benign (#13 stale path, #18 network fail-safe). Run against a combined W1 + #138-Kotlin build (disjoint surfaces → one run gates both).

## C3 eval result

Re-ran the eval's **C3** fixture (`work/C3`: a markerless `test.js`, 5 tests, sitting inside this repo) against the combined release build with `CLAUDETTE_WORKSPACE` = the fixture. Debug-traced: `run_tests` auto-detect now **stops at the workspace boundary** (`boundary = <fixture dir>`, no `cargo` walk-up), returns the auto-detect error, and the model falls back to `node test.js` → reports **5/5 passed** — the fixture's own tests, not claudette's 1,034-test suite. Verifier PASS. **The eval goes 47/50 → 48/50** as predicted. (Also tightened the eval verifier's `tc "5"` substring to a word-boundary `\b5\b` locally — the bare `5` matched `1,052` and masked this defect since 2026-05-30; `runs/` is not committed.)

## Also in this PR

A separate commit fixes a stale doc-comment at `run.rs:315`: `maybe_compact_session` still described `compact_threshold` as "(1M default)". Since PR #92 the default derives from the model's `num_ctx` (half the window); 1M is only the upper cap / unknown-`num_ctx` fallback (see `run/compaction_policy.rs`). Doc-comment only, no behavior change.

## Tests

Four new `quality.rs` unit tests (mirroring the existing `detect_framework_*` templates): marker above the workspace root is ignored; marker at the root is found; no-marker-inside-workspace returns `None` (the C3 shape); unset-workspace keeps the unbounded walk. Plus a `detect_diag_tool` boundary test. `cargo fmt` + `clippy --all-targets --all-features -D warnings` clean; full suite green in both default (lean) and `--all-features`.

Closes #176
