### PR TITLE
feat(onboarding): Phase 1 — full-flavor binaries, README progressive disclosure, quickstart checklist

### DIFF
--- a/.github/scripts/package-archive.sh
+++ b/.github/scripts/package-archive.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Package one release-binary flavor into dist/ with a SHA256 sidecar.
+# Called twice per build-binaries matrix leg (release.yml): once for the lean
+# coding-only binary, once for the `--features integrations` full binary.
+#
+# Env contract (set by the calling step):
+#   FLAVOR  "lean" or "full" — picks the archive stem prefix
+#           (claudette-… vs claudette-full-…). The binary *inside* the archive
+#           is named `claudette` either way, so install.sh / install.ps1
+#           extract both flavors identically.
+#   TARGET  Rust target triple (matrix.target); locates the built binary.
+#   EXT     "tar.gz" or "zip" (matrix.ext).
+# Emits `stem=<archive stem>` to $GITHUB_OUTPUT.
+#
+# Runs under bash on every runner. Windows runners ship `tar` and `7z` but
+# only `sha256sum` (no `shasum`); macOS ships `shasum` (perl-based) but no
+# `sha256sum`; Linux ships both. Try `shasum` first, fall back to `sha256sum`
+# — output format ("<hash>  <filename>") is identical between the two.
+set -euo pipefail
+
+# On tag push: GITHUB_REF=refs/tags/v0.5.4 -> version=0.5.4.
+# On workflow_dispatch: no tag, so use a `dev-<short-sha>` stamp so the
+# archive name stays slash-free and the dry-run is distinguishable from a
+# real release.
+if [ "${GITHUB_REF#refs/tags/v}" != "${GITHUB_REF}" ]; then
+  version="${GITHUB_REF#refs/tags/v}"
+else
+  version="dev-${GITHUB_SHA:0:7}"
+fi
+
+case "${FLAVOR}" in
+  lean) prefix="claudette" ;;
+  full) prefix="claudette-full" ;;
+  *)
+    echo "::error::unknown FLAVOR '${FLAVOR}' (expected 'lean' or 'full')"
+    exit 1
+    ;;
+esac
+
+stem="${prefix}-v${version}-${TARGET}"
+# Per-flavor staging dir: the two flavors are packaged from the same
+# target/<target>/release/claudette path (the full build overwrites the lean
+# binary), so each package step must copy its binary aside before the next
+# build runs — and must not see the other flavor's copy.
+staging="staging-${FLAVOR}"
+mkdir -p dist "${staging}"
+
+if [ "${EXT}" = "zip" ]; then
+  cp "target/${TARGET}/release/claudette.exe" "${staging}/"
+  (cd "${staging}" && 7z a "../dist/${stem}.zip" claudette.exe >/dev/null)
+else
+  cp "target/${TARGET}/release/claudette" "${staging}/"
+  chmod +x "${staging}/claudette"
+  tar -C "${staging}" -czf "dist/${stem}.tar.gz" claudette
+fi
+
+archive="${stem}.${EXT}"
+cd dist
+if command -v shasum >/dev/null 2>&1; then
+  shasum -a 256 "${archive}" > "${archive}.sha256"
+else
+  sha256sum "${archive}" > "${archive}.sha256"
+fi
+
+echo "stem=${stem}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,13 @@ name: Release
 #   4. `publish`          — `cargo publish` to crates.io via OIDC (no stored
 #                           token); idempotent (already-published = success).
 #                           `build-binaries` matrix produces prebuilt archives
-#                           for win/linux/macos in parallel.
+#                           for win/linux/macos in parallel, in TWO flavors per
+#                           target: lean (claudette-…, the coding-only default)
+#                           and full (claudette-full-…, `--features
+#                           integrations`) so binary-install users can get
+#                           Telegram/Gmail/Calendar/voice without a Rust
+#                           toolchain (`CLAUDETTE_FLAVOR=full` in the install
+#                           scripts).
 #   5. `release`          — once every matrix leg is green (independent of the
 #                           crates.io publish), attach all binary archives +
 #                           their SHA256 sidecars to a GitHub Release with
@@ -203,8 +209,9 @@ jobs:
   build-binaries:
     name: build ${{ matrix.target }}
     needs: [verify, tag-version-match, audit, deny]
-    # Five archives total: win-x64, linux-x64, linux-arm64, macos-x64,
-    # macos-arm64. linux-arm64 uses GitHub's free arm64 runner. macOS x64
+    # Five targets, two flavors each (lean + full/integrations) = ten archives
+    # total: win-x64, linux-x64, linux-arm64, macos-x64, macos-arm64.
+    # linux-arm64 uses GitHub's free arm64 runner. macOS x64
     # cross-compiles from macos-latest (Apple Silicon) via the universal
     # Xcode SDK — the macos-13 (Intel) free-tier runner pool starves for
     # hours at a time and was the cause of the v0.5.3 release being cut
@@ -228,52 +235,44 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2.9.1
         with:
           key: release-${{ matrix.target }}
-      - name: cargo build --release --locked
+      - name: cargo build --release --locked (lean)
         run: cargo build --release --locked -p claudette --target ${{ matrix.target }}
-      - name: Package archive + SHA256
+      - name: Package lean archive + SHA256
         id: pkg
         shell: bash
-        # Run under bash on every runner. Windows runners ship Git Bash
-        # which provides `tar` and `7z` but only `sha256sum` (no `shasum`);
-        # macOS ships `shasum` (perl-based) but no `sha256sum`; Linux ships
-        # both. Try `shasum` first, fall back to `sha256sum` — output
-        # format ("<hash>  <filename>") is identical between the two.
-        run: |
-          set -euo pipefail
-          # On tag push: GITHUB_REF=refs/tags/v0.5.4 -> version=0.5.4.
-          # On workflow_dispatch: no tag, so use a `dev-<short-sha>` stamp
-          # so the archive name stays slash-free and the dry-run is
-          # distinguishable from a real release.
-          if [ "${GITHUB_REF#refs/tags/v}" != "${GITHUB_REF}" ]; then
-            version="${GITHUB_REF#refs/tags/v}"
-          else
-            version="dev-${GITHUB_SHA:0:7}"
-          fi
-          stem="claudette-v${version}-${{ matrix.target }}"
-          mkdir -p dist staging
-          if [ "${{ matrix.ext }}" = "zip" ]; then
-            cp "target/${{ matrix.target }}/release/claudette.exe" staging/
-            (cd staging && 7z a "../dist/${stem}.zip" claudette.exe >/dev/null)
-          else
-            cp "target/${{ matrix.target }}/release/claudette" staging/
-            chmod +x "staging/claudette"
-            tar -C staging -czf "dist/${stem}.tar.gz" claudette
-          fi
-          archive="${stem}.${{ matrix.ext }}"
-          cd dist
-          if command -v shasum >/dev/null 2>&1; then
-            shasum -a 256 "$archive" > "$archive.sha256"
-          else
-            sha256sum "$archive" > "$archive.sha256"
-          fi
-          echo "stem=${stem}" >> "$GITHUB_OUTPUT"
-      - name: Upload archive artifact
+        env:
+          FLAVOR: lean
+          TARGET: ${{ matrix.target }}
+          EXT: ${{ matrix.ext }}
+        run: bash .github/scripts/package-archive.sh
+      # Full flavor: the opt-in cloud integrations (Telegram, Gmail, Calendar,
+      # voice, briefing) prebuilt for users without a Rust toolchain —
+      # otherwise the in-binary "reinstall with `--features integrations`"
+      # notice is a dead end for binary installs. Built AFTER the lean package
+      # step because both builds emit target/<target>/release/claudette and
+      # this one overwrites it.
+      - name: cargo build --release --locked (full — integrations)
+        run: cargo build --release --locked -p claudette --features integrations --target ${{ matrix.target }}
+      - name: Package full archive + SHA256
+        id: pkgfull
+        shell: bash
+        env:
+          FLAVOR: full
+          TARGET: ${{ matrix.target }}
+          EXT: ${{ matrix.ext }}
+        run: bash .github/scripts/package-archive.sh
+      # One artifact per matrix leg carrying both flavors; named after the
+      # lean stem (artifact names only need to be unique per leg — `release`
+      # downloads with merge-multiple and globs the files back apart).
+      - name: Upload archive artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ steps.pkg.outputs.stem }}
           path: |
             dist/${{ steps.pkg.outputs.stem }}.${{ matrix.ext }}
             dist/${{ steps.pkg.outputs.stem }}.${{ matrix.ext }}.sha256
+            dist/${{ steps.pkgfull.outputs.stem }}.${{ matrix.ext }}
+            dist/${{ steps.pkgfull.outputs.stem }}.${{ matrix.ext }}.sha256
           if-no-files-found: error
           retention-days: 7
 
@@ -304,11 +303,18 @@ jobs:
       - name: Create GitHub Release with binaries attached
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
+          # Two globs per extension: `claudette-v*` (lean) does not match the
+          # full flavor's `claudette-full-v*` stems, and unmatched-file
+          # enforcement below means a missing flavor fails the release loudly.
           files: |
             dist/claudette-v*.tar.gz
             dist/claudette-v*.tar.gz.sha256
             dist/claudette-v*.zip
             dist/claudette-v*.zip.sha256
+            dist/claudette-full-v*.tar.gz
+            dist/claudette-full-v*.tar.gz.sha256
+            dist/claudette-full-v*.zip
+            dist/claudette-full-v*.zip.sha256
           generate_release_notes: true
           make_latest: true
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
 # Claudette
 
-**An air-gapped AI coding agent that runs entirely on your own hardware.** One Rust binary, one local model through [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai/), no cloud. Run it with `--offline` and it physically can't reach the network - your code and your prompts can't leave the machine. (It's a capable personal assistant too - notes, calendar, Telegram voice - but the headline is a coding agent you can run on a no-cloud box.)
+**An air-gapped AI coding agent in one Rust binary — run it `--offline` and your code physically cannot leave the machine.** It drives a model *you* run locally through [Ollama](https://ollama.com) or [LM Studio](https://lmstudio.ai/); there is no cloud-brain code in the binary at all.
 
 [![Crates.io](https://img.shields.io/crates/v/claudette.svg)](https://crates.io/crates/claudette)
 [![CI](https://github.com/mrdushidush/claudette/actions/workflows/ci.yml/badge.svg)](https://github.com/mrdushidush/claudette/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![Air-gap: enforced](https://img.shields.io/badge/air--gap-enforced-success.svg)](#-air-gapped-and-enforced)
 
+<!-- TODO(onboarding 1.3): swap for docs/images/forge-demo.gif once recorded — scripts/record-demo.md has the shot list. -->
 ![Claudette editing her own repo, clearing the cargo gate, and opening a real pull request - all on a local model, offline](docs/images/claudette-ships-pr.png)
 
 *Claudette in her own repo on a local 35B model - editing the code, clearing the full `cargo fmt` / `clippy` / `cargo test` gate, then opening a genuine pull request. No cloud; nothing leaves the machine.*
+
+## Get started in 2 minutes
+
+```sh
+# 1. Install (prebuilt binary, SHA256-verified)
+curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux / macOS
+iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows (PowerShell)
+
+# 2. Pull the default local brain (3.4 GB, one-time — install Ollama from ollama.com first)
+ollama pull qwen3.5:4b
+
+# 3. Check the setup: green rows = ready (it also names the best model for YOUR GPU)
+claudette --doctor
+
+# 4. Talk to it
+claudette "hello — what can you do?"
+```
+
+**Pick your path:** 🛠️ **Local coding agent** → [first-success.md#coding](docs/first-success.md#coding) · 🏠 **Private assistant + Telegram** → [first-success.md#assistant](docs/first-success.md#assistant) · 🔒 **Maximum privacy (`--offline`)** → [first-success.md#airgap](docs/first-success.md#airgap)
 
 ---
 
@@ -23,18 +43,20 @@ There's no cloud-brain code in the binary to begin with, so there's no "private 
 
 ## Install
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux / macOS
-iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows
-cargo install claudette                                                                    # Rust
-```
+The one-liners above grab the latest prebuilt binary and verify its SHA256. Prefer cargo?
 
 ```sh
-ollama pull qwen3.5:4b        # 3.4 GB model, one-time download
-claudette "what time is it?"
+cargo install claudette        # needs a Rust toolchain
 ```
 
-**Want the cloud integrations** (Telegram bot, Gmail, Google Calendar, voice in/out, morning briefing)? They reach third-party services, so they are **not** in the default coding-only build — install with `cargo install claudette --features integrations` (or add `--features integrations` to a `cargo build`). Without it, `--telegram`, `--auth-google`, and `--briefing` print a one-line "reinstall with `--features integrations`" notice instead of running.
+**Want the cloud integrations** (Telegram bot, Gmail, Google Calendar, voice in/out, morning briefing)? They reach third-party services, so they are **not** in the default coding-only build. No Rust toolchain? Grab the prebuilt **full** flavor:
+
+```sh
+CLAUDETTE_FLAVOR=full curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux / macOS
+$env:CLAUDETTE_FLAVOR='full'; iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows
+```
+
+With a toolchain, `cargo install claudette --features integrations` builds the same thing. In the lean build, `--telegram`, `--auth-google`, and `--briefing` print these install commands instead of running.
 
 Prefer not to pipe curl into a shell? Grab a [prebuilt release](https://github.com/mrdushidush/claudette/releases/latest) - each ships a SHA256. No GPU? The 4B model runs on plain CPU. Full setup and first flows → [docs/quickstart.md](docs/quickstart.md).
 
@@ -98,7 +120,8 @@ Runs on 8 GB VRAM or plain CPU; 16 GB for the 35B brain. Footprint details → [
 
 ## Docs
 
-- [docs/show-me.md](docs/show-me.md) - **start here:** plain-English example prompts
+- [docs/first-success.md](docs/first-success.md) - **start here:** copy-paste recipes to a first real win (coding, air-gap, assistant)
+- [docs/show-me.md](docs/show-me.md) - plain-English example prompts
 - [docs/quickstart.md](docs/quickstart.md) - full setup, common flows, tokens
 - [docs/configuration.md](docs/configuration.md) - every env var and token fallback
 - [docs/power-user.md](docs/power-user.md) - LM Studio recipe, brain pinning, forge knobs

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -589,16 +589,33 @@ fn dispatch_google_auth(scope: Option<&str>, revoke: bool) -> ExitCode {
     }
 }
 
+/// Builds the "this flag needs the full build" notice for the coding-only
+/// binary. Points at the prebuilt full-flavor archive first (binary-install
+/// users have no Rust toolchain, so "reinstall with `--features integrations`"
+/// alone is a dead end) and the cargo path second.
+#[cfg(not(feature = "integrations"))]
+fn integrations_notice(flag: &str, missing: &str) -> String {
+    format!(
+        "{flag} needs the `integrations` feature — this is a coding-only build (the default), so \
+         {missing}.\n\
+         Get the prebuilt full binary (no Rust toolchain needed):\n\
+           Linux/macOS: CLAUDETTE_FLAVOR=full curl -fsSL \
+         https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh\n\
+           Windows:     $env:CLAUDETTE_FLAVOR='full'; iwr -useb \
+         https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex\n\
+         Or with a Rust toolchain: cargo install claudette --features integrations"
+    )
+}
+
 #[cfg(not(feature = "integrations"))]
 fn dispatch_google_auth(_scope: Option<&str>, _revoke: bool) -> ExitCode {
     eprintln!(
         "{} {}",
         theme::error(theme::ERR_GLYPH),
-        theme::error(
-            "--auth-google needs the `integrations` feature — this is a coding-only build (the \
-             default), so there is no Google code in it. Reinstall with `--features integrations` \
-             to use Gmail/Calendar."
-        )
+        theme::error(&integrations_notice(
+            "--auth-google",
+            "there is no Google code in it"
+        ))
     );
     ExitCode::FAILURE
 }
@@ -648,11 +665,10 @@ fn dispatch_telegram(_chat_ids: Vec<i64>, _allow_any_chat: bool, _resume: bool) 
     eprintln!(
         "{} {}",
         theme::error(theme::ERR_GLYPH),
-        theme::error(
-            "--telegram needs the `integrations` feature — this is a coding-only build (the \
-             default), so the Telegram bridge isn't in it. Reinstall with `--features \
-             integrations` to run the bot."
-        )
+        theme::error(&integrations_notice(
+            "--telegram",
+            "the Telegram bridge isn't in it"
+        ))
     );
     ExitCode::FAILURE
 }
@@ -787,11 +803,10 @@ fn run_briefing_setup(_time: Option<&str>, _days: Option<&str>) -> ExitCode {
     eprintln!(
         "{} {}",
         theme::error(theme::ERR_GLYPH),
-        theme::error(
-            "--briefing needs the `integrations` feature — this is a coding-only build, so the \
-             morning-briefing helper isn't in it. Reinstall with `--features integrations` to \
-             schedule briefings."
-        )
+        theme::error(&integrations_notice(
+            "--briefing",
+            "the morning-briefing helper isn't in it"
+        ))
     );
     ExitCode::FAILURE
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,17 @@ All variables are optional; defaults are shown. Set them in your shell environme
 
 Claudette intentionally does **not** auto-load `.env` from the current working directory or its parents — that would let a shared project smuggle `OLLAMA_HOST`, `GITHUB_TOKEN`, etc. into the agent without the user noticing. For per-project overrides, use `direnv` or `source path/to/.env` before invoking.
 
+## Installer (`install.sh` / `install.ps1`)
+
+These are read by the one-line install scripts, not by the binary itself:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLAUDETTE_FLAVOR` | `lean` | `full` downloads the prebuilt `--features integrations` binary (Telegram, Gmail, Calendar, voice, morning briefing) instead of the lean coding-only one — no Rust toolchain needed. |
+| `CLAUDETTE_VERSION` | latest | Pin a release version, e.g. `0.16.0`. |
+| `CLAUDETTE_INSTALL_DIR` | `~/.local/bin` (Unix) / `%LOCALAPPDATA%\Programs\claudette` (Windows) | Install location. |
+| `CLAUDETTE_NO_MODIFY_PATH` | unset | (Unix only) Set to anything to suppress the PATH hint. |
+
 ## Core
 
 | Variable | Default | Purpose |

--- a/docs/first-success.md
+++ b/docs/first-success.md
@@ -1,0 +1,145 @@
+# First success — pick a path, get a real win
+
+Four copy-paste recipes, each ending in something you can verify worked. All of them assume you've done the two-minute install from the [README](../README.md#get-started-in-2-minutes): installer one-liner → `ollama pull qwen3.5:4b` → `claudette --doctor` shows green.
+
+Want a broader "what can I even ask it?" catalog instead of a guided path? → [show-me.md](show-me.md).
+
+| Path | You get | Time |
+|------|---------|------|
+| [Safe first steps](#safe) | Notes, todos, weather — fully local | 3 min |
+| [Local coding agent](#coding) | A build-and-test-verified commit on a branch, made by Forge | 10 min |
+| [Maximum privacy](#airgap) | A complete coding session under an enforced air-gap | 10 min |
+| [Private assistant + Telegram](#assistant) | Voice assistant on your phone + morning briefing | 20 min |
+
+---
+
+<a id="safe"></a>
+## 🌱 Safe first steps (fully local, nothing can leave)
+
+Notes and todos live in plain files under `~/.claudette/`; weather uses a keyless public API. Start `claudette` and paste these one at a time:
+
+```text
+take a note: the storage closet key lives behind the printer
+add a todo: review the quarterly report by Friday
+what's the weather in Tel Aviv tomorrow?
+list my open todos
+what did I write down about the storage closet?
+```
+
+**You should see:** each note/todo confirmed as saved, the weather with real numbers, and the last prompt finding your note *by meaning* — even if you phrase it differently than you wrote it.
+
+**If not:** a hang of 1–3 minutes on the very first prompt is the model loading into memory, not a bug — see [troubleshooting.md](troubleshooting.md#the-first-prompt-hangs-for-13-minutes-then-answers).
+
+---
+
+<a id="coding"></a>
+## 🛠️ Local coding agent (Forge, on any repo of yours)
+
+Forge runs an autonomous **Planner → Coder → Verifier** pipeline. The Verifier actually builds and runs your project's tests each round — a diff that doesn't compile or breaks a test can't pass. No GitHub token needed for this recipe: on a local repo, Forge commits to an isolated branch and never touches your working branch.
+
+```sh
+cd ~/code/any-git-repo-you-own      # any git repo under $HOME
+claudette --forge "add a --version flag that prints the package version"
+```
+
+(Swap the task for anything small and testable in your project.)
+
+**You should see** the phases stream past:
+
+```text
+forge: planner                 # localizes the code, writes a short plan
+forge: coder (round 0)         # makes the edit, commits to the mission branch
+forge: build + test            # cargo check / pytest / go test / npm test
+forge: verifier   score=9 pass=true
+forge: changes committed locally at <your repo> (ephemeral/local mission — no
+       GitHub PR target). Review with `git log`/`git diff`, then push + open a
+       PR manually if you want one.
+```
+
+Then inspect and take the win (the branch is named `claudette-mission/<slug>-<timestamp>`):
+
+```sh
+git branch --list 'claudette-mission/*'   # find the mission branch
+git log --oneline <that-branch>           # the verified commit
+git diff main...<that-branch>             # the full change
+git merge <that-branch>                   # keep it (or git branch -D to toss it)
+```
+
+**Success =** the branch exists, the diff does what you asked, and the build/test gate ran before the commit was made. Your working branch was never touched.
+
+**Next:** point it at a GitHub repo with `/brownfield owner/repo` + `/forge <task>` — that path ends in a real PR behind a plan-and-diff `[y/N]` review gate. Full pipeline: [forge.md](forge.md).
+
+---
+
+<a id="airgap"></a>
+## 🔒 Maximum privacy: the enforced air-gap
+
+This is Claudette's wedge: `--offline` is not a promise, it's an enforced mode with two guard layers (in-process HTTP **and** subprocesses) and an integration test that drives every networked tool to prove it refuses. Nothing else in [comparison.md](comparison.md)'s matrix has an enforced, tested equivalent.
+
+**1. See exactly what's allowed:**
+
+```sh
+claudette --offline --doctor
+```
+
+**You should see:** the doctor report plus the offline allow-list — your local model server and loopback, nothing else.
+
+**2. Try to break it.** Start `claudette --offline` and ask it to reach out:
+
+```text
+search the web for rust news
+push this repo to github
+run: bash -c "curl example.com"
+```
+
+**You should see:** every one refuse with a clear `blocked by offline mode` error. The `bash` tool refuses **wholesale** under `--offline` — a raw shell is an escape hatch no allow-list can inspect, so it isn't filtered, it's off.
+
+**3. Now do real work in the same session:**
+
+```text
+map this repo and explain the module layout
+find every TODO in src/ and list them by file
+add a unit test for the parse_config function, then run the tests
+```
+
+**Success =** file ops, search, repo-map, edits, and test runs all work normally — the brain is local, so the air-gap costs you nothing for coding. Every place a byte *could* leave the machine in normal mode is inventoried in [PRIVACY.md](../PRIVACY.md).
+
+---
+
+<a id="assistant"></a>
+## 🏠 Private assistant + Telegram (full flavor)
+
+Three commands from lean install to a voice assistant on your phone. This path uses the **full** flavor (the cloud integrations are deliberately not in the default build).
+
+**1. Get the full binary** (skip if you installed with `--features integrations`):
+
+```sh
+CLAUDETTE_FLAVOR=full curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux / macOS
+$env:CLAUDETTE_FLAVOR='full'; iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows
+```
+
+**2. Connect Google** (one-time OAuth; full walkthrough with screenshots: [google_setup.md](google_setup.md)):
+
+```sh
+claudette --auth-google calendar
+claudette --auth-google gmail
+```
+
+**You should see:** a browser window for consent, then `claudette "what's on my calendar tomorrow?"` answers with your real events. Your inbox is read-only — Claudette can search and read mail, never send.
+
+**3. Put it on your phone.** Get a bot token from `@BotFather` in Telegram, then:
+
+```sh
+export TELEGRAM_BOT_TOKEN=123456:ABC...   # $env:TELEGRAM_BOT_TOKEN= on Windows
+claudette --telegram --chat any           # lock to --chat <your-id> once it works
+```
+
+**You should see:** your bot answer a text message from your phone. Send a voice note and it transcribes (Whisper, local — pull a model to `~/.claudette/models/ggml-large-v3-turbo.bin` first) and answers; type `/voice` for spoken replies. Telegram default-denies anything destructive — no shell, no git push from your phone.
+
+**Bonus — the morning briefing:**
+
+```sh
+claudette --briefing        # 07:00 weekdays: calendar + weather + email digest
+```
+
+**Success =** you ask your phone "what's on my calendar tomorrow?" from the supermarket and get your real schedule back, off your own hardware.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,34 +1,54 @@
 # Quickstart
 
-Zero to a working agent in **under five minutes**, then a 60-second tour of the
-TUI and the Forge code-change pipeline.
+Zero to a working agent in **under five minutes**. Work the checklist top to
+bottom — every step says what success looks like, and where to look if you
+don't see it:
 
-## 1. Install (2 min)
+> ☐ installed → ☐ `--doctor` all green → ☐ first conversation → ☐ first
+> coding one-shot → ☐ Forge on a repo → ☐ *(optional)* Telegram
+
+## ☐ 1. Install (2 min)
+
+The fastest path is the prebuilt binary — SHA256-verified, no Rust toolchain
+needed (that's also what the [README](../README.md#get-started-in-2-minutes)
+leads with):
 
 ```bash
-# a. Install Ollama from https://ollama.com (one-time).
-ollama serve &
-
-# b. Pull the default brain (~3.4 GB on disk, ~3.4 GB VRAM).
-ollama pull qwen3.5:4b
-
-# c. Install Claudette.
-cargo install claudette
+curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh   # Linux / macOS
+iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex  # Windows (PowerShell)
 ```
+
+Have a Rust toolchain and prefer it? `cargo install claudette` builds the same
+lean binary.
+
+Then the model server and the default brain:
+
+```bash
+# Install Ollama from https://ollama.com (one-time), then:
+ollama serve &
+ollama pull qwen3.5:4b     # ~3.4 GB on disk, ~3.4 GB VRAM — runs on plain CPU too
+```
+
+**You should see:** the installer end with `installed vX.Y.Z (lean) → …` and a
+`next: claudette --doctor` hint; `ollama pull` reach 100%.
+**If `claudette` isn't found in a new terminal:**
+[troubleshooting → command not found](troubleshooting.md#claudette-command-not-found-after-install).
 
 The `qwen3.5:4b` brain handles every tool-using flow on its own. Prefer LM
 Studio or a bigger model? See [configuration.md](configuration.md) and
 [hardware.md](hardware.md).
 
-> **Integrations are opt-in at build time.** The default install is a lean,
-> air-gapped coding agent with **no cloud code**. The Telegram bot, Gmail,
-> Google Calendar, and the voice / morning-briefing helpers live behind the
-> `integrations` feature — install with `cargo install claudette --features
-> integrations` if you want them. The `--telegram`, `--auth-google`, and
-> `--briefing` flows below all need that build; without it they print a
-> one-line "reinstall with `--features integrations`" notice.
+> **Integrations are opt-in.** The default install is a lean, air-gapped
+> coding agent with **no cloud code**. The Telegram bot, Gmail, Google
+> Calendar, and the voice / morning-briefing helpers ship in the **full**
+> flavor — grab it prebuilt with
+> `CLAUDETTE_FLAVOR=full curl -fsSL …/install.sh | sh`
+> (Windows: `$env:CLAUDETTE_FLAVOR='full'; iwr -useb …/install.ps1 | iex`),
+> or build it with `cargo install claudette --features integrations`. The
+> `--telegram`, `--auth-google`, and `--briefing` flows below all need it; the
+> lean build prints those exact install commands if you try one.
 
-## 2. Verify (30 sec)
+## ☐ 2. `--doctor` all green (30 sec)
 
 ```bash
 claudette --doctor
@@ -37,8 +57,8 @@ claudette --doctor
 `--doctor` probes every dependency and prints a green/red report with a
 **copy-paste `↳ fix:` command** under anything that's broken — model server not
 running, brain not pulled, a missing build toolchain (`git` / `cargo` /
-`python` / `node` / `go`), or absent voice deps. Green "local brain" and "build
-toolchains" rows mean you're ready. Run it any time something misbehaves.
+`python` / `node` / `go`), or absent voice deps. Run it any time something
+misbehaves.
 
 It also **recommends a Claudette-Certified model for your GPU**: the "pick a
 brain" section detects VRAM via `nvidia-smi` (falling back to
@@ -49,11 +69,55 @@ And if the first interactive run finds the brain missing, claudette **offers
 to pull it on the spot** (`[Y/n]` → `ollama pull …` with live progress) instead
 of dead-ending. Piped/CI/`--offline` runs keep the old print-and-exit behaviour.
 
-## 3. First conversation (30 sec)
+**You should see:** green "local brain" and "build toolchains" rows.
+**If a row is red:** run the `↳ fix:` command printed right under it, then
+re-run `--doctor`. Still stuck →
+[troubleshooting.md](troubleshooting.md).
+
+## ☐ 3. First conversation (30 sec)
 
 ```bash
 claudette "what time is it?"
 ```
+
+**You should see:** a correct answer within a few seconds — except the very
+first prompt after a model load, which can hang 1–3 minutes while the model
+loads into memory. That's normal:
+[troubleshooting → first-prompt hang](troubleshooting.md#the-first-prompt-hangs-for-13-minutes-then-answers).
+
+## ☐ 4. First coding one-shot (1 min)
+
+```bash
+cd ~/code/any-project
+claudette "map this repo and explain the module layout in five bullets"
+```
+
+**You should see:** tool calls stream past (`repo_map`, `read_file`, …), then a
+grounded summary of *your actual code* — not generic filler. That's the coding
+core (files, search, tests) working; it's pre-enabled in any repo.
+
+## ☐ 5. Forge on a repo (5–10 min)
+
+Forge is the autonomous Planner → Coder → Verifier pipeline — the build/test
+gate means a diff that doesn't compile or breaks a test can't pass. Follow the
+copy-paste recipe in
+[first-success.md#coding](first-success.md#coding), or the full walkthrough
+[below](#forge-hands-off-code-changes-with-a-review-gate).
+
+**You should see:** phases stream (`forge: planner` → `coder` → `build + test`
+→ `verifier … pass=true`), ending in a verified commit on an isolated
+`claudette-mission/*` branch (local repo) or a `[y/N]` review gate before a PR
+(GitHub repo).
+
+## ☐ 6. *(Optional)* Telegram from your phone
+
+Needs the **full** flavor from step 1's integrations note. Three commands:
+[first-success.md#assistant](first-success.md#assistant).
+
+**You should see:** your bot reply to a text from your phone, and transcribe a
+voice note.
+
+---
 
 Four entry points, one runtime, one session format — switching is just a
 different command:
@@ -224,6 +288,7 @@ claudette --briefing --time 08:30 --days weekdays
 
 ## Where to go next
 
+- [`first-success.md`](first-success.md) — guided copy-paste recipes to a first real win (coding / air-gap / assistant)
 - [`configuration.md`](configuration.md) — every env var, token fallbacks, recall settings
 - [`forge.md`](forge.md) — the full Forge pipeline, review gate, build/test gate, role-routing
 - [`hardware.md`](hardware.md) — VRAM per preset, running a big brain on constrained VRAM

--- a/install.ps1
+++ b/install.ps1
@@ -6,10 +6,16 @@
 # Env overrides:
 #   $env:CLAUDETTE_VERSION       Pin a version (e.g. 0.5.2). Default: latest.
 #   $env:CLAUDETTE_INSTALL_DIR   Install location. Default: %LOCALAPPDATA%\Programs\claudette.
+#   $env:CLAUDETTE_FLAVOR        'lean' (default) or 'full'. The full flavor
+#                                bundles the opt-in cloud integrations
+#                                (Telegram, Gmail, Calendar, voice, briefing)
+#                                — same as a `--features integrations` source
+#                                build, no Rust toolchain needed.
 #
 # What this script does, in order:
 #   1. Resolves the requested tag (latest by default) from the GitHub API.
-#   2. Downloads claudette-<tag>-x86_64-pc-windows-msvc.zip + .sha256 sidecar.
+#   2. Downloads claudette-<tag>-x86_64-pc-windows-msvc.zip + .sha256 sidecar
+#      (claudette-full-<tag>-… for the full flavor).
 #   3. Verifies the SHA256 (refuses to install on mismatch).
 #   4. Extracts claudette.exe into the install dir.
 #   5. Prints a PATH update command if the install dir isn't on User PATH.
@@ -45,6 +51,13 @@ if ($arch -ne 'AMD64') {
 }
 $Target = 'x86_64-pc-windows-msvc'
 
+$Flavor = if ($env:CLAUDETTE_FLAVOR) { $env:CLAUDETTE_FLAVOR.ToLower() } else { 'lean' }
+switch ($Flavor) {
+    'lean' { $StemPrefix = 'claudette' }
+    'full' { $StemPrefix = 'claudette-full' }
+    default { Fail "unknown CLAUDETTE_FLAVOR: '$Flavor' (use 'lean' or 'full')" }
+}
+
 if ($env:CLAUDETTE_VERSION) {
     $Tag = 'v' + ($env:CLAUDETTE_VERSION -replace '^v','')
 } else {
@@ -58,7 +71,7 @@ if ($env:CLAUDETTE_VERSION) {
     if (-not $Tag) { Fail 'GitHub API returned an empty tag_name' }
 }
 
-$Stem    = "claudette-$Tag-$Target"
+$Stem    = "$StemPrefix-$Tag-$Target"
 $Archive = "$Stem.zip"
 $Url     = "https://github.com/$Repo/releases/download/$Tag/$Archive"
 $ShaUrl  = "$Url.sha256"
@@ -70,7 +83,11 @@ try {
         Invoke-WebRequest -Uri $Url    -OutFile (Join-Path $tmp $Archive)         -UseBasicParsing
         Invoke-WebRequest -Uri $ShaUrl -OutFile (Join-Path $tmp "$Archive.sha256") -UseBasicParsing
     } catch {
-        Fail "download failed: $($_.Exception.Message) (does this release exist?)"
+        if ($Flavor -eq 'full') {
+            Fail "download failed: $($_.Exception.Message) (does this release ship a full-flavor archive? Older releases are lean-only - use 'cargo install claudette --features integrations' there)"
+        } else {
+            Fail "download failed: $($_.Exception.Message) (does this release exist?)"
+        }
     }
 
     Info 'verifying SHA256'
@@ -88,7 +105,7 @@ try {
     }
     Copy-Item -Path (Join-Path $tmp 'claudette.exe') -Destination (Join-Path $InstallDir 'claudette.exe') -Force
 
-    Info "installed $Tag -> $(Join-Path $InstallDir 'claudette.exe')"
+    Info "installed $Tag ($Flavor) -> $(Join-Path $InstallDir 'claudette.exe')"
 } finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
 }

--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,17 @@
 #   CLAUDETTE_VERSION         Pin a version (e.g. 0.5.2). Default: latest.
 #   CLAUDETTE_INSTALL_DIR     Install location. Default: $HOME/.local/bin.
 #   CLAUDETTE_NO_MODIFY_PATH  Set to anything to suppress PATH hints.
+#   CLAUDETTE_FLAVOR          "lean" (default) or "full". The full flavor
+#                             bundles the opt-in cloud integrations (Telegram,
+#                             Gmail, Calendar, voice, briefing) — same as a
+#                             `--features integrations` source build, no Rust
+#                             toolchain needed.
 #
 # What this script does, in order:
 #   1. Detects OS + arch and maps to the Rust target triple we ship.
 #   2. Resolves the requested tag (latest by default) from the GitHub API.
-#   3. Downloads claudette-<tag>-<target>.tar.gz + .sha256 sidecar.
+#   3. Downloads claudette-<tag>-<target>.tar.gz + .sha256 sidecar
+#      (claudette-full-<tag>-<target>.tar.gz for the full flavor).
 #   4. Verifies the SHA256 (refuses to install on mismatch).
 #   5. Drops the `claudette` binary into the install dir.
 #   6. Prints a PATH update hint if the install dir isn't on PATH.
@@ -52,6 +58,13 @@ esac
 
 TARGET="${ARCH}-${OS}"
 
+FLAVOR="${CLAUDETTE_FLAVOR:-lean}"
+case "$FLAVOR" in
+  lean) STEM_PREFIX="claudette" ;;
+  full) STEM_PREFIX="claudette-full" ;;
+  *)    err "unknown CLAUDETTE_FLAVOR: '$FLAVOR' (use 'lean' or 'full')" ;;
+esac
+
 VERSION="${CLAUDETTE_VERSION:-}"
 if [ -z "$VERSION" ]; then
   info "resolving latest release tag..."
@@ -62,7 +75,7 @@ else
   TAG="v${VERSION#v}"
 fi
 
-STEM="claudette-${TAG}-${TARGET}"
+STEM="${STEM_PREFIX}-${TAG}-${TARGET}"
 ARCHIVE="${STEM}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
 SHA_URL="${URL}.sha256"
@@ -70,9 +83,15 @@ SHA_URL="${URL}.sha256"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
+if [ "$FLAVOR" = "full" ]; then
+  DL_HINT="does this release ship a full-flavor archive? Older releases are lean-only — use 'cargo install claudette --features integrations' there"
+else
+  DL_HINT="does this release exist?"
+fi
+
 info "downloading ${ARCHIVE}"
 curl -fsSL "$URL"     -o "${TMP}/${ARCHIVE}" \
-  || err "download failed: ${URL} (does this release exist?)"
+  || err "download failed: ${URL} (${DL_HINT})"
 curl -fsSL "$SHA_URL" -o "${TMP}/${ARCHIVE}.sha256" \
   || err "checksum download failed: ${SHA_URL}"
 
@@ -95,7 +114,7 @@ mkdir -p "$INSTALL_DIR"
 mv "${TMP}/claudette" "${INSTALL_DIR}/claudette"
 chmod +x "${INSTALL_DIR}/claudette"
 
-info "installed ${TAG} → ${INSTALL_DIR}/claudette"
+info "installed ${TAG} (${FLAVOR}) → ${INSTALL_DIR}/claudette"
 
 case ":$PATH:" in
   *:"$INSTALL_DIR":*)

--- a/scripts/record-demo.md
+++ b/scripts/record-demo.md
@@ -1,0 +1,66 @@
+# Recording the hero demo GIF (`docs/images/forge-demo.gif`)
+
+Shot list + exact commands for the 30–45 second recording that replaces the
+static PNG at the top of the README. Target: **< 5 MB**, terminal-only, no
+narration, readable at README column width.
+
+## Setup (before recording)
+
+- Linux/macOS terminal (asciinema doesn't record on Windows; use WSL or the
+  Linux box). 100×30 terminal, a font that renders `↳`/`⚠`/box-drawing glyphs,
+  dark theme, font size large enough that a phone reader can follow.
+- Brain loaded and **warm** (run one throwaway prompt first — the demo must not
+  eat a 60 s model-load hang).
+- A small toy repo with a test suite (ideal: a tiny Rust or Python CLI of
+  ~5 files where `--forge` can add a small flag). Clean working tree — forge
+  refuses a dirty tree.
+- `export CLAUDETTE_NO_SPINNER=` (leave the spinner ON — it reads as "alive"
+  in the GIF).
+- Install the recorder + converter:
+
+```sh
+cargo install --locked agg          # asciinema GIF renderer
+# asciinema via your package manager (apt install asciinema / brew install asciinema)
+```
+
+## Shot list (one continuous take, ~40 s)
+
+| # | Seconds | Action | What the viewer must see |
+|---|---------|--------|--------------------------|
+| 1 | 0–6 | `claudette --doctor` | The green rows — local brain, toolchains — and the GPU model recommendation. **All green.** |
+| 2 | 6–14 | `claudette "add a note: demo day"`, then `claudette "list my notes"` | One-shot round trip: instant tool call, instant answer. Proves it's alive and local. |
+| 3 | 14–38 | `claudette --forge "<small task>"` in the toy repo | The phase lines streaming: `forge: planner` → `forge: coder (round 0)` → `forge: build + test` → `forge: verifier … pass=true`. |
+| 4 | 38–44 | The review gate | The **colored diff** and the `⚠ … [y/N]` prompt — pause 2 s on it, type `y` (GitHub-mission take) or let the local-mission commit line land. **This is the money shot: a human gate in an autonomous pipeline.** |
+
+Keep-it-tight rules: no typos/backspacing (rehearse the take), no window
+switching, don't scroll back. If the forge round takes longer than ~25 s,
+cut the take and pick a smaller task — a boring wait kills the GIF.
+
+## Record → convert → verify
+
+```sh
+asciinema rec demo.cast --cols 100 --rows 30      # run the shot list, Ctrl+D to stop
+agg demo.cast forge-demo.gif \
+    --font-size 16 --speed 1.25 --theme monokai   # 1.25× trims dead air
+ls -lh forge-demo.gif                             # must be < 5 MB
+```
+
+Too big? In order of preference: `--speed 1.5`, re-record with fewer idle
+seconds, `--font-size 14`, or post-process with
+`gifsicle -O3 --lossy=80 forge-demo.gif -o forge-demo.gif`.
+
+## Ship it
+
+```sh
+mv forge-demo.gif docs/images/forge-demo.gif
+```
+
+Then in `README.md`, replace the `claudette-ships-pr.png` image line (it has a
+`TODO(onboarding 1.3)` comment above it) with:
+
+```markdown
+![claudette --doctor going green, a one-shot answer, then Forge planning, coding, passing the build-and-test gate, and stopping at the human diff review](docs/images/forge-demo.gif)
+```
+
+Keep the PNG in `docs/images/` — it stays as the social-preview / fallback
+image.


### PR DESCRIPTION
Phase 1 of the onboarding plan (docs/ONBOARDING_PLAN.md, kept local), plus 2.3 pulled forward so the new README persona links resolve.

## 1.1 — the one hard onboarding bug: integrations/binary dead end
- **release.yml**: each build-binaries leg now builds **two flavors** — lean (unchanged names) and `claudette-full-<tag>-<target>` built with `--features integrations` — via a shared `.github/scripts/package-archive.sh`; both attach to the GitHub Release with sha256 sidecars (`fail_on_unmatched_files` covers the new globs).
- **install.sh / install.ps1**: `CLAUDETTE_FLAVOR=full` fetches the full archive; lean stays the default; flavor-aware error hint for pre-full releases.
- **In-binary notices** (`--auth-google` / `--telegram` / `--briefing` in the lean build): now print the full-flavor install one-liners first, cargo second — a non-Rust user has a path.
- `CLAUDETTE_FLAVOR` + the other installer env vars documented in configuration.md (keeps `every_env_var_is_documented` green).

## 1.2 — README top rewrite (progressive disclosure)
Unhedged hook → badges → hero visual (GIF slot TODO-commented until 1.3 is recorded) → **Get started in 2 minutes** → three persona links. Everything below the install section untouched.

## 2.3 (pulled forward) — docs/first-success.md
Four copy-paste recipes with explicit success criteria: `#safe`, `#coding` (forge on a local repo, transcript matches the real `forge_run.rs` output), `#airgap` (the wedge page), `#assistant` (full flavor → OAuth → Telegram). Pulled forward so the README links aren't dead.

## 1.4 — quickstart sync
Installer leads, cargo is the alternative (was reversed); six-item success checklist, each step with a "you should see" and a troubleshooting anchor.

## 1.3 — scripts/record-demo.md
Shot list + asciinema/agg commands for the <5 MB hero GIF. **[HUMAN records]**

## Verification
- `cargo fmt` clean; clippy `-D warnings` clean on default **and** `--all-features`
- 1052 lib+bin tests green, incl. the env-var doc-drift guard
- `sh -n install.sh` OK; `install.ps1` PSParser-clean; release.yml YAML-valid
- Note: the two-flavor release path first runs for real on the next `v*` tag; a `workflow_dispatch` dry-run of release.yml can validate the matrix before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)