### PR TITLE
feat(runtime): wire opt-in post-edit checks into write-tool results

### DIFF
--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -1160,12 +1160,6 @@ mod tests {
             "CLAUDETTE_ZZZ_TEST_NONEXISTENT_ABC_TOKEN", // secrets.rs test sentinel
             "CLAUDETTE_FORGE_X",                        // sample code in a repomap test fixture
             "CLAUDETTE_FORGE_Y",                        // ditto
-            // Post-edit-check knobs: read by the not-yet-wired module
-            // (tools/post_edit_check.rs). Documented in configuration.md when
-            // the executor wiring lands (W4b) and they take effect.
-            "CLAUDETTE_POST_EDIT_CHECK",
-            "CLAUDETTE_CHECK_CMD",
-            "CLAUDETTE_CHECK_TIMEOUT_SECS",
         ];
 
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -2899,4 +2899,160 @@ mod tests {
         // string during refactors.
         assert!(VISION_DISCIPLINE_HINT.to_lowercase().contains("image"));
     }
+
+    // ─── Post-edit check wiring (W4, 2026-07-11) ────────────────────────────
+    //
+    // These drive a real turn through the loop with a stub write_file executor
+    // and a CLAUDETTE_CHECK_CMD override (`git <bogus-subcommand>` — portable,
+    // fast, guaranteed non-zero). They share post_edit_check's crate-wide
+    // ENV_LOCK because both test modules mutate the same env vars inside one
+    // parallel test binary.
+
+    /// Scripted client: one assistant message carrying `write_file` ToolUse
+    /// blocks for each given path, then a plain closing message.
+    struct WriteFileScript {
+        paths: Vec<&'static str>,
+        call_count: usize,
+    }
+
+    impl ApiClient for WriteFileScript {
+        fn stream(
+            &mut self,
+            _request: &ApiRequest<'_>,
+        ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            self.call_count += 1;
+            match self.call_count {
+                1 => {
+                    let mut events = vec![AssistantEvent::TextDelta("Writing.".to_string())];
+                    for (i, path) in self.paths.iter().enumerate() {
+                        events.push(AssistantEvent::ToolUse {
+                            id: format!("tool-{i}"),
+                            name: "write_file".to_string(),
+                            input: format!("{{\"path\":\"{path}\",\"content\":\"x\"}}"),
+                        });
+                    }
+                    events.push(AssistantEvent::MessageStop);
+                    Ok(events)
+                }
+                2 => Ok(vec![
+                    AssistantEvent::TextDelta("Done.".to_string()),
+                    AssistantEvent::MessageStop,
+                ]),
+                _ => Err(RuntimeError::new("unexpected extra API call")),
+            }
+        }
+    }
+
+    /// Build a runtime whose `write_file` stub always succeeds with `"ok"`,
+    /// allowed without prompting, and run one scripted turn.
+    fn run_write_file_turn(paths: Vec<&'static str>) -> super::TurnSummary {
+        let api_client = WriteFileScript {
+            paths,
+            call_count: 0,
+        };
+        let tool_executor =
+            StaticToolExecutor::new().register("write_file", |_input| Ok("ok".to_string()));
+        let permission_policy = PermissionPolicy::new(PermissionMode::WorkspaceWrite)
+            .with_tool_requirement("write_file", PermissionMode::WorkspaceWrite);
+        let system_prompt = SystemPromptBuilder::new()
+            .with_project_context(ProjectContext {
+                cwd: PathBuf::from("/tmp/project"),
+                current_date: "2026-07-11".to_string(),
+                git_status: None,
+                git_diff: None,
+                instruction_files: Vec::new(),
+            })
+            .with_os("linux", "6.8")
+            .build();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            api_client,
+            tool_executor,
+            permission_policy,
+            system_prompt,
+        );
+        runtime
+            .run_turn("write the file", None)
+            .expect("turn should succeed")
+    }
+
+    fn tool_result_output(summary: &super::TurnSummary, index: usize) -> String {
+        match &summary.tool_results[index].blocks[0] {
+            ContentBlock::ToolResult { output, .. } => output.clone(),
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn post_edit_check_off_leaves_tool_result_untouched() {
+        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
+        // A command that WOULD fail if the feature ran while disabled.
+        std::env::set_var(
+            crate::tools::post_edit_check::CMD_ENV,
+            "git definitely-not-a-subcommand {file}",
+        );
+
+        let summary = run_write_file_turn(vec!["a.rs"]);
+        let output = tool_result_output(&summary, 0);
+        assert_eq!(
+            output, "ok",
+            "knob off must leave the result byte-identical"
+        );
+
+        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
+    }
+
+    #[test]
+    fn post_edit_check_appends_failure_output() {
+        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
+        std::env::set_var(
+            crate::tools::post_edit_check::CMD_ENV,
+            "git definitely-not-a-subcommand {file}",
+        );
+
+        let summary = run_write_file_turn(vec!["a.rs"]);
+        let output = tool_result_output(&summary, 0);
+        assert!(
+            output.starts_with("ok"),
+            "the tool's own output stays first: {output}"
+        );
+        assert!(
+            output.contains("[post_edit_check] the edited file fails its check:"),
+            "check failure must be appended: {output}"
+        );
+
+        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
+        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
+    }
+
+    #[test]
+    fn post_edit_check_caps_rounds_per_file() {
+        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
+        std::env::set_var(
+            crate::tools::post_edit_check::CMD_ENV,
+            "git definitely-not-a-subcommand {file}",
+        );
+        std::env::set_var(crate::tools::post_edit_check::MAX_ROUNDS_ENV, "1");
+
+        // Two writes to the SAME path in one turn: round 1 gets the full
+        // check output, round 2 the one-line suppression notice.
+        let summary = run_write_file_turn(vec!["a.rs", "a.rs"]);
+        let first = tool_result_output(&summary, 0);
+        let second = tool_result_output(&summary, 1);
+        assert!(
+            first.contains("[post_edit_check] the edited file fails its check:"),
+            "round 1 gets full output: {first}"
+        );
+        assert!(
+            second.contains("still fails its check (output suppressed"),
+            "round 2 gets the suppression notice: {second}"
+        );
+
+        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
+        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
+        std::env::remove_var(crate::tools::post_edit_check::MAX_ROUNDS_ENV);
+    }
 }

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -384,6 +384,10 @@ where
             read_loop_limit_from(std::env::var(READ_LOOP_LIMIT_ENV_VAR).ok().as_deref());
         let mut read_seen: std::collections::HashMap<String, (u64, usize)> =
             std::collections::HashMap::new();
+        // Per-file per-turn round counter for the post-edit-check above.
+        // Resets at the top of each turn (same scope as `read_seen`).
+        let mut check_fails: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
         // No-progress breaker: tool calls since the last SUCCESSFUL mutation,
         // plus a once-per-turn flag for the steering line.
         let mut iters_since_mutation = 0usize;
@@ -582,6 +586,47 @@ where
                                 if reads >= read_loop_limit {
                                     output = unchanged_read_notice(&path, reads);
                                     is_error = true;
+                                }
+                            }
+
+                            // Post-edit check (opt-in, CLAUDETTE_POST_EDIT_CHECK): after a
+                            // successful single-file write, run a fast syntax/type check and
+                            // surface failures in the same tool result so the brain fixes
+                            // breakage now, not at run_tests time. apply_patch is excluded in
+                            // v1 (multi-file). Capped per file per turn so a stubborn error
+                            // can't feed an edit↔check spiral (design 2026-07-11, W4).
+                            if !is_error
+                                && matches!(
+                                    tool_name.as_str(),
+                                    "write_file" | "edit_file" | "apply_diff"
+                                )
+                                && crate::tools::post_edit_check::enabled()
+                            {
+                                let path = read_file_path(&input);
+                                if !path.is_empty() {
+                                    let workspace = crate::missions::active_cwd();
+                                    if let Some(check) =
+                                        crate::tools::post_edit_check::run_post_edit_check(
+                                            std::path::Path::new(&path),
+                                            &workspace,
+                                        )
+                                    {
+                                        let rounds = {
+                                            let n = check_fails.entry(path.clone()).or_insert(0);
+                                            *n += 1;
+                                            *n
+                                        };
+                                        if rounds <= crate::tools::post_edit_check::max_rounds() {
+                                            use std::fmt::Write as _;
+                                            let _ = write!(output, "\n\n[post_edit_check] the edited file fails its check:\n{check}\nFix this before moving on.");
+                                        } else {
+                                            output.push_str(
+                                                &crate::tools::post_edit_check::suppressed_notice(
+                                                    &path,
+                                                ),
+                                            );
+                                        }
+                                    }
                                 }
                             }
 

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -64,7 +64,7 @@ mod mission;
 mod near_miss;
 mod notes;
 mod patch;
-mod post_edit_check;
+pub(crate) mod post_edit_check;
 pub(crate) mod quality;
 mod recall;
 mod registry;

--- a/crates/claudette/src/tools/post_edit_check.rs
+++ b/crates/claudette/src/tools/post_edit_check.rs
@@ -267,14 +267,17 @@ pub(crate) fn run_post_edit_check(file: &Path, workspace: &Path) -> Option<Strin
     Some(truncate_output(&output))
 }
 
+/// Serializes every test that mutates the post-edit-check env knobs — the
+/// module tests below AND the integration tests in `runtime/conversation.rs`
+/// run in the same test binary, so they must share one lock. Each holder
+/// restores/removes the vars before dropping the guard.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
-
-    /// Every test that touches env vars must hold this lock and restore/remove
-    /// the vars before dropping the guard.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn set_env(key: &str, val: &str) {
         std::env::set_var(key, val);

--- a/crates/claudette/src/tools/post_edit_check.rs
+++ b/crates/claudette/src/tools/post_edit_check.rs
@@ -7,8 +7,6 @@
 //! toolchains execute arbitrary project code (same rule as `run_tests`; roast
 //! 2026-06-30 H1).
 
-#![allow(dead_code)] // wired into the executor in the follow-up PR (W4b)
-
 use std::path::{Path, PathBuf};
 
 /// Environment variable that enables post-edit checks.
@@ -19,6 +17,9 @@ pub(crate) const CMD_ENV: &str = "CLAUDETTE_CHECK_CMD";
 
 /// Environment variable for the timeout in seconds (clamped to 1..=120).
 pub(crate) const TIMEOUT_ENV: &str = "CLAUDETTE_CHECK_TIMEOUT_SECS";
+
+/// Environment variable for the max fix rounds per file per turn (clamped to 1..=10).
+pub(crate) const MAX_ROUNDS_ENV: &str = "CLAUDETTE_CHECK_MAX_ROUNDS";
 
 /// Maximum number of output lines to retain.
 pub(crate) const MAX_OUTPUT_LINES: usize = 30;
@@ -53,6 +54,29 @@ pub(crate) fn timeout_secs() -> u64 {
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(10)
         .clamp(1, 120)
+}
+
+/// Per-file per-turn cap on appended check-failure output.
+///
+/// Parses `MAX_ROUNDS_ENV`, clamps to `1..=10`, defaults to `2` when unset or
+/// unparseable. A stubborn error can't feed an edit↔check spiral beyond this
+/// count (design 2026-07-11, W4).
+pub(crate) fn max_rounds() -> u32 {
+    std::env::var(MAX_ROUNDS_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(2)
+        .clamp(1, 10)
+}
+
+/// Suppressed-notice body when the per-file round cap is exceeded.
+///
+/// Returned verbatim — no trailing newline (the caller appends its own).
+pub(crate) fn suppressed_notice(path: &str) -> String {
+    format!(
+        "\n\n[post_edit_check] {path} still fails its check \
+         (output suppressed after repeated rounds this turn — run run_tests or diagnostics for the full picture)"
+    )
 }
 
 /// Parse a raw command string into a `CheckCmd`.
@@ -457,5 +481,37 @@ mod tests {
 
         unset_env(CHECK_ENV);
         std::env::remove_var(crate::egress::OFFLINE_ENV);
+    }
+
+    #[test]
+    fn max_rounds_defaults_and_clamps() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        // Unset → 2.
+        unset_env(MAX_ROUNDS_ENV);
+        assert_eq!(max_rounds(), 2);
+
+        set_env(MAX_ROUNDS_ENV, "1");
+        assert_eq!(max_rounds(), 1);
+
+        set_env(MAX_ROUNDS_ENV, "0");
+        assert_eq!(max_rounds(), 1); // clamped to min.
+
+        set_env(MAX_ROUNDS_ENV, "99");
+        assert_eq!(max_rounds(), 10); // clamped to max.
+
+        set_env(MAX_ROUNDS_ENV, "garbage");
+        assert_eq!(max_rounds(), 2); // fallback default.
+
+        unset_env(MAX_ROUNDS_ENV);
+    }
+
+    #[test]
+    fn suppressed_notice_names_the_file() {
+        let path = "src/main.rs";
+        let notice = suppressed_notice(path);
+        assert!(notice.contains("[post_edit_check]"));
+        assert!(notice.contains("still fails its check"));
+        assert!(notice.contains("output suppressed after repeated rounds this turn — run run_tests or diagnostics for the full picture"));
+        assert!(notice.contains("src/main.rs"));
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,3 +146,29 @@ Rarely needed; defaults are tuned for local small models. Mostly useful for debu
 | `CLAUDETTE_NO_SPINNER` | unset | Set to `1` to suppress the REPL/TUI activity spinner (TTY only). |
 | `CLAUDETTE_MODEL_RELOAD_RETRY_MS` | `750` | Backoff (ms) before retrying a request after the backend reports the model was unloaded/reloaded. |
 | `CLAUDETTE_DISABLE_MODEL_RELOAD_RETRY` | unset | Set to `1` to disable the post-reload retry and fail fast instead. |
+
+### Post-edit checks (opt-in)
+
+Opt-in syntax/type check that runs after a successful `write_file`, `edit_file`, or `apply_diff`. With `CLAUDETTE_POST_EDIT_CHECK=1` the module auto-detects a fast check command for `.rs`, `.py`, `.go`, and `.js`/`.mjs`/`.cjs` files; non-zero output is appended to the same tool result so the brain fixes breakage immediately.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLAUDETTE_POST_EDIT_CHECK` | unset (off) | Set to `1`, `true`, `yes`, or `on` (case-insensitive) to enable post-edit checks. The feature does nothing unless explicitly enabled — the default is OFF, so every byte of behaviour is unchanged when unset. |
+| `CLAUDETTE_CHECK_CMD` | auto-detected | Custom check command string. Tokens are split on whitespace; the first token is the program, the rest are arguments. Any argument containing `{file}` gets replaced by the edited file's path. If no token contained `{file}`, the file path is appended as one extra final argument. Set to an empty string to force auto-detection even when the variable exists. |
+| `CLAUDETTE_CHECK_TIMEOUT_SECS` | `10` | Timeout in seconds for the check command. Clamped to `[1, 120]`. A timed-out check is silently skipped (treated as success). |
+| `CLAUDETTE_CHECK_MAX_ROUNDS` | `2` | Per-file per-turn cap on appended check-failure output. Clamped to `[1, 10]`. When the cap is exceeded for a file in a single turn, further failures are summarized with a one-line notice instead of repeating the full output. |
+
+**Auto-detection (when `CLAUDETTE_CHECK_CMD` is unset or empty):**
+
+| Extension | Command | Notes |
+|-----------|---------|-------|
+| `.rs` | `cargo check --message-format=short` | Runs in workspace root. |
+| `.py` | `ruff check <file>` | Falls back to `python -m py_compile <file>` when `ruff` is not on PATH. |
+| `.go` | `go vet .` | Runs in the file's parent directory (workspace root if the file is at the root). |
+| `.js`, `.mjs`, `.cjs` | `node --check <file>` | Runs in workspace root. |
+
+**Notes:**
+
+- Success (exit 0) appends nothing to the tool result — only failures surface output.
+- The whole feature is a no-op under `--offline` / `CLAUDETTE_OFFLINE=1`.
+- `apply_patch` is excluded from v1 because it touches multiple files; only single-file writes (`write_file`, `edit_file`, `apply_diff`) trigger checks.


### PR DESCRIPTION
W4b of the 2026-07-11 co-dev backlog sprint — second half of the post-edit check loop (design: `runs/codev-2026-07-11/design-post-edit-check.md`; cards: `cards/W4b.md` + `cards/W4b-attempt2.md`).

**Authored by Claudette (forge, byteshape champion), attempt 2 with CLAUDETTE_MAX_ITERATIONS=100** (attempt 1 edited 4/5 files cleanly and died on the default 40-iteration cap). Verifier 10/10; Claude pushed + opened the PR per the ephemeral-mission protocol.

- `CLAUDETTE_POST_EDIT_CHECK=1` → successful `write_file`/`edit_file`/`apply_diff` triggers the auto-detected check; non-zero output appended to the same tool result; per-file per-turn cap `CLAUDETTE_CHECK_MAX_ROUNDS` (default 2). `apply_patch` excluded in v1.
- **Knob OFF (default) = byte-identical behavior** — guarded by `enabled()` early-return + the `post_edit_check_off_leaves_tool_result_untouched` integration test.
- Knob env vars documented in `configuration.md`, removed from the doc-drift ALLOW list.

⚠️ **BEHAVIORAL when ON — do not merge until the A/B battery evidence is posted here** (knob-ON brain100 on both gate models vs the codev-sprint baselines, per goal-doc Appendix C). Claude is running those now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)