### PR TITLE
fix(tests): stop write_file code tests leaking fixtures into the repo

### DIFF
--- a/crates/claudette/src/tools/file_ops.rs
+++ b/crates/claudette/src/tools/file_ops.rs
@@ -412,27 +412,44 @@ mod tests {
         // The generate_code coder sidecar was retired — write_file now writes
         // source files itself, no size gate and no workspace requirement.
         // Use a `.sh` file so no external interpreter is involved.
-        let input =
-            json!({ "path": "claudette-writecode-test.sh", "content": "echo hi\n" }).to_string();
-        let target = files_dir().join("claudette-writecode-test.sh");
-        let _ = fs::remove_file(&target);
-        let out = run_write_file(&input);
-        let _ = fs::remove_file(&target);
-        let out = out.expect("code file should be written directly");
-        assert!(out.contains("\"ok\":true"), "got: {out}");
+        with_workspace_env(None, || {
+            let input = json!({ "path": "claudette-writecode-test.sh", "content": "echo hi\n" })
+                .to_string();
+            let target = files_dir().join("claudette-writecode-test.sh");
+            let _ = fs::remove_file(&target);
+            let out = run_write_file(&input);
+            let landed = target.exists();
+            let _ = fs::remove_file(&target);
+            let out = out.expect("code file should be written directly");
+            assert!(out.contains("\"ok\":true"), "got: {out}");
+            assert!(
+                landed,
+                "file must land in files_dir, got nothing at {}",
+                target.display()
+            );
+        });
     }
 
     #[test]
     fn write_file_accepts_large_code_directly() {
         // A large source file is no longer refused/routed anywhere — it writes.
-        let body = "x = 1\n".repeat(200);
-        let input = json!({ "path": "claudette-writecode-big.sh", "content": body }).to_string();
-        let target = files_dir().join("claudette-writecode-big.sh");
-        let _ = fs::remove_file(&target);
-        let out = run_write_file(&input);
-        let _ = fs::remove_file(&target);
-        let out = out.expect("large code file should be written directly");
-        assert!(out.contains("\"ok\":true"), "got: {out}");
+        with_workspace_env(None, || {
+            let body = "x = 1\n".repeat(200);
+            let input =
+                json!({ "path": "claudette-writecode-big.sh", "content": body }).to_string();
+            let target = files_dir().join("claudette-writecode-big.sh");
+            let _ = fs::remove_file(&target);
+            let out = run_write_file(&input);
+            let landed = target.exists();
+            let _ = fs::remove_file(&target);
+            let out = out.expect("large code file should be written directly");
+            assert!(out.contains("\"ok\":true"), "got: {out}");
+            assert!(
+                landed,
+                "file must land in files_dir, got nothing at {}",
+                target.display()
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
A plain `cargo test` could leave two untracked files behind in the repo:

```
crates/claudette/claudette-writecode-test.sh   ("echo hi")
crates/claudette/claudette-writecode-big.sh    ("x = 1" x200)
```

They nearly rode into #197 as junk, which is what prompted the dig.

## Cause

`write_file_accepts_code_directly` and `write_file_accepts_large_code_directly`
compute their cleanup target from `files_dir()`, which reads
`CLAUDETTE_WORKSPACE` — but unlike their sibling allow-tests they took no env
lock and pinned nothing.

When `CLAUDETTE_WORKSPACE` is set, `run_write_file` resolves the bare relative
path against the workspace while the cleanup target still points at the
sandbox `files_dir()`. Cleanup unlinks a path that was never written, and the
real file stays behind in the crate dir (cargo runs tests with the CWD set
there).

**This is not a flake.** It reproduces deterministically whenever
`CLAUDETTE_WORKSPACE` is set — which is exactly how Claudette runs in co-dev,
so she leaks these into her own working tree every time she runs the gate. It
looked intermittent only because a bare `cargo test` with the var unset never
triggers it.

## Fix

Wrap both tests in the existing `with_workspace_env(None, ..)` helper the
sibling allow-tests already use — it pins the var under the global env lock for
the whole test — and assert the file actually landed in `files_dir()`, so a
future regression fails loudly instead of leaking silently.

Tests only; no production code changed.

## Verification

Same command, before and after:

| | `CLAUDETTE_WORKSPACE=<repo> cargo test --lib write_file_accepts` |
|---|---|
| main | **leaks both files** |
| this branch | **clean** |

Full suite run under the leaking condition: **1080 passed, 0 failed, 0 leaked**.
`cargo fmt --all --check` and `clippy --all-targets -- -D warnings` clean.

## Note on the old branch

This supersedes the dormant local `fix/write-file-test-env-leak` branch, which
should be deleted rather than PRd: its content already merged as #59, and it
forked before v0.10.0 — opening it now would revert ~17k lines (`setup.rs`,
`context_evict.rs`, the Phase 1/2 onboarding work) and resurrect tests that no
longer exist. Its extra `with_workspace_env` call sites all target tests that
were removed when the `generate_code` sidecar was retired. The two tests in
this PR are *newer* than that branch, which is why they were never covered.