### PR TITLE
docs: onboarding Phase 3 — docs index, day-one troubleshooting, VS Code row, benchmark form

### DIFF
--- a/.github/ISSUE_TEMPLATE/model-benchmark.yml
+++ b/.github/ISSUE_TEMPLATE/model-benchmark.yml
@@ -1,0 +1,99 @@
+name: Model benchmark result
+description: Report a local model's score on the Claudette battery — the most useful contribution that needs no Rust
+title: "[bench] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for benching a model! Results here feed the README's
+        "Which model should I run?" table and `--doctor`'s recommendation,
+        so other people get a better default for their GPU.
+
+        Run the battery with `run_model_eval.sh` — the harness and method are
+        documented in
+        [MODEL-COMPARISON.md](https://github.com/mrdushidush/claudette/blob/main/runs/eval-2026-05-29/battery/MODEL-COMPARISON.md).
+        Partial results are welcome: fill in what you measured and leave the
+        rest blank. Please don't estimate numbers you didn't run.
+
+  - type: input
+    id: model
+    attributes:
+      label: Model + quant
+      description: The exact model id, including the quant and its publisher.
+      placeholder: byteshape/qwen3.6-35b-a3b-mtp (3.06 bpw, 13.6 GB)
+    validations:
+      required: true
+
+  - type: input
+    id: backend
+    attributes:
+      label: Backend + runtime version
+      description: LM Studio or Ollama, plus the runtime/engine version. The runtime can flip template health on its own, so the exact version matters.
+      placeholder: LM Studio 0.4.19 (runtime cuda12-avx2 2.24.0)
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: GPU + VRAM
+      description: Say if the model spilled to RAM rather than staying VRAM-resident — it dominates speed.
+      placeholder: RTX 5060 Ti 16 GB — fully resident, no spill
+    validations:
+      required: true
+
+  - type: input
+    id: battery
+    attributes:
+      label: Battery score (core 50)
+      description: The frozen core-50 score, as "N/50". Include the context window you ran at.
+      placeholder: 50/50 @ 24k ctx
+    validations:
+      required: true
+
+  - type: input
+    id: k_score
+    attributes:
+      label: K score (new-language section, 8 tasks)
+      description: Scored separately from the core 50. Leave blank if you didn't run it.
+      placeholder: 8/8
+
+  - type: input
+    id: speed
+    attributes:
+      label: Generation speed (tok/s)
+      description: Roughly, at your run's context. Leave blank if you didn't measure it.
+      placeholder: ~70-76 tok/s
+
+  - type: textarea
+    id: load_command
+    attributes:
+      label: Load command
+      description: The exact command you loaded the model with — flags included. This is what lets someone reproduce your numbers.
+      render: shell
+      placeholder: |
+        lms load "byteshape/qwen3.6-35b-a3b-mtp" -c 65536 --parallel 1 \
+            --speculative-draft-mtp --speculative-draft-max-tokens 2 -y
+    validations:
+      required: true
+
+  - type: input
+    id: claudette_version
+    attributes:
+      label: Claudette version
+      description: Output of `claudette --version`.
+      placeholder: claudette 0.16.0
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes — where it failed, and anything surprising
+      description: Which task types it lost points on, spirals, template or tool-call weirdness, thermals. The failure shape is usually more useful than the score.
+
+  - type: checkboxes
+    id: honesty
+    attributes:
+      label: Before you submit
+      options:
+        - label: These numbers are from a run I actually did, not an estimate.
+          required: true

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Prefer not to pipe curl into a shell? Grab a [prebuilt release](https://github.c
 | **One-shot** | `claudette "..."` | Print a reply and exit; pipe-friendly |
 | **TUI** _(experimental)_ | `claudette --tui` | Demo-only fullscreen UI, 5 tabs; known rendering rough edges — the REPL is the daily driver |
 | **Telegram** | `claudette --telegram` | Voice-capable chat from your phone |
+| **VS Code** | [`editor/vscode/`](editor/vscode/README.md) | Send a selection or the open file to Claudette without leaving the editor |
 
 - **80+ tools across 20 opt-in groups.** The model turns a group on (`enable_tools("git")`) only when it needs it, so the base schema stays ~200 tokens however many tools exist. Point Claudette at a repo and the coding core - files, search, tests - is pre-enabled.
 - **Forge - an autonomous code pipeline.** `claudette --forge "<task>"` runs Planner → Coder → Verifier → fix-loop → Submitter. The Verifier actually builds and runs the tests each round (`cargo`, `go`, `pytest`, `npm`), so a diff that doesn't compile or breaks a test can't pass - and no PR opens until you approve the plan and the full diff. → [docs/forge.md](docs/forge.md)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ iwr -useb https://raw.githubusercontent.com/mrdushidush/claudette/main/install.p
 # 2. Pull the default local brain (3.4 GB, one-time — install Ollama from ollama.com first)
 ollama pull qwen3.5:4b
 
-# 3. Check the setup: green rows = ready (it also names the best model for YOUR GPU)
-claudette --doctor
+# 3. Guided setup: detects your GPU, offers the right brain, ends in a green check
+claudette --setup
 
 # 4. Talk to it
 claudette "hello — what can you do?"
@@ -119,6 +119,8 @@ Runs on 8 GB VRAM or plain CPU; 16 GB for the 35B brain. Footprint details → [
 ---
 
 ## Docs
+
+**New here?** [quickstart.md](docs/quickstart.md) → [first-success.md](docs/first-success.md) → then [forge.md](docs/forge.md) (autonomous coding) or [google_setup.md](docs/google_setup.md) + Telegram (private assistant). Full index: [docs/README.md](docs/README.md).
 
 - [docs/first-success.md](docs/first-success.md) - **start here:** copy-paste recipes to a first real win (coding, air-gap, assistant)
 - [docs/show-me.md](docs/show-me.md) - plain-English example prompts

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -47,6 +47,15 @@ const TAB_COUNT: u8 = 5;
 const PAGE_LINES: u16 = 8;
 /// Cursor blink interval.
 const BLINK_MS: u64 = 400;
+
+/// Shown in the input row the moment the TUI opens, so the experimental
+/// status is visible where the user actually is. It rides `paste_notice`
+/// rather than a pre-launch `eprintln!` because the alternate screen
+/// swallows anything printed before `run_tui`; it clears on the first
+/// keypress like any other notice.
+const TUI_EXPERIMENTAL_NOTICE: &str =
+    "⚠ the TUI is experimental (demo-only) — the REPL is the daily driver";
+
 /// How often to re-scan the notes directory.
 const NOTES_CACHE_SECS: u64 = 2;
 
@@ -726,7 +735,10 @@ fn run_loop(
     tui_rx: &Receiver<TuiEvent>,
     user_tx: &Sender<UserInput>,
 ) -> Result<()> {
-    let mut app = App::default();
+    let mut app = App {
+        paste_notice: Some(TUI_EXPERIMENTAL_NOTICE.to_string()),
+        ..App::default()
+    };
 
     loop {
         // Drain worker events.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,46 @@
+# Docs index
+
+**New here? Read in this order:**
+[install](../README.md#get-started-in-2-minutes) →
+[quickstart.md](quickstart.md) →
+[first-success.md](first-success.md) → then pick your path:
+[forge.md](forge.md) for autonomous coding, or
+[google_setup.md](google_setup.md) + Telegram for the private assistant.
+
+## Start here
+
+- [first-success.md](first-success.md) — copy-paste recipes to a first real win (coding, air-gap, assistant)
+- [quickstart.md](quickstart.md) — zero to a working agent: install, `--setup`, first flows
+- [show-me.md](show-me.md) — plain-English example prompts that work today
+
+## Reference
+
+- [usage.md](usage.md) — every CLI flag, slash command, and Telegram command
+- [configuration.md](configuration.md) — every env var and the token lookup order
+- [hardware.md](hardware.md) — the canonical model page: which brain for your GPU, VRAM/RAM/disk, CPU-only mode
+- [troubleshooting.md](troubleshooting.md) — symptom-keyed fixes, day-one failures first
+- [power-user.md](power-user.md) — cheat-sheet view: LM Studio recipe, brain pinning, forge knobs
+
+## How it works
+
+- [architecture.md](architecture.md) — module layout, tool-group contract, storage layout
+- [forge.md](forge.md) — the Planner → Coder → Verifier pipeline, brownfield missions, `models.toml`
+- [comparison.md](comparison.md) — honest side-by-side vs. opencode / Aider / OpenHands / Cline / Continue
+
+## Setup & deployment
+
+- [google_setup.md](google_setup.md) — Google OAuth click-through for Calendar + Gmail (needs the full flavor)
+- [deploy.md](deploy.md) — Pi / VPS / home-server via docker-compose
+- [../editor/vscode/README.md](../editor/vscode/README.md) — the VS Code extension
+
+## Project-level
+
+- [../PRIVACY.md](../PRIVACY.md) — every place a byte could leave, and the condition for each
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — how to contribute; benching a model needs no Rust
+- [../SECURITY.md](../SECURITY.md) — private advisory flow for security issues
+- [../CHANGELOG.md](../CHANGELOG.md) — what shipped in each release
+
+## Historical
+
+- [decisions.md](decisions.md) — **historical** planning-era ADs; `architecture.md` is the source of truth
+- [archive/](archive/README.md) — superseded docs kept for provenance

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Zero to a working agent in **under five minutes**. Work the checklist top to
 bottom — every step says what success looks like, and where to look if you
 don't see it:
 
-> ☐ installed → ☐ `--doctor` all green → ☐ first conversation → ☐ first
+> ☐ installed → ☐ `--setup` all green → ☐ first conversation → ☐ first
 > coding one-shot → ☐ Forge on a repo → ☐ *(optional)* Telegram
 
 ## ☐ 1. Install (2 min)
@@ -30,7 +30,7 @@ ollama pull qwen3.5:4b     # ~3.4 GB on disk, ~3.4 GB VRAM — runs on plain CPU
 ```
 
 **You should see:** the installer end with `installed vX.Y.Z (lean) → …` and a
-`next: claudette --doctor` hint; `ollama pull` reach 100%.
+`next: claudette --setup` hint; `ollama pull` reach 100%.
 **If `claudette` isn't found in a new terminal:**
 [troubleshooting → command not found](troubleshooting.md#claudette-command-not-found-after-install).
 
@@ -48,7 +48,19 @@ Studio or a bigger model? See [configuration.md](configuration.md) and
 > `--telegram`, `--auth-google`, and `--briefing` flows below all need it; the
 > lean build prints those exact install commands if you try one.
 
-## ☐ 2. `--doctor` all green (30 sec)
+## ☐ 2. Guided setup → all green (1 min)
+
+```bash
+claudette --setup
+```
+
+`--setup` is the one-time wizard: it detects your backend (Ollama / LM Studio)
+and GPU VRAM, offers to pull the brain that fits your card, points at the
+integrations setup, and finishes by running the full `--doctor` report. It
+needs a real terminal, and it refuses under `--offline`.
+
+Already set up, or just want the check? `claudette --doctor` runs the report on
+its own, any time something misbehaves:
 
 ```bash
 claudette --doctor

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,56 @@ the resolved brain model, toolchains, and (if `--offline`) the egress guard.
 
 ---
 
+## Day one: the five things that usually bite first
+
+New install, something already wrong? It is almost certainly one of these.
+Each links to the full entry below.
+
+| Symptom | Likely cause | Jump to |
+|---------|--------------|---------|
+| `claudette: command not found` right after install | the install dir isn't on your `PATH` | [command not found](#claudette-command-not-found-after-install) |
+| Everything errors: "connection refused" / backend unreachable | Ollama (or LM Studio) isn't running | [backend not running](#the-backend-isnt-running) |
+| The very first prompt hangs 1–3 minutes, then answers | cold model load — normal, not a hang | [first-prompt hang](#the-first-prompt-hangs-for-13-minutes-then-answers) |
+| `/recall` warns about `/v1/embeddings HTTP 501` | no embedding model loaded; recall is optional | [recall 501](#recall-returns-v1embeddings-http-501-or-400) |
+| `--telegram` / `--auth-google` / `--briefing` just print install commands | you have the lean build; those need the full flavor | [lean build](#telegram--google--briefing-print-an-install-command-instead-of-running) |
+
+---
+
+## The backend isn't running
+
+**Cause:** Claudette drives a model server you run yourself. If Ollama or LM
+Studio isn't up, every turn fails at the first request — there is no cloud
+fallback to quietly paper over it.
+
+**Fixes:**
+- **Ollama:** start it with `ollama serve` (it also starts on demand on most
+  desktop installs), then confirm the brain is present with `ollama list`.
+- **LM Studio:** open **Developer → Local Server**, hit **Start**, and load a
+  model. Claudette needs `OLLAMA_HOST=http://localhost:1234` and
+  `CLAUDETTE_OPENAI_COMPAT=1` to talk to it — see
+  [configuration.md](configuration.md).
+- Either way, `claudette --doctor` names which backend it probed and at what
+  URL; the red row carries a copy-paste `↳ fix:` command.
+
+---
+
+## Telegram / Google / briefing print an install command instead of running
+
+**Cause:** you're on the **lean** build. The cloud integrations (Telegram,
+Gmail, Google Calendar, voice, morning briefing) reach third-party services, so
+they are deliberately not compiled into the default coding-only binary. Nothing
+is broken — the flag is telling you what to install.
+
+**Fixes:**
+- Grab the prebuilt **full** flavor:
+  `CLAUDETTE_FLAVOR=full curl -fsSL …/install.sh | sh`
+  (Windows: `$env:CLAUDETTE_FLAVOR='full'; iwr -useb …/install.ps1 | iex`).
+- With a Rust toolchain: `cargo install claudette --features integrations`.
+- Staying lean is a valid choice — the coding agent and the air-gap are all in
+  the default build.
+
+---
+
 ## The first prompt hangs for 1–3 minutes, then answers
 
 **Cause:** the backend evicted the model (idle TTL) or never loaded it, so


### PR DESCRIPTION
Phase 3 of the onboarding plan. Four bounded cards, co-dev mode (Claude specs → Claudette implements → Claude reviews). Docs-heavy; one small code touch.

### What is in it

- **Docs index** (`docs/README.md`, new) — every doc with a one-liner, opening with the ordered new-user path (install → quickstart → first-success → forge *or* assistant). The path is mirrored in the README's Docs section. All 25 links verified to resolve.
- **Day-one troubleshooting** — a table at the top of `troubleshooting.md` indexing the five likeliest first-install failures, each linking to its full entry. Two of the five had no entry to link to, so this adds them: *backend not running* and *lean build prints an install command*. Existing sections untouched; all anchors verified against real headers.
- **TUI caveat at launch** — the README has called the TUI experimental for a while, but nothing said so inside the TUI. The notice now shows in the input row on open and clears on the first keypress.
- **VS Code row** in the README's what-it-does table — the extension shipped but was reachable only from the docs list.
- **Model-benchmark issue form** (`.github/ISSUE_TEMPLATE/model-benchmark.yml`) — the README calls benching the most useful no-Rust contribution, but there was no structured way to send one in.

### Phase 2 carry-overs folded in

The installers have printed `next: claudette --setup` since #196, but the README's step 3 and the quickstart still said `--doctor`. Both now say `--setup`, and the quickstart's step 2 documents the wizard with `--doctor` kept as the standalone re-check. A stale line claiming the installer prints a `--doctor` hint is also corrected.

### Notes for review

- **Why `paste_notice` and not an `eprintln!` before `run_tui`:** the alternate screen swallows anything printed before it, so a pre-launch line would only become visible *after* the user quits. Riding the existing transient input-row notice puts it where the user actually is.
- **No `labels:` on the issue form** — no fitting label exists yet. A `model-benchmark` label would help triage; happy to add it and wire it in.
- The TUI notice is verified by its render path (`render_input` reads `paste_notice`), not by driving the TUI — that needs a TTY.

### Gate

`cargo fmt --all --check` clean · `cargo clippy --all-targets --no-deps -- -D warnings` clean · **1080 tests, 0 failures**. No new env vars, so the `every_env_var_is_documented` guard stays quiet.