### PR TITLE
feat(repo_map): Kotlin definition extraction (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Added
+
+- **`repo_map` now extracts Kotlin definitions** (`.kt` / `.kts`): top-level
+  and member `fun`, `class` (incl. `data` / `enum` / `sealed` / `annotation` /
+  `value`), `interface` (incl. `fun interface`), and `object` / `companion
+  object`. Kotlin joins the model-visible `(Languages: …)` list. Contributed as
+  a worked template for issue #138 — Swift and Scala are still up for grabs.
+  (#138)
+
 ### Fixed
 
 - **`run_tests` / `diagnostics` no longer escape the workspace root.** When

--- a/crates/claudette/src/tools/repomap.rs
+++ b/crates/claudette/src/tools/repomap.rs
@@ -48,7 +48,7 @@ const MAX_DISTINCT_NAMES: usize = 200;
 /// sees the real `const X = 3;` ahead of a stale doc saying `2`.
 const SOURCE_EXTENSIONS: &[&str] = &[
     "rs", "py", "js", "mjs", "cjs", "jsx", "ts", "tsx", "go", "java", "c", "cc", "cpp", "cxx", "h",
-    "hpp", "hh", "rb", "php", "sh", "bash", "sql", "kt", "swift", "scala", "cs",
+    "hpp", "hh", "rb", "php", "sh", "bash", "sql", "kt", "kts", "swift", "scala", "cs",
 ];
 
 fn is_source_file(path: &Path) -> bool {
@@ -660,6 +660,33 @@ const LANG_PATTERNS: &[LangSpec] = &[
             ),
         ],
     ),
+    (
+        "Kotlin",
+        &["kt", "kts"],
+        &[
+            // Order matters (first match per line wins): class / interface /
+            // object precede `fun` so `fun interface Foo` (a functional
+            // interface) is captured as an interface, not a function "interface".
+            (
+                "class",
+                r"^\s*(?:(?:public|private|protected|internal|open|final|abstract|sealed|data|inner|enum|annotation|value|expect|actual)\s+)*class\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "interface",
+                r"^\s*(?:(?:public|private|protected|internal|sealed|fun|expect|actual)\s+)*interface\s+([A-Za-z_]\w*)",
+            ),
+            (
+                "object",
+                r"^\s*(?:(?:public|private|protected|internal|expect|actual)\s+)*(?:companion\s+)?object\s+([A-Za-z_]\w*)",
+            ),
+            // Functions last. Skips an optional generic list (`fun <T> …`) and a
+            // simple extension receiver (`fun String.foo` → captures `foo`).
+            (
+                "fun",
+                r"^\s*(?:(?:public|private|protected|internal|open|final|abstract|override|suspend|inline|operator|infix|tailrec|external|expect|actual)\s+)*fun\s+(?:<[^>]*>\s*)?(?:[A-Za-z_][\w.]*\.)?([A-Za-z_]\w*)",
+            ),
+        ],
+    ),
 ];
 
 /// Comma-joined display names of the map languages, for the schema description.
@@ -792,6 +819,105 @@ mod tests {
             "def self.class_method",
             "def valid?",
             "def say_hello",
+        ] {
+            assert!(out.contains(sig), "expected `{sig}` in the outline:\n{out}");
+        }
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn kotlin_patterns_capture_class_interface_object_and_fun() {
+        let pats = patterns_for(Path::new("x.kt")).unwrap();
+        let hit = |line: &str| {
+            pats.iter()
+                .find_map(|(k, re)| re.captures(line).map(|c| (*k, c[1].to_string())))
+        };
+
+        // plain + modified functions
+        assert_eq!(hit("fun main() {"), Some(("fun", "main".to_string())));
+        assert_eq!(
+            hit("    private suspend fun fetch(id: Int): User {"),
+            Some(("fun", "fetch".to_string()))
+        );
+        // generic function — skip <T> and capture the name
+        assert_eq!(
+            hit("fun <T> singletonList(item: T): List<T> {"),
+            Some(("fun", "singletonList".to_string()))
+        );
+        // extension function — receiver stripped, member name captured
+        assert_eq!(
+            hit("fun String.isPalindrome(): Boolean {"),
+            Some(("fun", "isPalindrome".to_string()))
+        );
+
+        // classes with modifiers / kinds
+        assert_eq!(
+            hit("class Greeting(val name: String) {"),
+            Some(("class", "Greeting".to_string()))
+        );
+        assert_eq!(
+            hit("data class Point(val x: Int, val y: Int)"),
+            Some(("class", "Point".to_string()))
+        );
+        assert_eq!(
+            hit("enum class Color { RED, GREEN }"),
+            Some(("class", "Color".to_string()))
+        );
+        assert_eq!(
+            hit("sealed class Shape"),
+            Some(("class", "Shape".to_string()))
+        );
+
+        // interface, incl. the `fun interface` disambiguation
+        assert_eq!(
+            hit("interface Repository {"),
+            Some(("interface", "Repository".to_string()))
+        );
+        assert_eq!(
+            hit("fun interface Runnable {"),
+            Some(("interface", "Runnable".to_string()))
+        );
+
+        // object + companion object
+        assert_eq!(
+            hit("object Singleton {"),
+            Some(("object", "Singleton".to_string()))
+        );
+        assert_eq!(
+            hit("    companion object Factory {"),
+            Some(("object", "Factory".to_string()))
+        );
+    }
+
+    #[test]
+    fn repo_map_kotlin_definitions_extracted_in_map_mode() {
+        let _eg = crate::test_env_lock();
+        let base = super::super::user_home()
+            .join(".claudette")
+            .join("files")
+            .join("claudette-repomap-test-kotlin");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("src")).unwrap();
+        let kotlin_content = "package demo\n\ninterface Greeter {\n    fun greet(name: String): String\n}\n\nclass Greeting(val prefix: String) : Greeter {\n    override fun greet(name: String): String = \"$prefix, $name\"\n}\n\nobject Config {\n    const val VERSION = \"1.0\"\n}\n\nfun main() {\n    println(Greeting(\"Hello\").greet(\"world\"))\n}\n";
+        std::fs::write(base.join("src").join("Greeting.kt"), kotlin_content).unwrap();
+
+        let input = json!({
+            "query": "greeter greeting config main",
+            "path": base.to_str().unwrap()
+        })
+        .to_string();
+        let out = run_repo_map(&input).unwrap().replace('\\', "/");
+
+        assert!(
+            out.contains("src/Greeting.kt"),
+            "Greeting.kt should be found:\n{out}"
+        );
+        for sig in [
+            "interface Greeter",
+            "class Greeting",
+            "object Config",
+            "fun main",
         ] {
             assert!(out.contains(sig), "expected `{sig}` in the outline:\n{out}");
         }


### PR DESCRIPTION
## What

Adds **Kotlin** to `repo_map`'s definition extraction — one `LANG_PATTERNS` entry for `.kt` / `.kts`:

- `fun` (incl. modifiers, generics `fun <T> …`, and simple extension receivers `fun String.foo` → captures `foo`)
- `class` (incl. `data` / `enum` / `sealed` / `annotation` / `inner` / `value`)
- `interface` (incl. `fun interface`)
- `object` / `companion object`

Ordering puts `class` / `interface` / `object` **before** `fun` (the scan takes the first match per line), so `fun interface Foo` is captured as an interface, not a function named "interface". `.kts` is added to `SOURCE_EXTENSIONS` (`.kt` was already present). Kotlin joins the model-visible `(Languages: …)` schema list, which is generated from the table.

## Why "Kotlin" and not "Ruby"

#138 is a **standing community invitation** (the good-first-issue funnel), not a closable defect — so this PR **references, and does not close, #138**. The issue text and the internal goal both suggested Ruby, but **Ruby was already added** to `LANG_PATTERNS` on `main` (commit `e0ec8db`, the table refactor). So this contributes the next worked template from the issue's own candidate list — **Kotlin** — leaving **Swift** and **Scala** genuinely up for grabs.

## Tests

Two tests mirroring the existing per-language pattern:
- `kotlin_patterns_capture_class_interface_object_and_fun` — pattern-level: plain/modified/generic/extension funs, class kinds, the `fun interface` disambiguation, and `companion object`.
- `repo_map_kotlin_definitions_extracted_in_map_mode` — a `.kt` fixture whose defs surface in a real `mode=map` outline.

## Behavioral (model-facing) → A/B gated

Extending the `(Languages: …)` schema list is model-visible. Battery A/B on both champions vs the post-codet-retirement baseline, run against a **combined #176 + Kotlin build** (disjoint surfaces, so one run gates both):

| Model | Baseline | New (combined) | Verdict |
|-------|----------|----------------|---------|
| qwen3.5-4b | 96/100 | 93/100 | ✅ no regression |
| qwen3.6-35b-a3b@q3_k_xl | 88/100 raw (~93 adj) | 93/100 | ✅ no regression |

**No regression on either champion.** Every failure is in a known-benign class (stale-corpus path / phrasing / network-permission fail-safe); none touches `repo_map` or `run_tests`. The 4b delta (96→93) is frozen-corpus/phrasing variance (it recovered baseline fail #41); the 35b scored *above* baseline (88→93), recovering 7 baseline fails and adding only 2 known-benign. Full per-task analysis lives in the #176 PR and `runs/issues-2026-07-09/PLAN.md`.

`cargo fmt` + `clippy --all-targets --all-features -D warnings` clean; full suite green in both default (lean) and `--all-features`.

Refs #138 (does not close — Swift/Scala still open for contributors)
