### PR TITLE
docs(show-me): add a worked code-navigation example (#139)

### DIFF
--- a/docs/show-me.md
+++ b/docs/show-me.md
@@ -94,6 +94,14 @@ Claudette is first and foremost a coding agent. It writes and edits code directl
 
 `--forge` runs a Planner → Coder → Verifier loop autonomously, opens a PR when it converges, and re-tries with feedback up to a configurable round limit. See [`forge.md`](forge.md).
 
+### A worked example: understanding unfamiliar code
+
+A real interaction, not a polished demo. Opened Claudette in a checkout of a mid-sized Rust project and asked:
+
+> *"Where in this codebase is the decision made about when to compact the conversation, and what's the default threshold?"*
+
+Claudette ran `repo_map` to find the concept, read `run.rs` and `run/compaction_policy.rs`, and answered in one pass: the per-turn gate is `maybe_compact_session()` in `run.rs`, and the default threshold is adaptive — half the model's context window (`num_ctx / 2`), floored at 4,000 and capped at 1,000,000 tokens, overridable with `CLAUDETTE_COMPACT_THRESHOLD`. Four tool-assisted steps, no wrong turns — the kind of "explain how X works across these files" question that saves you an afternoon of grepping.
+
 ---
 
 ## Briefings, schedules, reminders


### PR DESCRIPTION
## What

Adds one worked example to the Code section of `docs/show-me.md` — the **start-here** doc of plain-English example prompts.

The example is a real, run-live code-navigation interaction (not a polished demo), in the existing voice:

> *"Where in this codebase is the decision made about when to compact the conversation, and what's the default threshold?"*

…followed by an honest 1–3 line account of what Claudette actually did: ran `repo_map` to find the concept, read `run.rs` + `run/compaction_policy.rs`, and answered the adaptive `num_ctx / 2` default (floored at 4k, capped at 1M, `CLAUDETTE_COMPACT_THRESHOLD` override) in four tool-assisted steps.

## Why open, not closed

#139 is a **standing community invitation** (the contributor funnel), not a closable task. This PR **references, and does not close, #139** — it seeds one worked example as a template and leaves room for more (git-history questions, notes/todos flows, multimodal, small CLI flags).

Pure docs — no Rust, no build. Markdown renders cleanly.

Refs #139 (does not close)
