### PR TITLE
fix(runtime): recover empty reasoning-only turns by retrying at 2x num_predict

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -748,6 +748,12 @@ impl OllamaApiClient {
             tools
         };
         let history_budget = self.history_budget_chars_for_tools(request, &tools);
+        // A per-request override (the empty-turn retry doubles it) wins over the
+        // client's configured ceiling for the body's `max_tokens`/`num_predict`.
+        // The history budget above is deliberately left on the base `num_predict`
+        // so the retry sends the exact same context — only the generation ceiling
+        // rises, giving a reasoning-heavy turn room to finish and emit an answer.
+        let max_output = request.max_output_tokens.unwrap_or(self.num_predict);
         if self.openai_compat {
             // OpenAI Chat Completions shape. `temperature` and `max_tokens`
             // are top-level (not nested in `options`). `num_ctx` has no
@@ -775,7 +781,7 @@ impl OllamaApiClient {
                 "stream": true,
                 "stream_options": { "include_usage": true },
                 "temperature": 0.0,
-                "max_tokens": self.num_predict,
+                "max_tokens": max_output,
             });
         }
         let messages = build_messages(request, history_budget);
@@ -793,7 +799,7 @@ impl OllamaApiClient {
             "options": {
                 "temperature": 0.0,
                 "num_ctx": self.num_ctx,
-                "num_predict": self.num_predict
+                "num_predict": max_output
             }
         })
     }
@@ -2133,6 +2139,7 @@ mod tests {
         let request = ApiRequest {
             messages: vec![user_text("this is the only thing the user said")].into(),
             system_prompt: vec!["you are an assistant".to_string()],
+            max_output_tokens: None,
         };
         let result = build_messages(&request, 0);
         assert_eq!(result.len(), 2, "expected system + newest, got {result:?}");
@@ -2151,6 +2158,7 @@ mod tests {
             ]
             .into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
         // Budget large enough only for the last message (~6 chars).
         let result = build_messages(&request, 20);
@@ -2172,10 +2180,12 @@ mod tests {
         let small_sys = ApiRequest {
             messages: Vec::new().into(),
             system_prompt: vec!["short".to_string()],
+            max_output_tokens: None,
         };
         let big_sys = ApiRequest {
             messages: Vec::new().into(),
             system_prompt: vec!["x".repeat(500)],
+            max_output_tokens: None,
         };
         let small_budget = client.history_budget_chars(&small_sys);
         let big_budget = client.history_budget_chars(&big_sys);
@@ -2635,6 +2645,7 @@ mod tests {
         let request = ApiRequest {
             messages: Vec::new().into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
         // Use a large enough num_ctx that even the full 27-tool schema
         // (~12 K chars) doesn't saturate the budget to zero. With 4096 the
@@ -2725,6 +2736,7 @@ mod tests {
         let req = ApiRequest {
             messages: vec![user_text("hi")].into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
         let body = client.build_chat_body(&req);
         // Compat path now streams (SSE) so the flagship model shows tokens as
@@ -2745,6 +2757,37 @@ mod tests {
     }
 
     #[test]
+    fn build_chat_body_honors_max_output_override() {
+        // Empty-turn retry path: a per-request `max_output_tokens` override wins
+        // over the client's configured `num_predict` for the body ceiling, on
+        // both the compat (`max_tokens`) and ollama (`options.num_predict`) shapes.
+        let mut compat =
+            OllamaApiClient::new("openai/gpt-oss-20b", json!([])).with_openai_compat(true);
+        compat.num_predict = 1000;
+        let base = compat.build_chat_body(&ApiRequest {
+            messages: vec![user_text("hi")].into(),
+            system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
+        });
+        assert_eq!(base["max_tokens"], json!(1000), "base uses num_predict");
+        let overridden = compat.build_chat_body(&ApiRequest {
+            messages: vec![user_text("hi")].into(),
+            system_prompt: vec!["sys".to_string()],
+            max_output_tokens: Some(2000),
+        });
+        assert_eq!(overridden["max_tokens"], json!(2000), "override wins");
+
+        let mut ollama = OllamaApiClient::new("qwen3.5:4b", json!([])).with_openai_compat(false);
+        ollama.num_predict = 1000;
+        let ollama_override = ollama.build_chat_body(&ApiRequest {
+            messages: vec![user_text("hi")].into(),
+            system_prompt: vec!["sys".to_string()],
+            max_output_tokens: Some(2000),
+        });
+        assert_eq!(ollama_override["options"]["num_predict"], json!(2000));
+    }
+
+    #[test]
     fn build_chat_body_default_stays_ollama_shape() {
         // Pin compat off — ambient CLAUDETTE_OPENAI_COMPAT must not flip the
         // ollama body shape this test asserts.
@@ -2752,6 +2795,7 @@ mod tests {
         let req = ApiRequest {
             messages: vec![user_text("hi")].into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
         let body = client.build_chat_body(&req);
         assert_eq!(body["stream"], json!(true));
@@ -3170,6 +3214,7 @@ mod tests {
             ]
             .into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
         let body = client.build_chat_body(&req);
         let msgs = body["messages"].as_array().expect("messages array");
@@ -3224,6 +3269,7 @@ mod tests {
         let request = ApiRequest {
             messages: Vec::new().into(),
             system_prompt: vec!["sys".to_string()],
+            max_output_tokens: None,
         };
 
         let before = client.history_budget_chars(&request);

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -104,6 +104,11 @@ fn build_turn_system_prompt(base: &[String], has_images: bool) -> Vec<String> {
 pub struct ApiRequest<'a> {
     pub system_prompt: Vec<String>,
     pub messages: Cow<'a, [ConversationMessage]>,
+    /// Per-request override for the completion token ceiling (`max_tokens` /
+    /// `num_predict`). `None` uses the client's configured `num_predict`. Set
+    /// on the empty-turn retry to grant a reasoning-heavy turn more room to
+    /// finish thinking and still emit an answer — see the retry in `run_turn`.
+    pub max_output_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -432,15 +437,37 @@ where
                     system_prompt.push(iteration_budget_nudge(remaining));
                 }
             }
+            let num_ctx = crate::api::current_num_ctx() as usize;
+            let evict_trigger = crate::context_evict::trigger_percent();
             let request = ApiRequest {
                 system_prompt,
-                messages: apply_context_eviction(
-                    &self.session.messages,
-                    crate::api::current_num_ctx() as usize,
-                    crate::context_evict::trigger_percent(),
-                ),
+                messages: apply_context_eviction(&self.session.messages, num_ctx, evict_trigger),
+                max_output_tokens: None,
             };
-            let events = self.api_client.stream(&request)?;
+            let mut events = self.api_client.stream(&request)?;
+            // Empty-turn recovery ("empty-stream flake"): this brain streams its
+            // chain-of-thought in a separate `reasoning_content` channel the SSE
+            // parser does not surface. When it spends the whole `num_predict`
+            // budget reasoning and never emits a `content` token, the turn carries
+            // no visible text and no tool call, and `build_assistant_message`
+            // rejects it as "produced no content", aborting the run. The overrun is
+            // deterministic per-logits but intermittent run-to-run (MTP/CUDA jitter
+            // shifts the reasoning length across the budget boundary). Retry once
+            // with double the token ceiling so the reasoning has room to finish and
+            // still emit an answer — the surgical alternative to permanently raising
+            // `num_predict`, which is reserved out of every turn's context budget.
+            if turn_produced_no_content(&events) {
+                let retry_request = ApiRequest {
+                    system_prompt: request.system_prompt.clone(),
+                    messages: apply_context_eviction(
+                        &self.session.messages,
+                        num_ctx,
+                        evict_trigger,
+                    ),
+                    max_output_tokens: Some(crate::api::current_num_predict().saturating_mul(2)),
+                };
+                events = self.api_client.stream(&retry_request)?;
+            }
             let (assistant_message, usage) = build_assistant_message(events)?;
             if let Some(usage) = usage {
                 self.usage_tracker.record(usage);
@@ -752,6 +779,7 @@ where
                 crate::api::current_num_ctx() as usize,
                 crate::context_evict::trigger_percent(),
             ),
+            max_output_tokens: None,
         };
         let events = self
             .api_client
@@ -873,6 +901,22 @@ fn parse_auto_compaction_threshold(value: Option<&str>) -> u32 {
         .and_then(|raw| raw.trim().parse::<u32>().ok())
         .filter(|threshold| *threshold > 0)
         .unwrap_or(DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD)
+}
+
+/// True when a streamed turn carried no user-visible text and no tool call —
+/// only bookkeeping events (usage / message-stop). With this brain's
+/// `reasoning_content` split that happens when it spends the entire
+/// `num_predict` budget reasoning and emits no `content`; the turn would then
+/// be rejected by [`build_assistant_message`] as "produced no content". The
+/// `run_turn` loop uses this to retry once (with a doubled token ceiling)
+/// before aborting the run — the "empty-stream flake" recovery.
+fn turn_produced_no_content(events: &[AssistantEvent]) -> bool {
+    !events.iter().any(|event| {
+        matches!(
+            event,
+            AssistantEvent::TextDelta(_) | AssistantEvent::ToolUse { .. }
+        )
+    })
 }
 
 fn build_assistant_message(
@@ -1375,6 +1419,105 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Serves a queued script of turn responses (one per `stream` call) and
+    /// records the `max_output_tokens` each request carried. Drives the
+    /// empty-stream-flake recovery tests.
+    struct QueuedApi {
+        responses: std::collections::VecDeque<Vec<AssistantEvent>>,
+        seen_output_caps: Vec<Option<u32>>,
+    }
+
+    impl QueuedApi {
+        fn new(responses: Vec<Vec<AssistantEvent>>) -> Self {
+            Self {
+                responses: responses.into(),
+                seen_output_caps: Vec::new(),
+            }
+        }
+    }
+
+    impl ApiClient for QueuedApi {
+        fn stream(
+            &mut self,
+            request: &ApiRequest<'_>,
+        ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            self.seen_output_caps.push(request.max_output_tokens);
+            self.responses
+                .pop_front()
+                .ok_or_else(|| RuntimeError::new("QueuedApi: no scripted response left"))
+        }
+    }
+
+    fn queued_runtime(api: QueuedApi) -> ConversationRuntime<QueuedApi, StaticToolExecutor> {
+        ConversationRuntime::new(
+            Session::new(),
+            api,
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::WorkspaceWrite),
+            vec!["test system prompt".to_string()],
+        )
+    }
+
+    #[test]
+    fn empty_turn_recovers_via_one_retry_with_doubled_budget() {
+        // First turn is content-less (all budget spent in the parser-ignored
+        // reasoning channel); the retry lands a real answer. The run must
+        // recover, and the retry must carry double the base num_predict.
+        let answer = vec![
+            AssistantEvent::TextDelta("The answer is 42.".to_string()),
+            AssistantEvent::MessageStop,
+        ];
+        let api = QueuedApi::new(vec![vec![AssistantEvent::MessageStop], answer]);
+        let mut runtime = queued_runtime(api);
+
+        let summary = runtime
+            .run_turn("what is the answer?", None)
+            .expect("empty turn must recover via one retry");
+
+        assert_eq!(summary.iterations, 1, "recovery is one logical iteration");
+        let last_text = summary
+            .assistant_messages
+            .last()
+            .and_then(|m| {
+                m.blocks.iter().find_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.clone()),
+                    _ => None,
+                })
+            })
+            .expect("recovered turn must carry text");
+        assert!(last_text.contains("42"));
+        let expected_retry_cap = crate::api::current_num_predict().saturating_mul(2);
+        assert_eq!(
+            runtime.api_client.seen_output_caps,
+            vec![None, Some(expected_retry_cap)],
+            "base call uncapped, retry doubles the budget",
+        );
+    }
+
+    #[test]
+    fn empty_turn_twice_aborts_with_no_content_error() {
+        // Both the base call and the single retry come back empty: no infinite
+        // retry loop — the run aborts with the honest "no content" error.
+        let api = QueuedApi::new(vec![
+            vec![AssistantEvent::MessageStop],
+            vec![AssistantEvent::MessageStop],
+        ]);
+        let mut runtime = queued_runtime(api);
+
+        let err = runtime
+            .run_turn("what is the answer?", None)
+            .expect_err("two empty turns must abort");
+        assert!(
+            err.to_string().contains("produced no content"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            runtime.api_client.seen_output_caps.len(),
+            2,
+            "exactly one retry, no more",
+        );
     }
 
     /// Api client that calls the `step` tool forever — until it sees the


### PR DESCRIPTION
## The empty-stream flake

`assistant stream produced no content` was aborting runs at a ~1-in-5-to-10 rate all through 2026-07-17 — size-independent, and an `lms unload`/`lms load` did not cure it.

**Root cause is claudette-side, not an LM Studio abort or a runtime-version issue.** The champion (`qwen3.6-35b-a3b-mtp`) streams its chain-of-thought in a separate `reasoning_content` SSE channel. `api.rs::consume_sse_lines` reads **only** `choices[0].delta.content` and ignores `reasoning_content`. When a turn spends its whole `num_predict` budget (default **6144**) reasoning and never emits a `content` token, the parser accumulates nothing → `build_assistant_message` rejects it as `"produced no content"` → the run aborts.

It's deterministic per-logits but **intermittent run-to-run**: MTP/CUDA numerical jitter shifts the reasoning length across the `num_predict` boundary, so the same task sometimes lands just under (emits an answer) and sometimes just over (empty). That is the whole "isolated re-run passed" behavior.

### Wire-level repro (deterministic)
- Hard puzzle at `max_tokens:1024` → **1023 reasoning deltas, 0 content deltas**, `finish_reason:"length"` → empty turn.
- Same puzzle at `max_tokens:6144` → 1066 reasoning tokens, then **175 content deltas**, `finish_reason:"stop"` → clean answer.
- 30-gen `curl -N` battery (temp 0.2, short outputs) → **0/30 empty**; the raw endpoint is solid, so this is not a server abort.

## The fix

When a turn comes back with no visible text **and** no tool call, `run_turn` retries it **once at 2× `num_predict`**, threaded through a new per-request `ApiRequest.max_output_tokens` override (base call `None`, retry `Some(2×)`). Identical context is resent — only the generation ceiling rises, giving a reasoning-heavy turn room to finish thinking and still emit an answer.

This is the surgical alternative to permanently raising `num_predict`, which is reserved out of every turn's context budget (the history truncator subtracts `num_predict × chars_per_token`). It composes with the existing `run_turn_with_retry` enable_tools nudge, which targets a different empty cause (model wanting a disabled tool); the inner double-budget retry fires first and cures the reasoning-overrun case before it bubbles up.

## Verification

- **Unit:** `empty_turn_recovers_via_one_retry_with_doubled_budget`, `empty_turn_twice_aborts_with_no_content_error`, `build_chat_body_honors_max_output_override`. Full lib suite **1067 pass**; `cargo fmt` + `cargo clippy -D warnings` clean.
- **End-to-end A/B against the live champion** (one-shot, `num_predict=300`, long-reasoning + one-number prompt):
  - **Control** (fix stashed): base empties → `❌ produced no content`, exit 1.
  - **Fixed**: base empties at 300 → retry fires at 600 → correct answer, exit 0. Two generations confirmed in `lms log stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
