### PR TITLE
test(secrets): isolate chat-id tests under a temp HOME (fix flaky coverage job)

### DIFF
--- a/crates/claudette/src/secrets.rs
+++ b/crates/claudette/src/secrets.rs
@@ -409,41 +409,36 @@ mod tests {
 
     #[test]
     fn load_chat_ids_empty_when_no_file() {
-        // With no file present, should return empty vec.
-        let ids = load_chat_ids();
-        // We can't assert empty because previous tests may have written the file.
-        // Just ensure it doesn't panic.
-        assert!(ids.len() < 1000);
+        // Isolate HOME so no sibling test's chat-id file can leak in; with a
+        // fresh home there is genuinely no file, so we can assert emptiness
+        // outright instead of the old "doesn't panic" hedge.
+        crate::with_temp_home(|_home| {
+            assert!(load_chat_ids().is_empty());
+        });
     }
 
     #[test]
     fn save_and_load_chat_id_roundtrip() {
-        let path = chat_id_path();
-        let _ = std::fs::create_dir_all(path.parent().unwrap());
+        // Run against an isolated temp HOME (holds `test_env_lock` for the whole
+        // closure), so a concurrent test can't overwrite the shared chat-id file
+        // between our save and load. This is what previously flaked: a sibling's
+        // `write(&path, "")` landing mid-roundtrip made `load_chat_ids()` return
+        // `[]`. No backup/restore dance needed — the temp home is torn down for us.
+        crate::with_temp_home(|_home| {
+            save_chat_id(9999999);
+            assert!(
+                load_chat_ids().contains(&9999999),
+                "got: {:?}",
+                load_chat_ids()
+            );
 
-        // Backup existing file.
-        let backup = std::fs::read_to_string(&path).ok();
-
-        // Write a test ID.
-        let _ = std::fs::write(&path, "");
-        save_chat_id(9999999);
-        let ids = load_chat_ids();
-        assert!(ids.contains(&9999999), "got: {ids:?}");
-
-        // Duplicate should not add another line.
-        save_chat_id(9999999);
-        let ids2 = load_chat_ids();
-        assert_eq!(
-            ids2.iter().filter(|&&id| id == 9999999).count(),
-            1,
-            "duplicate ID should not be saved twice"
-        );
-
-        // Restore backup.
-        if let Some(b) = backup {
-            let _ = std::fs::write(&path, b);
-        } else {
-            let _ = std::fs::remove_file(&path);
-        }
+            // Duplicate should not add another line.
+            save_chat_id(9999999);
+            assert_eq!(
+                load_chat_ids().iter().filter(|&&id| id == 9999999).count(),
+                1,
+                "duplicate ID should not be saved twice"
+            );
+        });
     }
 }


### PR DESCRIPTION
## The flake

The `coverage (llvm-cov)` CI job intermittently fails with:

```
thread 'secrets::tests::save_and_load_chat_id_roundtrip' panicked at crates/claudette/src/secrets.rs:431:
got: []
```

Most recently on the `main` push for `028098f` ([run 29076093147](https://github.com/mrdushidush/claudette/actions/runs/29076093147)). It is **non-blocking** (the coverage job is `continue-on-error: true` by design — a signal, not a gate) and **pre-existing** — `secrets.rs` was not touched by any recent PR — but it's noise worth removing.

## Root cause — test isolation, not product code

`save_and_load_chat_id_roundtrip` and `load_chat_ids_empty_when_no_file` both read/write the **shared** global path `~/.claudette/secrets/telegram_chat.id` (`chat_id_path()` → `home_dir()/.claudette/secrets/…`) with **no `test_env_lock()` and no temp isolation**. Cargo runs tests multi-threaded, so a sibling's `write(&path, "")` can land between the roundtrip test's `save_chat_id` and `load_chat_ids`, leaving `load_chat_ids()` to read an empty file → `[]`. The normal `test (ubuntu/windows)` jobs happened to schedule around it; the `llvm-cov` job — different instrumentation and timing — hit the race. (On the same failing run, the normal `test` jobs passed on the identical commit.)

## Fix

Wrap both tests in the existing `crate::with_temp_home` helper — the same one "every test that touches `~/.claudette`" already uses. It holds `test_env_lock()` for the whole closure and swaps `HOME`/`USERPROFILE` to a fresh per-run temp dir, so the shared file simply cannot be raced.

Bonus tightening the isolation now allows:
- `load_chat_ids_empty_when_no_file` asserts **genuine** emptiness (`is_empty()`) instead of the old "doesn't panic" hedge — a fresh home has no file.
- `save_and_load_chat_id_roundtrip` drops its fragile backup/restore-the-real-file dance (the temp home is torn down for us).

## Scope / verification

- **Test-only. No product behavior change.** (`with_temp_home` is `#[cfg(test)]`.)
- No CHANGELOG entry — internal test hygiene, not user-facing.
- `cargo fmt --all` clean; `cargo clippy --all-targets {--all-features,} --no-deps -D warnings` clean in **both** feature sets; full suite green in **both** default (lean) and `--all-features`.