### PR TITLE
feat(onboarding): Phase 2 — --setup wizard, first-success nudge, cold-start note + canonical model page

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -584,6 +584,22 @@ fn lm_studio_models_data_is_empty(body: &str) -> bool {
 
 impl ApiClient for OllamaApiClient {
     fn stream(&mut self, request: &ApiRequest<'_>) -> Result<Vec<AssistantEvent>, RuntimeError> {
+        // Cold-start heads-up, once per process: the first request may hit a
+        // model the backend still has to load into VRAM — 10–60s of silence
+        // on a big quant, which reads as a hang. Routed through the status
+        // controller so it can't collide with the REPL spinner, and so every
+        // non-REPL surface (one-shot, forge, TUI, tests) stays byte-for-byte
+        // unchanged (the controller is a no-op unless the interactive REPL
+        // enabled it). Fn-local static survives the runtime/client rebuilds
+        // that `brain_selector` does mid-session.
+        static COLD_START_NOTE: std::sync::Once = std::sync::Once::new();
+        COLD_START_NOTE.call_once(|| {
+            crate::status::global().print_note(
+                "first request — the backend may need to load the model into memory \
+                 (10–60s of silence is normal on a cold start; later turns are fast)",
+            );
+        });
+
         let body = self.build_chat_body(request);
         let path = if self.openai_compat {
             "/v1/chat/completions"

--- a/crates/claudette/src/firstrun.rs
+++ b/crates/claudette/src/firstrun.rs
@@ -90,8 +90,9 @@ pub fn classify_backend(base_url: &str, openai_compat: bool, configured: &str) -
 
 /// `[Y/n]` — default **yes** (this is a helpful offer, not a danger gate;
 /// the dangerous direction is doing nothing). EOF / read error / explicit
-/// `n` → false.
-fn confirm_default_yes(question: &str) -> bool {
+/// `n` → false. `pub(crate)`: shared with the `--setup` wizard so every
+/// onboarding prompt has the same default-yes semantics.
+pub(crate) fn confirm_default_yes(question: &str) -> bool {
     let mut err = std::io::stderr().lock();
     let _ = write!(
         err,
@@ -212,6 +213,64 @@ pub fn offer_fix_interactive() -> bool {
     }
 }
 
+// ─── First-success "what's next?" nudge ─────────────────────────────────
+
+/// Path of the "nudge already shown" sentinel under `home`. Absent =
+/// brand-new install that has never completed a successful REPL turn.
+fn onboarded_sentinel(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".claudette").join(".onboarded")
+}
+
+/// One-time "what's next?" menu after the first successful REPL turn of a
+/// brand-new install. Returns the menu when the sentinel was absent — and
+/// creates it BEFORE returning, so a crash mid-print can never re-arm it.
+/// `None` when the sentinel exists or can't be written (fail-closed: a box
+/// where `~/.claudette` isn't writable should stay quiet, not nudge every
+/// turn). Takes `home` explicitly so tests drive it via `with_temp_home`.
+pub(crate) fn first_success_nudge(home: &std::path::Path) -> Option<String> {
+    let path = onboarded_sentinel(home);
+    if path.exists() {
+        return None;
+    }
+    if let Some(dir) = path.parent() {
+        if std::fs::create_dir_all(dir).is_err() {
+            return None;
+        }
+    }
+    if std::fs::write(&path, "first-success nudge shown\n").is_err() {
+        return None;
+    }
+    Some(
+        "✨ first reply done — what's next?\n\
+         · point it at code — cd into a repo and ask \"explain this codebase\"\n\
+         · /help — the full slash-command list\n\
+         · claudette --forge \"<task>\" — the autonomous plan → code → verify pipeline\n\
+         · phone/voice assistant (Telegram) — docs/first-success.md#assistant"
+            .to_string(),
+    )
+}
+
+/// Print the first-success nudge if this install has never shown it. Called
+/// from the REPL's successful-turn arm only (one-shot / forge / TUI never
+/// call it), and additionally TTY-gated here because the REPL itself can be
+/// piped. Mirrors `offer_fix_interactive`'s fail-closed stance on pipes/CI.
+pub fn maybe_print_first_success_nudge() {
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return;
+    }
+    let home = crate::env_config::home_dir();
+    if let Some(menu) = first_success_nudge(&home) {
+        eprintln!();
+        let mut lines = menu.lines();
+        if let Some(first) = lines.next() {
+            eprintln!("{}", theme::accent(first));
+        }
+        for line in lines {
+            eprintln!("   {}", theme::dim(line));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{classify_models_response, FirstRunCause};
@@ -256,5 +315,50 @@ mod tests {
         // Under `cargo test`, stdin is not a TTY — the gate must refuse
         // before doing any network or printing anything.
         assert!(!super::offer_fix_interactive());
+    }
+
+    // ─── First-success nudge ─────────────────────────────────────────
+
+    #[test]
+    fn nudge_fires_once_then_never_again() {
+        crate::with_temp_home(|home| {
+            let first = super::first_success_nudge(home);
+            assert!(first.is_some(), "fresh home must fire the nudge");
+            assert!(
+                home.join(".claudette").join(".onboarded").exists(),
+                "sentinel must be created before the menu is returned"
+            );
+            assert!(
+                super::first_success_nudge(home).is_none(),
+                "second call must be suppressed by the sentinel"
+            );
+        });
+    }
+
+    #[test]
+    fn nudge_menu_names_every_next_step() {
+        crate::with_temp_home(|home| {
+            let menu = super::first_success_nudge(home).expect("fresh home fires");
+            for needle in ["/help", "--forge", "first-success.md#assistant"] {
+                assert!(menu.contains(needle), "menu missing `{needle}`:\n{menu}");
+            }
+        });
+    }
+
+    #[test]
+    fn nudge_respects_a_preexisting_sentinel() {
+        crate::with_temp_home(|home| {
+            let dir = home.join(".claudette");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(".onboarded"), "").unwrap();
+            assert!(super::first_success_nudge(home).is_none());
+        });
+    }
+
+    #[test]
+    fn nudge_wrapper_is_quiet_when_stdin_is_piped() {
+        // Under `cargo test`, stdin is not a TTY — the wrapper must return
+        // before touching the real home directory or printing anything.
+        super::maybe_print_first_success_nudge();
     }
 }

--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -77,6 +77,7 @@ pub mod run;
 pub mod scheduler;
 pub mod secrets;
 pub mod security_review;
+pub mod setup;
 pub mod status;
 #[cfg(feature = "integrations")]
 pub mod telegram_mode;

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -81,6 +81,10 @@ struct CliArgs {
     /// secrets dir). Exits before any interactive mode starts. Non-zero
     /// exit code if any probe was a hard failure (warnings tolerated).
     doctor: bool,
+    /// `--setup`: run the interactive first-run wizard (backend detect →
+    /// VRAM → recommended-brain pull offer → integrations pointers →
+    /// closing `--doctor` pass). TTY-only; refused under `--offline`.
+    setup: bool,
 }
 
 /// Help text printed on `--help` / `-h`. One source of truth; the README
@@ -120,6 +124,11 @@ TELEGRAM OPTIONS:
                          username can DM and get a full assistant.
 
 ONE-SHOT SETUP COMMANDS (each exits after doing its one job):
+    --setup              Interactive first-run wizard: detect the backend
+                         (Ollama / LM Studio) and GPU VRAM, offer to pull the
+                         recommended brain, point at the integrations setup,
+                         then finish with a --doctor pass. Needs a terminal;
+                         refused under --offline (pulling a model is egress).
     --doctor             Probe every dependency (Ollama, embed model, OAuth
                          tokens, voice deps, secrets dir) and print a
                          green/red diagnostic report. Useful when a tool
@@ -241,6 +250,7 @@ fn main() -> ExitCode {
         allow_any_chat,
         forge,
         doctor,
+        setup,
     } = args;
 
     // ── Offline-mode banner ───────────────────────────────────────────
@@ -256,6 +266,19 @@ fn main() -> ExitCode {
                 claudette::api::resolve_ollama_url()
             ))
         );
+    }
+
+    // ── --setup: interactive first-run wizard ────────────────────────
+    // Before `probe_ollama` on purpose — setup's whole job is walking the
+    // user out of the dead-backend / missing-model states that the probe
+    // would otherwise fail on. Exits with the wizard's own status code.
+    if setup {
+        let code = claudette::setup::run();
+        return if code == 0 {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        };
     }
 
     // ── --doctor: full diagnostic probe ──────────────────────────────
@@ -523,6 +546,7 @@ fn parse_args(args: &[String]) -> CliArgs {
             "--days" => expect = ExpectNext::Days,
             "--forge" => out.forge = true,
             "--doctor" => out.doctor = true,
+            "--setup" => out.setup = true,
             "--faceless" => {
                 // Persona overlay opt-out (Eva for assistant, CodeX-7 for
                 // forge Coder). Set the env var so the secretary prompt
@@ -1063,6 +1087,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_args_setup_flag() {
+        let a = parse_args(&["--setup".into()]);
+        assert!(a.setup);
+        assert!(!a.doctor);
+        assert!(a.prompt_words.is_empty());
+    }
+
+    #[test]
     fn parse_args_help_long() {
         let a = parse_args(&["--help".into()]);
         assert!(a.help);
@@ -1103,6 +1135,7 @@ mod tests {
             "--tui",
             "--forge",
             "--doctor",
+            "--setup",
             "--faceless",
             "--offline",
             "--chat",

--- a/crates/claudette/src/run/repl.rs
+++ b/crates/claudette/src/run/repl.rs
@@ -232,6 +232,13 @@ pub fn run_agent_repl(opts: SessionOptions) -> Result<()> {
                     );
                 }
 
+                // One-time "what's next?" menu after the first successful
+                // turn of a brand-new install (~/.claudette/.onboarded
+                // sentinel). REPL-only call site keeps one-shot / forge /
+                // TUI output untouched; the fn TTY-gates itself (the REPL
+                // can be piped) and self-disarms after a single print.
+                crate::firstrun::maybe_print_first_success_nudge();
+
                 // Cross-session recall: enqueue the user input + the
                 // assistant text from this turn for the async indexer
                 // thread (see [`index_turn_for_recall`] / [`recall_index_sender`]).

--- a/crates/claudette/src/setup.rs
+++ b/crates/claudette/src/setup.rs
@@ -1,0 +1,233 @@
+//! `claudette --setup` — the interactive first-run wizard.
+//!
+//! One command from a fresh install to a working first prompt: detect the
+//! backend (Ollama / LM Studio), read the GPU's VRAM, offer to pull the
+//! recommended Claudette-Certified brain, point at the integrations setup,
+//! then finish with a full `--doctor` pass and a suggested first prompt.
+//!
+//! Everything here reuses probes that `--doctor` and the first-run
+//! remediation already trust: [`crate::firstrun::classify_backend`] for the
+//! backend/model state, [`crate::hw`] for the VRAM→brain recommendation,
+//! [`crate::doctor`]'s hints and final pass. The wizard adds no new probe
+//! logic — it only sequences the existing pieces interactively.
+//!
+//! Fail-closed posture (mirrors `firstrun::offer_fix_interactive`): stdin
+//! AND stderr must be TTYs, and the wizard refuses under `--offline` (its
+//! whole point is pulling/loading models, which is egress). Piped / CI /
+//! offline runs get one explanatory line and exit non-zero.
+
+use std::io::IsTerminal;
+use std::process::Command;
+
+use crate::firstrun::FirstRunCause;
+use crate::theme;
+
+/// Total number of wizard steps, for the `[n/N]` progress prefix.
+const STEPS: u8 = 5;
+
+fn step(n: u8, label: &str) {
+    eprintln!();
+    eprintln!("{}", theme::accent(&format!("[{n}/{STEPS}] {label}")));
+}
+
+fn note(text: &str) {
+    eprintln!("  {}", theme::dim(text));
+}
+
+fn ok_line(text: &str) {
+    eprintln!("  {} {}", theme::OK_GLYPH, theme::ok(text));
+}
+
+fn fix_line(cmd: &str) {
+    eprintln!("      {} {}", theme::accent("↳ fix:"), theme::dim(cmd));
+}
+
+/// Entry point — returns the process exit code for the CLI (mirrors
+/// `doctor::run`). `0` when the wizard ran to the end and the closing
+/// doctor pass had no hard failures.
+#[allow(clippy::too_many_lines)] // linear wizard script — splitting it would obscure the flow
+pub fn run() -> i32 {
+    theme::init();
+
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        eprintln!(
+            "--setup is interactive and needs a terminal on stdin/stderr — run it directly, \
+             not piped or in CI. For a non-interactive report use: claudette --doctor"
+        );
+        return 1;
+    }
+    if crate::egress::is_offline() {
+        eprintln!(
+            "--setup is disabled under --offline: its job is pulling/loading models, which is \
+             egress by definition. Check an air-gapped box with: claudette --offline --doctor"
+        );
+        return 1;
+    }
+
+    eprintln!(
+        "{} {}",
+        theme::GEAR,
+        theme::brand(&format!(
+            "claudette --setup (v{}) — first-run wizard",
+            env!("CARGO_PKG_VERSION")
+        ))
+    );
+
+    let base_url = crate::api::resolve_ollama_url();
+    let compat = crate::api::resolve_openai_compat();
+    let configured = crate::run::current_model();
+
+    // ── [1/5] backend ────────────────────────────────────────────────
+    let backend_label = if compat {
+        "LM Studio / OpenAI-compat"
+    } else {
+        "Ollama"
+    };
+    step(1, &format!("model backend — {backend_label}"));
+    let state = crate::firstrun::classify_backend(&base_url, compat, &configured);
+    if state == FirstRunCause::Unreachable {
+        eprintln!(
+            "  {} {}",
+            theme::ERR_GLYPH,
+            theme::error(&format!("not reachable at {base_url}"))
+        );
+        fix_line(&crate::doctor::backend_start_hint(compat));
+        // Everything after this step (model presence, pull offer, the
+        // doctor pass) is meaningless against a dead server — stop here
+        // rather than walking the user through steps that can only fail.
+        note("start the server, then re-run: claudette --setup");
+        return 1;
+    }
+    ok_line(&format!("reachable at {base_url}"));
+
+    // ── [2/5] hardware ───────────────────────────────────────────────
+    step(2, "hardware — GPU VRAM");
+    let (vram_gb, source) = crate::hw::resolve_vram_gb();
+    match source {
+        crate::hw::VramSource::Detected => {
+            ok_line(&format!("{vram_gb:.1} GiB detected via nvidia-smi"));
+        }
+        crate::hw::VramSource::EnvVar => {
+            ok_line(&format!("{vram_gb:.1} GiB from CLAUDETTE_VRAM_GB"));
+        }
+        crate::hw::VramSource::Default => {
+            eprintln!(
+                "  {} {}",
+                theme::WARN_GLYPH,
+                theme::warn("no nvidia-smi (AMD/Apple/CPU?) — assuming 8 GiB")
+            );
+            note("set CLAUDETTE_VRAM_GB to your real figure for a better pick");
+        }
+    }
+
+    // ── [3/5] recommended brain + pull offer ─────────────────────────
+    let rec = crate::hw::recommend_brain(vram_gb, compat);
+    step(3, &format!("recommended brain — {}", rec.model));
+    note(rec.why);
+    match crate::firstrun::classify_backend(&base_url, compat, rec.model) {
+        FirstRunCause::Ready => {
+            ok_line("already available on the backend");
+        }
+        FirstRunCause::Unreachable => {
+            // The backend answered in step 1 and died since — rare enough
+            // to just hint and move on; the doctor pass will re-check.
+            fix_line(&crate::doctor::backend_start_hint(compat));
+        }
+        FirstRunCause::NoModelLoaded | FirstRunCause::ModelNotPulled { .. } => {
+            if compat {
+                // LM Studio loads happen in its GUI / `lms load` — not
+                // something we can drive reliably from here (same call as
+                // the first-run remediation path).
+                fix_line(&crate::doctor::model_load_hint(compat, rec.model));
+                note("flagship load flags (ctx / MTP): docs/hardware.md");
+            } else if crate::firstrun::confirm_default_yes(&format!(
+                "pull it now with `ollama pull {}`? (one-time download)",
+                rec.model
+            )) {
+                // Inherit stdio so the user sees ollama's progress bars.
+                match Command::new("ollama").args(["pull", rec.model]).status() {
+                    Ok(s) if s.success() => ok_line(&format!("`{}` pulled", rec.model)),
+                    Ok(s) => {
+                        eprintln!(
+                            "  {} {}",
+                            theme::ERR_GLYPH,
+                            theme::error(&format!("`ollama pull {}` exited with {s}", rec.model))
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "  {} {}",
+                            theme::ERR_GLYPH,
+                            theme::error(&format!("could not run `ollama` ({e})"))
+                        );
+                        fix_line(&crate::doctor::backend_start_hint(compat));
+                    }
+                }
+            } else {
+                note("skipped — pull it any time with the command above");
+            }
+        }
+    }
+    if !crate::doctor::model_present(std::slice::from_ref(&configured), rec.model) {
+        note(&format!(
+            "claudette is currently configured for `{configured}` — to switch, set \
+             CLAUDETTE_MODEL={} in ~/.claudette/.env (advisory; nothing is changed for you)",
+            rec.model
+        ));
+    }
+
+    // ── [4/5] cloud integrations (optional) ──────────────────────────
+    step(
+        4,
+        "cloud integrations — Telegram bot, Gmail, Calendar, voice (optional)",
+    );
+    note("these reach third-party services; everything so far is fully local");
+    if crate::firstrun::confirm_default_yes("show how to enable them?") {
+        if cfg!(feature = "integrations") {
+            note("this build includes them. Next steps:");
+            note("  Telegram bot:     claudette --telegram   (needs TELEGRAM_BOT_TOKEN)");
+            note("  Google APIs:      claudette --auth-google calendar   (or gmail)");
+            note("  full walkthrough: docs/first-success.md#assistant");
+        } else {
+            note("this is the lean coding-only build — grab the prebuilt full flavor:");
+            note("  Linux/macOS: CLAUDETTE_FLAVOR=full curl -fsSL https://raw.githubusercontent.com/mrdushidush/claudette/main/install.sh | sh");
+            note("  Windows:     $env:CLAUDETTE_FLAVOR='full'; iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.ps1 | iex");
+            note("  (or, with a Rust toolchain: cargo install claudette --features integrations)");
+        }
+    } else {
+        note("skipping — claudette stays fully local");
+    }
+
+    // ── [5/5] doctor pass ────────────────────────────────────────────
+    step(5, "final check — running the full --doctor probe");
+    let code = crate::doctor::run();
+
+    eprintln!();
+    if code == 0 {
+        eprintln!(
+            "{} {}",
+            theme::SPARKLES,
+            theme::ok("setup complete — try your first prompt:")
+        );
+    } else {
+        eprintln!(
+            "{} {}",
+            theme::WARN_GLYPH,
+            theme::warn("setup finished with red rows above — fix those, then try:")
+        );
+    }
+    eprintln!("      claudette \"hello — what can you do?\"");
+    note("first-win recipes (coding / air-gap / assistant): docs/first-success.md");
+    code
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn setup_refuses_without_a_tty() {
+        // Under `cargo test`, stdin is not a TTY — the wizard must refuse
+        // with exit 1 before doing any network I/O or prompting (mirrors
+        // firstrun::offer_is_refused_when_stdin_is_piped).
+        assert_eq!(super::run(), 1);
+    }
+}

--- a/crates/claudette/src/status.rs
+++ b/crates/claudette/src/status.rs
@@ -163,6 +163,25 @@ impl StatusController {
         self.transition(Phase::Idle, true);
     }
 
+    /// Erase the transient spinner line (if any) and print `line` dimmed to
+    /// stderr — for one-off notices (e.g. the cold-start heads-up) that must
+    /// not collide with an in-flight spinner. The phase is left unchanged,
+    /// so an active spinner simply redraws below the note on its next tick.
+    /// No-op when the indicator is disabled, which keeps every non-REPL
+    /// surface (one-shot, forge, TUI, tests) byte-for-byte unchanged.
+    pub fn print_note(&self, line: &str) {
+        if !self.enabled.load(Ordering::Relaxed) {
+            return;
+        }
+        let mut g = self.lock();
+        self.erase(&mut g);
+        // Still holding the inner lock, so the render thread can't redraw
+        // between the erase and this print.
+        let mut err = std::io::stderr().lock();
+        let _ = writeln!(err, "{}", theme::dim(line));
+        let _ = err.flush();
+    }
+
     fn transition(&self, phase: Phase, erase: bool) {
         if !self.enabled.load(Ordering::Relaxed) {
             return;
@@ -301,5 +320,7 @@ mod tests {
         c.on_tool_end();
         c.on_prompt();
         c.on_turn_end();
+        // Disabled → print_note writes nothing (non-REPL surfaces unchanged).
+        c.print_note("cold-start note");
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ These are read by the one-line install scripts, not by the binary itself:
 | `OLLAMA_HOST` | `http://localhost:11434` | Ollama API endpoint. Honoured exactly like Ollama itself. |
 | `CLAUDETTE_ALLOW_REMOTE_OLLAMA` | unset | Set to `1` to silence the startup warning when `OLLAMA_HOST` is non-loopback. Default posture is local-only. |
 | `CLAUDETTE_OFFLINE` | unset | Set to `1` (or pass `--offline`) to **enforce the air-gap**: hard-block every outbound network call except the local model backend + loopback. See [Enforced offline mode](#enforced-offline-mode---offline) below. |
-| `CLAUDETTE_MODEL` | `qwen3.5:4b` (Auto preset) | Brain model override. See [Recommended brain](#recommended-brain-measured-2026-07-11) below for the measured per-GPU picks. |
+| `CLAUDETTE_MODEL` | `qwen3.5:4b` (Auto preset) | Brain model override. See [Recommended brain](#recommended-brain) below for how to switch. |
 | `CLAUDETTE_NUM_CTX` | `16384` | Brain context window in tokens. |
 | `CLAUDETTE_NUM_PREDICT` | `6144` | Max output tokens per request. |
 | `CLAUDETTE_COMPACT_THRESHOLD` | `num_ctx / 2` (adaptive) | Auto-compaction trigger (estimated tokens). Unset → half the active brain's `num_ctx`, clamped to `[4000, 1000000]`, so a real 16K–128K window compacts *before* it overflows. Pin an exact value like `12000` to override; the `1000000` cap is only the ceiling for enormous windows. |
@@ -36,12 +36,13 @@ These are read by the one-line install scripts, not by the binary itself:
 | `CLAUDETTE_FALLBACK_BRAIN_MODEL` | `qwen3.5:9b` (Auto preset) | Brain to fall back to on stuck signals. |
 | `CLAUDETTE_WORKSPACE` | unset | Extra read roots outside `$HOME`, colon-separated on Unix, semicolon-separated on Windows. Example: `D:\dev\claudette` for developing Claudette itself. Reads under `$HOME` and under a `$HOME`-rooted CWD are always allowed regardless. |
 
-### Recommended brain (measured 2026-07-11)
+### Recommended brain
 
-The shipping default stays `qwen3.5:4b` — it runs anywhere (8 GB GPU or plain CPU)
-and scored 45/50 (90%) on the 50-task battery. On a **16 GB GPU with LM Studio**, the
-measured best is the byteshape MTP quant of qwen3.6-35b (50/50 on the same battery,
-~70–76 tok/s, fully VRAM-resident):
+Which model to run — the measured per-GPU tier table, scores, load commands, and the
+CPU-only path — lives on one canonical page:
+[`hardware.md`](hardware.md#which-model-for-which-gpu-measured). The shipping default
+is `qwen3.5:4b` (runs anywhere); on a **16 GB GPU with LM Studio** the measured best
+is the byteshape MTP quant of qwen3.6-35b. Switching to it is three env vars:
 
 ```bash
 export CLAUDETTE_OPENAI_COMPAT=1
@@ -50,8 +51,7 @@ export CLAUDETTE_MODEL=byteshape/qwen3.6-35b-a3b-mtp
 ```
 
 Rollback if it misbehaves: `CLAUDETTE_MODEL=qwen3.6-35b-a3b@q3_k_xl` (the previous
-16 GB default — 47/50, known-good). Load commands, per-tier table, and
-choosing-a-model guidance: [`hardware.md`](hardware.md#which-model-for-which-gpu-measured).
+16 GB default, known-good).
 
 ### Backend quirks: LM Studio variant suffix
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -105,36 +105,42 @@ OLLAMA_KV_CACHE_TYPE=q8_0     # quantised KV cache
 
 ## No GPU? CPU-only mode
 
-You don't need a discrete GPU to run Claudette. Ollama happily runs the smaller Qwen models on plain CPU — at lower throughput, but enough to be useful for short-turn assistant work (notes, calendar, weather, brief Q&A). The larger MoE models are not realistic on CPU; everything else is.
+You don't need a discrete GPU to run Claudette. Ollama happily runs the default brain on plain CPU — at lower throughput, but enough to be useful for assistant work (notes, calendar, weather, brief Q&A) and short coding turns. The larger MoE models are not realistic on CPU; everything else is.
 
-What to expect:
+One command, same default the installer suggests:
 
-| Hardware | Brain that fits | Realistic throughput |
-|----------|-----------------|----------------------|
-| MacBook Air M1/M2 (8 GB unified) | `qwen2.5:3b` (~2 GB) | ~12–18 t/s — perfectly conversational |
-| Intel laptop with 16 GB RAM, no GPU | `qwen2.5:1.5b` or `qwen2.5:3b` | ~5–10 t/s — usable, not snappy |
-| Raspberry Pi 5 (8 GB) | `qwen2.5:0.5b` or `1.5b` | ~3–6 t/s — best for the Telegram-bot use case |
-| Old desktop, 8 GB RAM, no GPU | `qwen2.5:0.5b` | ~4–8 t/s — works for short prompts |
+```sh
+ollama pull qwen3.5:4b     # ~3.4 GB
+```
 
-Pick a smaller brain and pin it. From inside Claudette:
+`qwen3.5:4b` scores **45/50 (90%) + K 8/8** on the battery. That score was measured on the GPU rig above — the model gives the same answers on CPU, just slower. We have **not** measured CPU tok/s on the battery yet, so the table below gives honest qualitative expectations, not numbers; a CPU-only benchmark report is one of the most useful contributions you can make.
+
+| Hardware | Brain that fits | Expectation (unmeasured) |
+|----------|-----------------|--------------------------|
+| MacBook Air M1/M2 (8 GB unified) | `qwen3.5:4b` | conversational — fine as a daily assistant |
+| Intel laptop with 16 GB RAM, no GPU | `qwen3.5:4b` | usable, not snappy |
+| Raspberry Pi 5 (8 GB) | `qwen2.5:1.5b` | short prompts / Telegram-bot duty |
+| Old desktop, 8 GB RAM, no GPU | `qwen2.5:0.5b`–`1.5b` | short prompts only |
+
+If you drop below the 4b, pin the smaller brain from inside Claudette:
 
 ```
-/brain qwen2.5:3b
+/brain qwen2.5:1.5b
 ```
 
 …or set it permanently in `~/.claudette/.env`:
 
 ```
-CLAUDETTE_MODEL=qwen2.5:3b
+CLAUDETTE_MODEL=qwen2.5:1.5b
 ```
 
-Pull the model once with `ollama pull qwen2.5:3b` (or whichever size matches your machine). Ollama auto-detects no-GPU and uses CPU; no configuration required on its side.
+Pull the model once with `ollama pull <model>`. Ollama auto-detects no-GPU and uses CPU; no configuration required on its side.
 
 **Trade-offs you should know:**
 
 - The 0.5b and 1.5b brains will hallucinate tool-call shapes more often than the 4b. The auto-fix loops catch most of it but you'll occasionally see retries in the TUI's Tools tab.
 - `--forge` mode is realistic on CPU only with a small brain and a lot of patience — the autonomous plan→code→verify→fix loop runs many turns. Prefer it on a GPU box.
-- First-token latency is the noticeable cost — model load time. Keep the same brain hot between turns; the 4-5 second warmup is per-cold-start, not per-turn.
+- First-token latency is the noticeable cost — model load time. Keep the same brain hot between turns; the load-time warmup is per-cold-start, not per-turn. The REPL prints a one-time heads-up on the first request of a session so a cold load never reads as a silent hang.
 
 If your machine is too small even for the 0.5b brain, Claudette is the wrong tool — at that point you want a hosted service (ChatGPT, Claude.ai). The whole *point* of Claudette is local inference; there is no cloud fallback.
 

--- a/docs/power-user.md
+++ b/docs/power-user.md
@@ -26,12 +26,14 @@ export CLAUDETTE_SKIP_LM_STUDIO_PROBE=1
 
 ## Pinning a brain (no preset gymnastics)
 
+Scores, speeds, and the full per-GPU tier table live on the canonical model page —
+[`hardware.md`](hardware.md#which-model-for-which-gpu-measured). The pinning mechanics:
+
 ```bash
-# Recommended on a 16 GB GPU (LM Studio backend) — 50/50 on the battery, ~70–76 tok/s,
-# fully VRAM-resident (measured 2026-07-11, see docs/hardware.md for the load command):
+# Recommended on a 16 GB GPU (LM Studio backend) — the measured champion:
 export CLAUDETTE_MODEL=byteshape/qwen3.6-35b-a3b-mtp
 
-# Known-good rollback (previous 16 GB default — 47/50, 33.8 tok/s):
+# Known-good rollback (previous 16 GB default):
 # export CLAUDETTE_MODEL=qwen3.6-35b-a3b@q3_k_xl
 
 # Or on 8 GB VRAM (Ollama backend):

--- a/install.ps1
+++ b/install.ps1
@@ -123,7 +123,7 @@ foreach ($p in ($userPath -split ';')) {
 }
 
 if ($onPath) {
-    Info 'next: claudette --doctor'
+    Info 'next: claudette --setup'
 } else {
     Write-Host ''
     Warn "$InstallDir is not on your User PATH."
@@ -131,5 +131,5 @@ if ($onPath) {
     Write-Host ''
     Write-Host "    [System.Environment]::SetEnvironmentVariable('Path', '$InstallDir;' + [System.Environment]::GetEnvironmentVariable('Path','User'), 'User')"
     Write-Host ''
-    Write-Host '  Then run: claudette --doctor'
+    Write-Host '  Then run: claudette --setup'
 }

--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ info "installed ${TAG} (${FLAVOR}) → ${INSTALL_DIR}/claudette"
 
 case ":$PATH:" in
   *:"$INSTALL_DIR":*)
-    info "next: claudette --doctor"
+    info "next: claudette --setup"
     ;;
   *)
     if [ -z "${CLAUDETTE_NO_MODIFY_PATH:-}" ]; then
@@ -126,7 +126,7 @@ case ":$PATH:" in
       warn "${INSTALL_DIR} is not on your PATH."
       printf '  Add this to your shell profile (~/.bashrc, ~/.zshrc, ~/.profile):\n\n'
       printf '    export PATH="%s:$PATH"\n\n' "$INSTALL_DIR"
-      printf '  Then run: claudette --doctor\n'
+      printf '  Then run: claudette --setup\n'
     fi
     ;;
 esac


### PR DESCRIPTION
Implements onboarding-plan Phase 2 (2.1 + 2.2 + 2.4) as one PR. Phase 1 landed in #192; 2.3 (first-success.md) was pulled forward there.

## 2.1 `claudette --setup` — interactive first-run wizard
- New `crates/claudette/src/setup.rs`: backend detect → GPU VRAM → recommended-brain pull offer (`ollama pull` interactive; LM Studio gets the load hint + hardware.md pointer) → optional integrations pointers (lean build prints the full-flavor install one-liner) → closing `doctor::run()` pass → suggested first prompt. Exit code mirrors `--doctor`.
- Reuses the existing probes only (`firstrun::classify_backend`, `hw::resolve_vram_gb`/`recommend_brain`, doctor's hints); `firstrun::confirm_default_yes` promoted to `pub(crate)` and shared.
- Fail-closed like the first-run remediation: stdin+stderr must be TTYs, refused under `--offline` (pulling a model is egress). Dispatched **before** `probe_ollama` so it works against a dead backend.
- `--setup` added to HELP_TEXT + the `help_text_mentions_every_flag` list; both installers' two "next:" lines now say `claudette --setup`.

## 2.2 what's-next nudge after the first successful turn
- Sentinel `~/.claudette/.onboarded` — created **before** printing, so the 4-line menu (coding task · `/help` · `--forge` · Telegram/assistant → first-success.md#assistant) can never fire twice; unwritable home = never prints (fail-closed).
- Core is `(home: &Path) -> Option<String>` tested via `with_temp_home`; REPL-only call site in `run/repl.rs`'s Ok-arm + a TTY gate inside the fn keep one-shot/piped/forge/TUI output byte-identical.

## 2.4 cold-start message + one canonical model page
- Once-per-process (`std::sync::Once`) heads-up at the single `ApiClient::stream` choke point: "first request — the backend may need to load the model… 10–60s is normal". Printed via a new `StatusController::print_note` that erases the spinner line first and is a no-op when the indicator is disabled → every non-REPL surface unchanged.
- `docs/hardware.md` is now the single canonical model page: No-GPU section leads with `qwen3.5:4b` + one command and marks CPU tok/s **unmeasured** (no invented numbers); `configuration.md` and `power-user.md` drop their duplicated measured-numbers narrative and link to it.

## No new env vars
`every_env_var_is_documented` and the safety-override guard stay untouched.

## Test plan
- `cargo fmt --all` clean · `cargo clippy --all-targets --no-deps -- -D warnings` clean · `cargo test -p claudette --lib --bins`: **1045 + 26 pass** (6 pre-existing ignores).
- New tests: setup TTY-refusal; nudge fires-once/sentinel-respect/menu-content/piped-quiet; `print_note` disabled no-op; `--setup` parse + help coverage.
- Smoke: `claudette --setup </dev/null` prints the refusal and exits 1 (proving dispatch precedes the backend probe); `--help` shows the new block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)