### PR TITLE
docs(battery): publish v0.16.0 model-sweep score evidence

### DIFF
--- a/runs/eval-2026-05-29/battery/SCORES-coder30b-BROKEN-template-32k.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-coder30b-BROKEN-template-32k.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	FAIL	1s	EC=1	recall=na	FAIL — cargo test failed:\n
+A2	rust	add-feature	FAIL	1s	EC=1	recall=na	FAIL — cargo test failed:\nerror[E0432]: unresolved import `calc::median`
+A3	rust	run-tests	PASS	1s	EC=1	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	FAIL	1s	EC=1	recall=na	FAIL — old definition 'fn add(' still present in src/lib.rs
+A5	rust	multi-file	FAIL	1s	EC=1	recall=na	FAIL — MAX_RETRIES: u32 = 5 not found in src/config.rs
+A6	rust	explain	FAIL	0s	EC=1	recall=na	FAIL — explanation omits that only consecutive/adjacent duplicates are removed
+A7	rust	debug-error	FAIL	0s	EC=1	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+B1	python	bugfix	FAIL	0s	EC=1	recall=na	FAIL — test_stats still failing (rc=1): Ran 1 test in 0.002s  FAILED (failures=1) 
+B2	python	add-feature	FAIL	0s	EC=1	recall=na	FAIL — variance test failing (rc=1): Ran 1 test in 0.000s  FAILED (errors=1) 
+B3	python	multi-file	FAIL	0s	EC=1	recall=na	FAIL — geometry tests failing (rc=1): Ran 3 tests in 0.001s  FAILED (failures=3) 
+B4	python	create-file	FAIL	0s	EC=1	recall=na	FAIL — utils.py was not created
+B5	python	debug-error	FAIL	0s	EC=1	recall=na	FAIL — app.py still crashing (rc=1):     counts[c] += 1     ~~~~~~^^^ KeyError: 'h' 
+B7	python	run-tests	FAIL	0s	EC=1	recall=na	FAIL — transcript missing '3' and/or passed/ok
+B8	python	answer-codebase	FAIL	0s	EC=1	recall=na	FAIL — transcript never mentions the real value 2
+C1	js	bugfix	FAIL	1s	EC=1	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	FAIL	1s	EC=1	recall=na	FAIL — node test.js exited 1: TypeError: applyDiscount is not a function
+C3	js	run-tests	FAIL	1s	EC=1	recall=na	FAIL — transcript does not mention 5 (the number that passed)
+C4	js	create-file	FAIL	0s	EC=1	recall=na	FAIL — slug.js was not created
+C5	js	multi-file	FAIL	0s	EC=1	recall=na	FAIL — node test.js exited 1:   throw new Error(`withTax(100) expected ${want} but got ${got}`);
+C6	js	explain	FAIL	0s	EC=1	recall=na	FAIL — did not describe the object/map/dictionary return value
+C7	js	debug-error	FAIL	0s	EC=1	recall=na	FAIL — node report.js exited 1: TypeError: Cannot read properties of undefined (reading 'map')
+D1	ts	bugfix	FAIL	1s	EC=1	recall=na	FAIL — node test.ts exited 1: FAIL: foo.com has no @ and should be invalid
+D2	ts	locate	FAIL	1s	EC=1	recall=na	FAIL — transcript does not identify session.ts as the definition site
+D4	ts	multi-file	FAIL	1s	EC=1	recall=na	FAIL — src/types.ts does not declare a 'role' field on User
+D6	ts	run-tests	PASS	1s	EC=1	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	FAIL	1s	EC=1	recall=na	FAIL — buggy line still present: 'if a < b { return a' (returns the smaller value)
+E2	go	refactor	FAIL	0s	EC=1	recall=na	FAIL — old name 'GetUserName' still present:\n/d/dev/claudette/runs/eval-2026-05-29/battery/work/E2/main.go:9:	fmt.Println(GetUserName(alice))
+E3	go	locate	FAIL	0s	EC=1	recall=na	FAIL — transcript does not name checkout.go as the defining file
+E4	go	explain	PASS	0s	EC=1	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	FAIL	1s	EC=1	recall=na	FAIL — missing line 'Hello, Ada!' (got: Hello, Ada
+F2	shell	create-file	FAIL	1s	EC=1	recall=na	FAIL — count.sh was not created in workdir
+F3	shell	explain	FAIL	1s	EC=1	recall=na	FAIL — explanation does not convey counting unique occurrences
+F4	shell	refactor	FAIL	1s	EC=1	recall=na	FAIL — old name 'process_file' still present:\n./lib.sh:4:process_file() {
+G1	html	add-feature	FAIL	0s	EC=1	recall=na	FAIL — no link with href="contact.html" in index.html
+G4	css	refactor	FAIL	0s	EC=1	recall=na	FAIL — old class 'btn-primary' still present:\n./index.html:12:    <a href="signup.html" class="btn-primary">Sign up</a>
+H2	sql	add-feature	FAIL	0s	EC=1	recall=na	FAIL — top_customer.sql did not produce a usable result: ERR: query returned no rows 
+H3	sql	create-file	FAIL	1s	EC=126	recall=na	FAIL — schema.sql was not created
+H4	sql	debug-error	FAIL	1s	EC=126	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.total 
+I1	bigrepo	enumerate	FAIL	0s	EC=126	recall=0/6	FAIL — only 0/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	FAIL	0s	EC=126	recall=0/8	FAIL — only 0/8 forge roles (need >=7; enumeration weak spot)
+I3	bigrepo	locate	FAIL	0s	EC=126	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	FAIL	0s	EC=126	recall=na	FAIL — missing qwen3-coder default and/or its source file
+I5	bigrepo	locate	FAIL	0s	EC=126	recall=na	FAIL — did not name conversation.rs
+I6	bigrepo	enumerate	FAIL	1s	EC=126	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I7	bigrepo	answer-codebase	FAIL	1s	EC=126	recall=na	FAIL — did not establish the no-telemetry / local-first answer
+I8	bigrepo	answer-codebase	FAIL	1s	EC=126	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	FAIL	0s	EC=126	recall=na	FAIL — did not identify notes.txt as the uncommitted change
+J2	git	git-workflow	FAIL	0s	EC=126	recall=na	FAIL — HEAD subject='Initial commit' tracked='greet.py' (expected commit 'Add greeting...' including greet.py)
+J3	git	git-workflow	FAIL	1s	EC=126	recall=na	FAIL — did not report the most-recent commit message
+J4	git	git-workflow	FAIL	1s	EC=126	recall=na	FAIL — feature/login branch was not created

--- a/runs/eval-2026-05-29/battery/SCORES-glm47-flash.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-glm47-flash.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	FAIL	53s	EC=1	recall=na	FAIL — cargo test failed:\n
+A2	rust	add-feature	FAIL	1s	EC=1	recall=na	FAIL — cargo test failed:\nerror[E0432]: unresolved import `calc::median`
+A3	rust	run-tests	PASS	1s	EC=1	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	FAIL	0s	EC=1	recall=na	FAIL — old definition 'fn add(' still present in src/lib.rs
+A5	rust	multi-file	FAIL	1s	EC=1	recall=na	FAIL — MAX_RETRIES: u32 = 5 not found in src/config.rs
+A6	rust	explain	FAIL	1s	EC=1	recall=na	FAIL — explanation omits that only consecutive/adjacent duplicates are removed
+A7	rust	debug-error	FAIL	0s	EC=1	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+B1	python	bugfix	FAIL	1s	EC=1	recall=na	FAIL — test_stats still failing (rc=1): Ran 1 test in 0.001s  FAILED (failures=1) 
+B2	python	add-feature	FAIL	0s	EC=1	recall=na	FAIL — variance test failing (rc=1): Ran 1 test in 0.000s  FAILED (errors=1) 
+B3	python	multi-file	FAIL	0s	EC=1	recall=na	FAIL — geometry tests failing (rc=1): Ran 3 tests in 0.001s  FAILED (failures=3) 
+B4	python	create-file	FAIL	1s	EC=1	recall=na	FAIL — utils.py was not created
+B5	python	debug-error	FAIL	0s	EC=1	recall=na	FAIL — app.py still crashing (rc=1):     counts[c] += 1     ~~~~~~^^^ KeyError: 'h' 
+B7	python	run-tests	FAIL	0s	EC=1	recall=na	FAIL — transcript missing '3' and/or passed/ok
+B8	python	answer-codebase	FAIL	1s	EC=1	recall=na	FAIL — transcript never mentions the real value 2
+C1	js	bugfix	FAIL	0s	EC=1	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	FAIL	0s	EC=1	recall=na	FAIL — node test.js exited 1: TypeError: applyDiscount is not a function
+C3	js	run-tests	FAIL	1s	EC=1	recall=na	FAIL — transcript does not mention 5 (the number that passed)
+C4	js	create-file	FAIL	0s	EC=1	recall=na	FAIL — slug.js was not created
+C5	js	multi-file	FAIL	0s	EC=1	recall=na	FAIL — node test.js exited 1:   throw new Error(`withTax(100) expected ${want} but got ${got}`);
+C6	js	explain	FAIL	1s	EC=1	recall=na	FAIL — did not describe the object/map/dictionary return value
+C7	js	debug-error	FAIL	1s	EC=1	recall=na	FAIL — node report.js exited 1: TypeError: Cannot read properties of undefined (reading 'map')
+D1	ts	bugfix	FAIL	0s	EC=1	recall=na	FAIL — node test.ts exited 1: FAIL: foo.com has no @ and should be invalid
+D2	ts	locate	FAIL	1s	EC=1	recall=na	FAIL — transcript does not identify session.ts as the definition site
+D4	ts	multi-file	FAIL	1s	EC=1	recall=na	FAIL — src/types.ts does not declare a 'role' field on User
+D6	ts	run-tests	PASS	0s	EC=1	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	FAIL	1s	EC=1	recall=na	FAIL — buggy line still present: 'if a < b { return a' (returns the smaller value)
+E2	go	refactor	FAIL	1s	EC=1	recall=na	FAIL — old name 'GetUserName' still present:\n/d/dev/claudette/runs/eval-2026-05-29/battery/work/E2/main.go:9:	fmt.Println(GetUserName(alice))
+E3	go	locate	FAIL	1s	EC=1	recall=na	FAIL — transcript does not name checkout.go as the defining file
+E4	go	explain	PASS	0s	EC=1	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	FAIL	0s	EC=1	recall=na	FAIL — missing line 'Hello, Ada!' (got: Hello, Ada
+F2	shell	create-file	FAIL	1s	EC=1	recall=na	FAIL — count.sh was not created in workdir
+F3	shell	explain	FAIL	1s	EC=1	recall=na	FAIL — explanation does not convey counting unique occurrences
+F4	shell	refactor	FAIL	0s	EC=1	recall=na	FAIL — old name 'process_file' still present:\n./lib.sh:4:process_file() {
+G1	html	add-feature	PASS	41s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	30s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	FAIL	26s	EC=0	recall=na	FAIL — top_customer.sql did not produce a usable result: ERR: query returned no rows 
+H3	sql	create-file	PASS	23s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	FAIL	23s	EC=0	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.order_amount 
+I1	bigrepo	enumerate	FAIL	10s	EC=0	recall=2/6	FAIL — only 2/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	PASS	31s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	25s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	31s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	17s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	60s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	17s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	FAIL	28s	EC=0	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	PASS	15s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	15s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	25s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	23s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-gptoss20b-v0160-ext.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-gptoss20b-v0160-ext.tsv
@@ -1,0 +1,8 @@
+K1	java	locate	PASS	2s	EC=0	recall=na	PASS — located computeTax in TaxCalculator.java
+K2	cpp	bugfix	PASS	5s	EC=0	recall=na	PASS — celsiusToFahrenheit now adds 32 (bug fixed)
+K3	csharp	locate	PASS	3s	EC=0	recall=na	PASS — located ValidateOrder in OrderValidator.cs
+K4	php	bugfix	PASS	4s	EC=0	recall=na	PASS — isEven now tests evenness correctly
+K5	kotlin	locate	PASS	2s	EC=0	recall=na	PASS — located data class Invoice in Invoice.kt
+K6	ruby	bugfix	PASS	4s	EC=0	recall=na	PASS — passing? now includes exactly 60 (inclusive >= 60)
+K7	js	replace-all	FAIL	13s	EC=0	recall=old=30 new=0/30	FAIL — incomplete rename: 30 trackEvent still present (0/30 recordEvent)
+K8	ts	scoped-grep	PASS	3s	EC=0	recall=na	PASS — found API_TIMEOUT_MS=8000 in settings.ts (.ts scope honored)

--- a/runs/eval-2026-05-29/battery/SCORES-gptoss20b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-gptoss20b-v0160.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	4s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	FAIL	7s	EC=0	recall=na	FAIL — cargo test failed:\nerror[E0432]: unresolved import `calc::median`
+A3	rust	run-tests	PASS	2s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	FAIL	3s	EC=1	recall=na	FAIL — old definition 'fn add(' still present in src/lib.rs
+A5	rust	multi-file	PASS	6s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	10s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	8s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	4s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	FAIL	8s	EC=0	recall=na	FAIL — variance test failing (rc=1): Ran 1 test in 0.003s  FAILED (errors=1) 
+B3	python	multi-file	PASS	7s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	4s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	7s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	4s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	6s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	FAIL	4s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	PASS	9s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	5s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS	3s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	6s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	4s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	6s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	6s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	2s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	7s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	22s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	5s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	FAIL	8s	EC=0	recall=na	FAIL — old name 'GetUserName' still present:\n/d/dev/claudette/runs/eval-2026-05-29/battery/work/E2/user.go:11:// GetUserName returns the user's full display name.
+E3	go	locate	PASS	2s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	6s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	FAIL	7s	EC=0	recall=na	FAIL — missing line 'Hello, Ada!' (got: Hello, Ada
+F2	shell	create-file	PASS	3s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	8s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	FAIL	17s	EC=1	recall=na	FAIL — old name 'process_file' still present:\n./lib.sh:4:process_file() {
+G1	html	add-feature	PASS	7s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	15s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	3s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	3s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	FAIL	9s	EC=0	recall=na	FAIL — report.sql still broken or wrong totals: ADA=None BOB=None ROWS=3 ERR: Ada total != 150 
+I1	bigrepo	enumerate	PASS	9s	EC=0	recall=6/6	PASS — enumerated 6/6 CLAUDETTE_FORGE_ vars
+I2	bigrepo	enumerate	PASS	13s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	PASS	6s	EC=0	recall=na	PASS — identified source value 3 + location (resisted stale-doc value 2)
+I4	bigrepo	answer-codebase	FAIL	29s	EC=0	recall=na	FAIL — missing qwen3-coder default and/or its source file
+I5	bigrepo	locate	PASS	9s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	20s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	6s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	13s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	3s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160-20260709.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160-20260709.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	25s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	35s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	8s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	62s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	29s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	31s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	25s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	61s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	23s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	51s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	35s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	22s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	13s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	31s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	26s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	31s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	FAIL	13s	EC=0	recall=na	FAIL — transcript does not mention 5 (the number that passed)
+C4	js	create-file	PASS	72s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	20s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	24s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	22s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	36s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	17s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	43s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	22s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	21s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	48s	EC=1	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	8s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	21s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	22s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	25s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	21s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	52s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	14s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	50s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	17s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	15s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	54s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=3)
+I1	bigrepo	enumerate	PASS	90s	EC=0	recall=6/6	PASS — enumerated 6/6 CLAUDETTE_FORGE_ vars
+I2	bigrepo	enumerate	PASS	44s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	PASS	30s	EC=0	recall=na	PASS — identified source value 3 + location (resisted stale-doc value 2)
+I4	bigrepo	answer-codebase	PASS	28s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	48s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	FAIL	39s	EC=0	recall=4/7	FAIL — only 4/7 CLI modes (need >=6; enumeration weak spot)
+I7	bigrepo	answer-codebase	PASS	158s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	FAIL	158s	EC=1	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	PASS	13s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	14s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	7s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	16s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160-ext.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160-ext.tsv
@@ -1,0 +1,8 @@
+K1	java	locate	PASS	8s	EC=0	recall=na	PASS — located computeTax in TaxCalculator.java
+K2	cpp	bugfix	PASS	34s	EC=0	recall=na	PASS — celsiusToFahrenheit now adds 32 (bug fixed)
+K3	csharp	locate	PASS	14s	EC=0	recall=na	PASS — located ValidateOrder in OrderValidator.cs
+K4	php	bugfix	PASS	19s	EC=0	recall=na	PASS — isEven now tests evenness correctly
+K5	kotlin	locate	PASS	8s	EC=0	recall=na	PASS — located data class Invoice in Invoice.kt
+K6	ruby	bugfix	PASS	28s	EC=0	recall=na	PASS — passing? now includes exactly 60 (inclusive >= 60)
+K7	js	replace-all	PASS	19s	EC=0	recall=old=0 new=30/30	PASS — renamed all 30 occurrences trackEvent->recordEvent (0 left)
+K8	ts	scoped-grep	PASS	15s	EC=0	recall=na	PASS — found API_TIMEOUT_MS=8000 in settings.ts (.ts scope honored)

--- a/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-q3-35b-v0160.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	22s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	30s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	8s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS(TIMEOUT)	181s	EC=124	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	40s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	25s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	22s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	41s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	28s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	20s	EC=0	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	42s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	32s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	32s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	28s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	24s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	50s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	17s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS	29s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	34s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	23s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	13s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	9s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	76s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	21s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	19s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	38s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	11s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	28s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	21s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	45s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	17s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	24s	EC=0	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	15s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	39s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	25s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	17s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	34s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=3)
+I1	bigrepo	enumerate	PASS	67s	EC=0	recall=6/6	PASS — enumerated 6/6 CLAUDETTE_FORGE_ vars
+I2	bigrepo	enumerate	PASS	72s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	PASS	18s	EC=0	recall=na	PASS — identified source value 3 + location (resisted stale-doc value 2)
+I4	bigrepo	answer-codebase	PASS	15s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	50s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	64s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	49s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	FAIL(TIMEOUT)	201s	EC=124	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	PASS	17s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	15s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	6s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	26s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-4b-v0160-ext.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-4b-v0160-ext.tsv
@@ -1,0 +1,8 @@
+K1	java	locate	PASS	5s	EC=0	recall=na	PASS — located computeTax in TaxCalculator.java
+K2	cpp	bugfix	PASS	17s	EC=0	recall=na	PASS — celsiusToFahrenheit now adds 32 (bug fixed)
+K3	csharp	locate	PASS	10s	EC=0	recall=na	PASS — located ValidateOrder in OrderValidator.cs
+K4	php	bugfix	PASS	20s	EC=0	recall=na	PASS — isEven now tests evenness correctly
+K5	kotlin	locate	PASS	5s	EC=0	recall=na	PASS — located data class Invoice in Invoice.kt
+K6	ruby	bugfix	PASS	20s	EC=0	recall=na	PASS — passing? now includes exactly 60 (inclusive >= 60)
+K7	js	replace-all	PASS	28s	EC=0	recall=old=0 new=30/30	PASS — renamed all 30 occurrences trackEvent->recordEvent (0 left)
+K8	ts	scoped-grep	PASS	11s	EC=0	recall=na	PASS — found API_TIMEOUT_MS=8000 in settings.ts (.ts scope honored)

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-4b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-4b-v0160.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	21s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	22s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	4s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	18s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	14s	EC=1	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	15s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	PASS	17s	EC=1	recall=na	PASS — cargo build succeeded (type error fixed)
+B1	python	bugfix	PASS	21s	EC=1	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	21s	EC=1	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	PASS	14s	EC=1	recall=na	PASS — tests pass and circle.py PI updated to 3.14159
+B4	python	create-file	PASS	20s	EC=1	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	10s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	12s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	7s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	24s	EC=1	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	20s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	FAIL	14s	EC=1	recall=na	FAIL — transcript does not report a standalone 5 (the number that passed)
+C4	js	create-file	PASS	16s	EC=1	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	14s	EC=1	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	18s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	9s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	20s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	PASS	10s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	15s	EC=1	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	23s	EC=1	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	18s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	20s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	8s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	13s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	14s	EC=1	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	15s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	PASS	11s	EC=0	recall=na	PASS — explanation conveys 3/3 concepts incl. counting unique occurrences
+F4	shell	refactor	PASS	23s	EC=1	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	11s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	20s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	11s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	6s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	FAIL	14s	EC=1	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.total 
+I1	bigrepo	enumerate	PASS	26s	EC=0	recall=6/6	PASS — enumerated 6/6 CLAUDETTE_FORGE_ vars
+I2	bigrepo	enumerate	PASS	21s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	16s	EC=1	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	17s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	FAIL	30s	EC=1	recall=na	FAIL — did not name conversation.rs
+I6	bigrepo	enumerate	FAIL	3s	EC=1	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I7	bigrepo	answer-codebase	PASS	22s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	26s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	PASS	9s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	5s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	7s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-9b-v0160-ext.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-9b-v0160-ext.tsv
@@ -1,0 +1,8 @@
+K1	java	locate	PASS	8s	EC=0	recall=na	PASS — located computeTax in TaxCalculator.java
+K2	cpp	bugfix	FAIL	12s	EC=1	recall=na	FAIL — conversion still subtracts 32 — bug not fixed
+K3	csharp	locate	PASS	10s	EC=0	recall=na	PASS — located ValidateOrder in OrderValidator.cs
+K4	php	bugfix	FAIL	12s	EC=1	recall=na	FAIL — isEven still uses the inverted test (% 2 == 1)
+K5	kotlin	locate	PASS	8s	EC=0	recall=na	PASS — located data class Invoice in Invoice.kt
+K6	ruby	bugfix	FAIL	15s	EC=1	recall=na	FAIL — passing? still uses > 60 — a score of 60 is wrongly excluded
+K7	js	replace-all	PASS	34s	EC=1	recall=old=0 new=30/30	PASS — renamed all 30 occurrences trackEvent->recordEvent (0 left)
+K8	ts	scoped-grep	PASS	10s	EC=0	recall=na	PASS — found API_TIMEOUT_MS=8000 in settings.ts (.ts scope honored)

--- a/runs/eval-2026-05-29/battery/SCORES-qwen35-9b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen35-9b-v0160.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	FAIL	11s	EC=1	recall=na	FAIL — cargo test failed:\n
+A2	rust	add-feature	PASS	22s	EC=1	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	6s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	FAIL	20s	EC=1	recall=na	FAIL — old definition 'fn add(' still present in src/lib.rs
+A5	rust	multi-file	FAIL	13s	EC=1	recall=na	FAIL — MAX_RETRIES: u32 = 5 not found in src/config.rs
+A6	rust	explain	PASS	24s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	FAIL	7s	EC=1	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+B1	python	bugfix	FAIL	16s	EC=1	recall=na	FAIL — test_stats still failing (rc=1): Ran 1 test in 0.002s  FAILED (failures=1) 
+B2	python	add-feature	FAIL	9s	EC=1	recall=na	FAIL — variance test failing (rc=1): Ran 1 test in 0.000s  FAILED (errors=1) 
+B3	python	multi-file	FAIL	16s	EC=1	recall=na	FAIL — geometry tests failing (rc=1): Ran 3 tests in 0.001s  FAILED (failures=3) 
+B4	python	create-file	FAIL	9s	EC=1	recall=na	FAIL — utils.py was not created
+B5	python	debug-error	FAIL	11s	EC=1	recall=na	FAIL — app.py still crashing (rc=1):     counts[c] += 1     ~~~~~~^^^ KeyError: 'h' 
+B7	python	run-tests	FAIL	7s	EC=1	recall=na	FAIL — transcript missing '3' and/or passed/ok
+B8	python	answer-codebase	PASS	14s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	FAIL	14s	EC=1	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C2	js	add-feature	FAIL	13s	EC=1	recall=na	FAIL — node test.js exited 1: TypeError: applyDiscount is not a function
+C3	js	run-tests	FAIL	8s	EC=1	recall=na	FAIL — transcript does not report a standalone 5 (the number that passed)
+C4	js	create-file	FAIL	13s	EC=1	recall=na	FAIL — slug.js was not created
+C5	js	multi-file	PASS	14s	EC=1	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	13s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	FAIL	9s	EC=1	recall=na	FAIL — node report.js exited 1: TypeError: Cannot read properties of undefined (reading 'map')
+D1	ts	bugfix	FAIL	13s	EC=1	recall=na	FAIL — node test.ts exited 1: FAIL: foo.com has no @ and should be invalid
+D2	ts	locate	PASS	7s	EC=0	recall=na	PASS — located refreshToken in src/auth/session.ts (full path given)
+D4	ts	multi-file	PASS	20s	EC=1	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	8s	EC=1	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	FAIL	12s	EC=1	recall=na	FAIL — buggy line still present: 'if a < b { return a' (returns the smaller value)
+E2	go	refactor	FAIL	21s	EC=1	recall=na	FAIL — old name 'GetUserName' still present:\n/d/dev/claudette/runs/eval-2026-05-29/battery/work/E2/main.go:9:	fmt.Println(GetUserName(alice))
+E3	go	locate	PASS	8s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	19s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	FAIL	7s	EC=1	recall=na	FAIL — missing line 'Hello, Ada!' (got: Hello, Ada
+F2	shell	create-file	FAIL	7s	EC=0	recall=na	FAIL — count.sh was not created in workdir
+F3	shell	explain	FAIL	7s	EC=1	recall=na	FAIL — explanation does not convey counting unique occurrences
+F4	shell	refactor	PASS	18s	EC=1	recall=na	PASS — process_file fully renamed to handle_file (3 occurrences)
+G1	html	add-feature	PASS	12s	EC=1	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	25s	EC=1	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	FAIL	7s	EC=1	recall=na	FAIL — top_customer.sql did not produce a usable result: ERR: query returned no rows 
+H3	sql	create-file	FAIL	10s	EC=0	recall=na	FAIL — schema.sql was not created
+H4	sql	debug-error	FAIL	9s	EC=1	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.total 
+I1	bigrepo	enumerate	FAIL	10s	EC=1	recall=0/6	FAIL — only 0/6 CLAUDETTE_FORGE_ vars (need >=5; enumeration weak spot)
+I2	bigrepo	enumerate	FAIL	20s	EC=1	recall=1/8	FAIL — only 1/8 forge roles (need >=7; enumeration weak spot)
+I3	bigrepo	locate	FAIL	19s	EC=1	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	18s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	PASS	20s	EC=0	recall=na	PASS — named conversation.rs
+I6	bigrepo	enumerate	PASS	66s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	16s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	FAIL	18s	EC=1	recall=na	FAIL — missing threshold(0) or mechanism(1)
+J1	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — named the modified file notes.txt
+J2	git	git-workflow	PASS	4s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	PASS	6s	EC=0	recall=na	PASS — reported the latest commit subject (null pointer in handler)
+J4	git	git-workflow	PASS	6s	EC=0	recall=na	PASS — branch feature/login exists

--- a/runs/eval-2026-05-29/battery/SCORES-qwen3coder30b-ext.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen3coder30b-ext.tsv
@@ -1,0 +1,8 @@
+K1	java	locate	PASS	15s	EC=0	recall=na	PASS — located computeTax in TaxCalculator.java
+K2	cpp	bugfix	PASS	23s	EC=0	recall=na	PASS — celsiusToFahrenheit now adds 32 (bug fixed)
+K3	csharp	locate	FAIL	8s	EC=0	recall=na	FAIL — transcript does not identify OrderValidator.cs as the definition site
+K4	php	bugfix	PASS	18s	EC=0	recall=na	PASS — isEven now tests evenness correctly
+K5	kotlin	locate	PASS	13s	EC=0	recall=na	PASS — located data class Invoice in Invoice.kt
+K6	ruby	bugfix	PASS	31s	EC=0	recall=na	PASS — passing? now includes exactly 60 (inclusive >= 60)
+K7	js	replace-all	PASS	41s	EC=0	recall=old=0 new=30/30	PASS — renamed all 30 occurrences trackEvent->recordEvent (0 left)
+K8	ts	scoped-grep	FAIL	9s	EC=0	recall=na	FAIL — did not report API_TIMEOUT_MS=8000 from the .ts files

--- a/runs/eval-2026-05-29/battery/SCORES-qwen3coder30b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-qwen3coder30b.tsv
@@ -1,0 +1,50 @@
+A1	rust	bugfix	PASS	24s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A2	rust	add-feature	PASS	32s	EC=0	recall=na	PASS — cargo test succeeded (median added)
+A3	rust	run-tests	PASS	9s	EC=0	recall=na	PASS — transcript reports 4 tests passed
+A4	rust	refactor	PASS	34s	EC=0	recall=na	PASS — add renamed to sum2 throughout; tests pass
+A5	rust	multi-file	PASS	18s	EC=0	recall=na	PASS — MAX_RETRIES raised to 5; retry test passes
+A6	rust	explain	PASS	17s	EC=0	recall=na	PASS — explanation covers dedup of consecutive/adjacent duplicates
+A7	rust	debug-error	FAIL	8s	EC=0	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+B1	python	bugfix	PASS	24s	EC=0	recall=na	PASS — test_stats passes (mean fixed): OK
+B2	python	add-feature	PASS	22s	EC=0	recall=na	PASS — variance added, test passes: OK
+B3	python	multi-file	FAIL	35s	EC=0	recall=na	FAIL — geometry tests failing (rc=1): Ran 3 tests in 0.001s  FAILED (failures=3) 
+B4	python	create-file	PASS	32s	EC=0	recall=na	PASS — utils.py created and clamp test passes: OK
+B5	python	debug-error	PASS	19s	EC=0	recall=na	PASS — app.py runs and counts 'l' as 2: {'h': 1, 'e': 1, 'l': 2, 'o': 1}
+B7	python	run-tests	PASS	16s	EC=0	recall=na	PASS — transcript reports 3 tests passing
+B8	python	answer-codebase	PASS	15s	EC=0	recall=na	PASS — transcript identifies the real retry count as 2 (MAX_ATTEMPTS)
+C1	js	bugfix	PASS	27s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C2	js	add-feature	PASS	19s	EC=0	recall=na	PASS — test.js passes (applyDiscount added)
+C3	js	run-tests	PASS	18s	EC=0	recall=na	PASS — tests green and agent reported 5 passed
+C4	js	create-file	PASS	34s	EC=0	recall=na	PASS — slug.js created and test.js passes
+C5	js	multi-file	PASS	24s	EC=0	recall=na	PASS — tax rate updated to 0.08 and test.js passes
+C6	js	explain	PASS	18s	EC=0	recall=na	PASS — explanation covers grouping, object return, and collection-valued buckets
+C7	js	debug-error	PASS	19s	EC=0	recall=na	PASS — report.js runs and prints member names (incl. Ada)
+D1	ts	bugfix	PASS	57s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+D2	ts	locate	FAIL	7s	EC=0	recall=na	FAIL — transcript does not identify session.ts as the definition site
+D4	ts	multi-file	PASS	30s	EC=0	recall=na	PASS — User.role added and label() returns 'name (role)'; node test.ts passed
+D6	ts	run-tests	PASS	18s	EC=0	recall=na	PASS — tests green and agent reported 6 passed
+E1	go	bugfix	PASS	21s	EC=0	recall=na	PASS — calc.go Max fixed to return the larger value (buggy line removed)
+E2	go	refactor	PASS	34s	EC=0	recall=na	PASS — GetUserName renamed to DisplayName everywhere (defn in user.go + 2 call sites; 3 total)
+E3	go	locate	PASS	10s	EC=0	recall=na	PASS — transcript identifies handlers/checkout.go as defining handleCheckout
+E4	go	explain	PASS	19s	EC=0	recall=na	PASS — explanation covers both deduplication and sorting
+F1	shell	bugfix	PASS	17s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+F2	shell	create-file	PASS	17s	EC=0	recall=na	PASS — count.sh prints 5 for the 5-line data.txt
+F3	shell	explain	FAIL	8s	EC=0	recall=na	FAIL — explanation does not convey counting unique occurrences
+F4	shell	refactor	FAIL	9s	EC=0	recall=na	FAIL — old name 'process_file' still present:\n./lib.sh:4:process_file() {
+G1	html	add-feature	PASS	23s	EC=0	recall=na	PASS — Contact->contact.html added inside nav/ul; Home+About intact (3 nav links)
+G4	css	refactor	PASS	35s	EC=0	recall=na	PASS — btn-primary -> button-main renamed in styles.css rule + 2 html usages (3 total); styles intact
+H2	sql	add-feature	PASS	15s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H3	sql	create-file	PASS	13s	EC=0	recall=na	PASS — products table created with id/name/price and 2 seeded rows
+H4	sql	debug-error	PASS	38s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=2)
+I1	bigrepo	enumerate	PASS	52s	EC=0	recall=6/6	PASS — enumerated 6/6 CLAUDETTE_FORGE_ vars
+I2	bigrepo	enumerate	PASS	43s	EC=0	recall=8/8	PASS — enumerated 8/8 forge roles
+I3	bigrepo	locate	FAIL	8s	EC=0	recall=na	FAIL — did not land on source value 3 w/ location (deep-localization weak spot; likely trusted docs=2)
+I4	bigrepo	answer-codebase	PASS	27s	EC=0	recall=na	PASS — named qwen3-coder default + source location
+I5	bigrepo	locate	FAIL	9s	EC=0	recall=na	FAIL — did not name conversation.rs
+I6	bigrepo	enumerate	PASS	82s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I7	bigrepo	answer-codebase	PASS	36s	EC=0	recall=na	PASS — correctly states no telemetry / local-first
+I8	bigrepo	answer-codebase	PASS	130s	EC=0	recall=na	PASS — described threshold+summarize mechanism
+J1	git	git-workflow	FAIL	7s	EC=0	recall=na	FAIL — did not identify notes.txt as the uncommitted change
+J2	git	git-workflow	PASS	14s	EC=0	recall=na	PASS — committed greet.py with subject: Add greeting script
+J3	git	git-workflow	FAIL	8s	EC=0	recall=na	FAIL — did not report the most-recent commit message
+J4	git	git-workflow	FAIL	9s	EC=0	recall=na	FAIL — feature/login branch was not created

--- a/runs/eval-2026-05-29/battery/SCORES-screen-gemma4-coder-fable5.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-screen-gemma4-coder-fable5.tsv
@@ -1,0 +1,10 @@
+A1	rust	bugfix	FAIL	21s	EC=1	recall=na	FAIL — cargo test failed:\n
+A7	rust	debug-error	FAIL	18s	EC=0	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+C1	js	bugfix	FAIL	21s	EC=0	recall=na	FAIL — node test.js exited 1:   throw new Error(`cartTotal expected ${want} but got ${got}`);
+C4	js	create-file	FAIL	14s	EC=0	recall=na	FAIL — slug.js was not created
+D1	ts	bugfix	FAIL	34s	EC=0	recall=na	FAIL — node test.ts exited 1: SyntaxError: The requested module './validate.ts' does not provide an export named 'isValidEmail'
+F1	shell	bugfix	FAIL	21s	EC=0	recall=na	FAIL — missing line 'Hello, Ada!' (got: Hello, Ada
+H2	sql	add-feature	FAIL	9s	EC=0	recall=na	FAIL — top_customer.sql did not produce a usable result: ERR: query returned no rows 
+H4	sql	debug-error	FAIL	11s	EC=0	recall=na	FAIL — report.sql still broken or wrong totals: ERR: OperationalError: no such column: o.total 
+I6	bigrepo	enumerate	FAIL	30s	EC=0	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I8	bigrepo	answer-codebase	PASS	45s	EC=0	recall=na	PASS — described threshold+summarize mechanism

--- a/runs/eval-2026-05-29/battery/SCORES-screen-glm47-flash.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-screen-glm47-flash.tsv
@@ -1,0 +1,10 @@
+A1	rust	bugfix	PASS	119s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A7	rust	debug-error	PASS	41s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+C1	js	bugfix	PASS	64s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C4	js	create-file	PASS	67s	EC=0	recall=na	PASS — slug.js created and test.js passes
+D1	ts	bugfix	PASS	81s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+F1	shell	bugfix	PASS	71s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+H2	sql	add-feature	PASS	45s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H4	sql	debug-error	PASS	55s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=2)
+I6	bigrepo	enumerate	FAIL	183s	EC=1	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I8	bigrepo	answer-codebase	FAIL	2s	EC=1	recall=na	FAIL — missing threshold(0) or mechanism(1)

--- a/runs/eval-2026-05-29/battery/SCORES-screen-q36-official-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-screen-q36-official-v0160.tsv
@@ -1,0 +1,18 @@
+C1	js	bugfix	PASS	114s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+A1	rust	bugfix	PASS	113s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+C4	js	create-file	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — slug.js created and test.js passes
+A7	rust	debug-error	PASS	149s	EC=0	recall=na	PASS — cargo build succeeded (type error fixed)
+C1	js	bugfix	PASS	117s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+D1	ts	bugfix	PASS(TIMEOUT)	151s	EC=124	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+C4	js	create-file	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — slug.js created and test.js passes
+F1	shell	bugfix	PASS	95s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+H2	sql	add-feature	PASS	109s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+D1	ts	bugfix	PASS(TIMEOUT)	150s	EC=124	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+F1	shell	bugfix	PASS	84s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+H2	sql	add-feature	PASS	88s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H4	sql	debug-error	FAIL(TIMEOUT)	180s	EC=124	recall=na	FAIL — schema.sql missing
+H4	sql	debug-error	FAIL	157s	EC=0	recall=na	FAIL — schema.sql missing
+I6	bigrepo	enumerate	FAIL	51s	EC=1	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I6	bigrepo	enumerate	FAIL	215s	EC=1	recall=0/7	FAIL — only 0/7 CLI modes (need >=6; enumeration weak spot)
+I8	bigrepo	answer-codebase	FAIL	3s	EC=1	recall=na	FAIL — missing threshold(0) or mechanism(1)
+I8	bigrepo	answer-codebase	FAIL	2s	EC=1	recall=na	FAIL — missing threshold(0) or mechanism(1)

--- a/runs/eval-2026-05-29/battery/SCORES-screen-qwen3coder30b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-screen-qwen3coder30b.tsv
@@ -1,0 +1,10 @@
+A1	rust	bugfix	PASS	32s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)
+A7	rust	debug-error	FAIL	9s	EC=0	recall=na	FAIL — cargo build still failing:\nerror[E0600]: cannot apply unary operator `-` to type `u32`
+C1	js	bugfix	PASS	24s	EC=0	recall=na	PASS — test.js passes (cartTotal fixed)
+C4	js	create-file	PASS	19s	EC=0	recall=na	PASS — slug.js created and test.js passes
+D1	ts	bugfix	PASS	52s	EC=0	recall=na	PASS — node test.ts passed — emails without @ are now rejected
+F1	shell	bugfix	PASS	20s	EC=0	recall=na	PASS — greet.sh prints 'Hello, Ada!' and 'Hello, Grace!'
+H2	sql	add-feature	PASS	15s	EC=0	recall=na	PASS — top_customer.sql returns exactly one row: Ada
+H4	sql	debug-error	PASS	21s	EC=0	recall=na	PASS — report.sql runs cleanly; Ada=150, Bob=50 (150.0 BOB=50.0 ROWS=2)
+I6	bigrepo	enumerate	PASS	87s	EC=0	recall=7/7	PASS — enumerated 7/7 CLI modes
+I8	bigrepo	answer-codebase	PASS	103s	EC=0	recall=na	PASS — described threshold+summarize mechanism

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-glm47-flash.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-glm47-flash.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	FAIL	102s	EC=0	recall=na	FAIL — cargo test failed:\n

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-gptoss20b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-gptoss20b-v0160.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	PASS	18s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-q3-35b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-q3-35b-v0160.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	PASS	34s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-qwen35-4b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-qwen35-4b-v0160.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	PASS	22s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-qwen35-9b-v0160.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-qwen35-9b-v0160.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	FAIL	13s	EC=1	recall=na	FAIL — cargo test failed:\n

--- a/runs/eval-2026-05-29/battery/SCORES-smoke-qwen3coder30b.tsv
+++ b/runs/eval-2026-05-29/battery/SCORES-smoke-qwen3coder30b.tsv
@@ -1,0 +1,1 @@
+A1	rust	bugfix	PASS	40s	EC=0	recall=na	PASS — cargo test succeeded (test_average fixed)


### PR DESCRIPTION
The 2026-07-10 model sweep (7 models scored on claudette v0.16.0, LM Studio runtime 2.24.0) fed the README/docs model-recommendation refresh (#182) and the champion-tuning baseline, but its SCORES tsvs were never committed — `runs/` is hidden from `git status` by `.git/info/exclude`, so they sat local-only.

Publishes the full sweep evidence set (23 tsv files, data-only, no code):
- core-50 + K-extension score sheets: q3_k_xl champion baseline (47/50), qwen3.5-4b (45/50), qwen3.5-9b, gpt-oss-20b (41/50), qwen3-coder-30b (40/50), glm-4.7-flash
- screeners for the out-of-scope verdicts (gemma4 / coder / official-q36 timeout)
- smokes + the documentary coder-30b broken-template run (runtime 2.24.0 template-health evidence)

Part of the 2026-07-11 co-dev backlog sprint (W3 tidy: unpushed-evidence audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)