### PR TITLE
feat(research): wire --research CLI + read-only runtime + batch driver

### DIFF
--- a/crates/claudette/src/lib.rs
+++ b/crates/claudette/src/lib.rs
@@ -105,8 +105,8 @@ pub use executor::AgentToolExecutor;
 pub use memory::{default_memory_path, try_load_memory, try_load_memory_at, MAX_MEMORY_CHARS};
 pub use prompt::{agent_system_prompt, agent_system_prompt_with_memory, forge_system_prompt};
 pub use run::{
-    default_session_path, run_agent, run_agent_repl, run_forge_mission, save_session,
-    save_session_at, try_load_session, try_load_session_at, SessionOptions,
+    default_session_path, run_agent, run_agent_repl, run_deep_research, run_forge_mission,
+    save_session, save_session_at, try_load_session, try_load_session_at, SessionOptions,
 };
 pub use tools::{agent_tools_json, workspace_startup_diagnostics};
 

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -24,8 +24,8 @@
 use std::process::ExitCode;
 
 use claudette::{
-    probe_ollama, run_agent, run_agent_repl, run_forge_mission, theme, try_load_session,
-    workspace_startup_diagnostics, SessionOptions,
+    probe_ollama, run_agent, run_agent_repl, run_deep_research, run_forge_mission, theme,
+    try_load_session, workspace_startup_diagnostics, SessionOptions,
 };
 use claudette::{ContentBlock, Session};
 // External-cloud integrations: only compiled into an `integrations` build.
@@ -85,6 +85,11 @@ struct CliArgs {
     /// VRAM → recommended-brain pull offer → integrations pointers →
     /// closing `--doctor` pass). TTY-only; refused under `--offline`.
     setup: bool,
+    /// `--research`: point claudette at a repo and run the unattended,
+    /// hard-enforced read-only review loop (batches of files per fresh
+    /// conversation, findings checkpointed to `~/.claudette/research/`).
+    /// Trailing prompt words become an optional focus hint. Forces offline.
+    research: bool,
 }
 
 /// Help text printed on `--help` / `-h`. One source of truth; the README
@@ -112,6 +117,9 @@ MODES (pick one; default is interactive REPL):
                          start one with /brownfield <repo> first. v0a runs a
                          single brain turn with file/search/git/advanced/github
                          tools pre-enabled and exits at mission_submit (auto-PR).
+    --research [FOCUS]   Unattended read-only review of the repo (CLAUDETTE_
+                         WORKSPACE or the git toplevel). Writes a findings
+                         report to ~/.claudette/research/. Forces --offline.
 
 TELEGRAM OPTIONS:
     --chat <id>          Restrict the Telegram bot to chat ID <id>.
@@ -251,6 +259,7 @@ fn main() -> ExitCode {
         forge,
         doctor,
         setup,
+        research,
     } = args;
 
     // ── Offline-mode banner ───────────────────────────────────────────
@@ -324,6 +333,25 @@ fn main() -> ExitCode {
         if !claudette::firstrun::offer_fix_interactive() {
             return ExitCode::FAILURE;
         }
+    }
+
+    // ── Deep-research mode (read-only, offline, unattended) ───────────
+    // Runs the batches phase of the review loop against the resolved repo
+    // and exits. Forces the air-gap and a hard ReadOnly permission tier;
+    // trailing prompt words are an optional focus hint.
+    if research {
+        let focus = prompt_args.join(" ");
+        return match run_deep_research(&focus) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!(
+                    "{} {}",
+                    theme::error(theme::ERR_GLYPH),
+                    theme::error(&format!("{e:#}"))
+                );
+                ExitCode::FAILURE
+            }
+        };
     }
 
     // ── Forge-mode (single-stage v0a) ─────────────────────────────────
@@ -547,6 +575,7 @@ fn parse_args(args: &[String]) -> CliArgs {
             "--forge" => out.forge = true,
             "--doctor" => out.doctor = true,
             "--setup" => out.setup = true,
+            "--research" => out.research = true,
             "--faceless" => {
                 // Persona overlay opt-out (Eva for assistant, CodeX-7 for
                 // forge Coder). Set the env var so the secretary prompt
@@ -930,6 +959,22 @@ mod tests {
             Some(v) => std::env::set_var(claudette::egress::OFFLINE_ENV, v),
             None => std::env::remove_var(claudette::egress::OFFLINE_ENV),
         }
+    }
+
+    #[test]
+    fn parse_args_research_flag() {
+        // `--research` is consumed; the trailing words remain the focus hint.
+        let a = parse_args(&[
+            "--research".into(),
+            "focus".into(),
+            "on".into(),
+            "parsers".into(),
+        ]);
+        assert!(a.research, "--research sets the research flag");
+        assert_eq!(
+            a.prompt_words,
+            vec!["focus".to_string(), "on".to_string(), "parsers".to_string()]
+        );
     }
 
     #[test]

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -50,8 +50,8 @@ pub(crate) use cli_prompter::{format_ctx_gauge, EMPTY_RESPONSE_NUDGE};
 // mission code keep resolving.
 mod runtime_build;
 pub(crate) use runtime_build::{
-    build_forge_role_runtime, build_forge_runtime, build_permission_policy, build_runtime,
-    build_runtime_streaming, build_runtime_with_brain,
+    build_forge_role_runtime, build_forge_runtime, build_permission_policy, build_research_runtime,
+    build_runtime, build_runtime_streaming, build_runtime_with_brain,
 };
 
 // Interactive agent REPL loop. Extracted to `run/repl.rs` (Wave C6);
@@ -68,8 +68,9 @@ pub(crate) use forge_run::forge_auto_approve_enabled;
 pub use forge_run::run_forge_mission;
 
 /// Deep-research mode pure core (manifest / batches / finding parser /
-/// progress stores). Driven by the CLI flag added in the follow-up PR.
+/// progress stores) plus the `--research` driver.
 mod research;
+pub use research::run_deep_research;
 
 /// Resolve the model name the runtime is currently using. Sprint 14: this
 /// now delegates to `model_config::active().brain.model`, so once a

--- a/crates/claudette/src/run/research.rs
+++ b/crates/claudette/src/run/research.rs
@@ -3,7 +3,13 @@
 //! plans 2-3-file batches, parses the reviewer's structured findings output,
 //! and persists progress/findings JSON so an interrupted run resumes exactly
 //! where it stopped.
-#![allow(dead_code)] // wired into the CLI driver in the follow-up PR (R2)
+#![allow(dead_code)] // verify/synthesize items wired in R3
+
+use std::fmt::Write as _;
+
+use crate::env_config;
+use crate::run::build_research_runtime;
+use crate::session::Session;
 
 pub(crate) const MAX_BATCH_BYTES: u64 = 48 * 1024;
 pub(crate) const MAX_FILE_BYTES: u64 = 256 * 1024;
@@ -265,6 +271,31 @@ impl Category {
             "smell" => Some(Self::Smell),
             _ => None,
         }
+    }
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::High => "HIGH",
+            Self::Medium => "MEDIUM",
+            Self::Low => "LOW",
+            Self::Info => "INFO",
+        })
+    }
+}
+
+impl std::fmt::Display for Category {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Bug => "bug",
+            Self::ErrorHandling => "error-handling",
+            Self::Security => "security",
+            Self::DeadCode => "dead-code",
+            Self::DocsDrift => "docs-drift",
+            Self::TestGap => "test-gap",
+            Self::Smell => "smell",
+        })
     }
 }
 
@@ -659,6 +690,576 @@ impl FindingsStore {
             });
         }
     }
+}
+
+/// Build the terse per-batch user prompt (SPEC §6). `files` is the batch's
+/// (rel_path, line_count) pairs; `focus` is the optional CLI focus hint
+/// (empty string when none).
+fn batch_prompt(n: usize, total: usize, files: &[(String, usize)], focus: &str) -> String {
+    let mut out = format!("Batch {n}/{total}. Files:\n");
+    for (path, lines) in files {
+        let _ = writeln!(out, "{path} ({lines} lines)");
+    }
+    if !focus.is_empty() {
+        let _ = writeln!(out, "{focus}");
+    }
+    out.push_str(
+        "Review per your briefing, then output:\n\
+         \n\
+         ### BATCH VERDICT\n\
+         <2-4 sentences: what these files do, overall health, anything odd>\n\
+         \n\
+         Then zero or more:\n\
+         \n\
+         ### FINDING\n\
+         file: <repo-relative path>:<line>\n\
+         severity: HIGH|MEDIUM|LOW|INFO\n\
+         category: bug|error-handling|security|dead-code|docs-drift|test-gap|smell\n\
+         claim: <one sentence>\n\
+         evidence: <quoted code, 1-3 lines>\n\
+         failure: <concrete scenario: inputs/state -> wrong outcome>",
+    );
+    out
+}
+
+/// The reviewer briefing system prompt (SPEC §6). `{root}` is substituted at build time.
+const RESEARCH_BRIEFING: &str = r"You are claudette in deep-research mode: a careful, skeptical code reviewer on
+a strictly read-only audit of the repository at {root}. You cannot modify
+anything; write tools are disabled and will be refused.
+
+Task per batch: read each assigned file COMPLETELY (read_file; large files in
+chunks), then report findings. Use repo_map/grep_search to check how the code
+is used elsewhere before judging it.
+
+Review lenses, in priority order: (1) correctness bugs, (2) error-handling and
+edge cases, (3) security, (4) dead or unreachable code, (5) comment/doc drift
+vs actual behavior, (6) missing or weak tests.
+
+Rules:
+- Report at most 5 findings per batch — only what you would defend to a
+  skeptical reviewer. A clean file is a valid result; say so and move on.
+- NEVER report a finding without a concrete failure scenario. No scenario,
+  no finding.
+- Cite exact file:line and quote the relevant code.
+- End with the required output format. Output nothing after it.";
+
+// ── Driver helpers (step 6) ────────────────────────────────────────────────
+
+/// Resolve the target root for a research run.
+/// `CLAUDETTE_WORKSPACE` first (first entry if platform-separated list; must be absolute),
+/// else `git rev-parse --show-toplevel`. Refuse with a clear error if neither resolves.
+fn resolve_target_root() -> Result<std::path::PathBuf, String> {
+    // Try CLAUDETTE_WORKSPACE first.
+    if let Ok(workspace) = std::env::var("CLAUDETTE_WORKSPACE") {
+        for entry in workspace.split(';') {
+            let path = entry.trim();
+            if !path.is_empty() && std::path::Path::new(path).is_absolute() {
+                return Ok(std::path::PathBuf::from(path));
+            }
+        }
+    }
+
+    // Fallback: git toplevel.
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Ok(std::path::PathBuf::from(path));
+            }
+        }
+        _ => {}
+    }
+
+    Err("neither CLAUDETTE_WORKSPACE (absolute) nor git toplevel resolved".into())
+}
+
+/// Resolve the output directory for research results.
+/// `CLAUDETTE_RESEARCH_DIR` used as-is if set; else
+/// `~/.claudette/research/<repo-dirname>-<YYYY-MM-DD>/`. Create it.
+fn resolve_output_dir(root: &std::path::Path) -> Result<std::path::PathBuf, String> {
+    // Override: used as-is, but it must never sit inside the target tree —
+    // the read-only promise covers the whole repo, so writing findings into
+    // it would break that guarantee (SPEC §6b). Compare canonical paths when
+    // both resolve; fall back to the lexical path for a not-yet-created dir.
+    if let Ok(dir) = std::env::var("CLAUDETTE_RESEARCH_DIR") {
+        let dir = std::path::PathBuf::from(dir);
+        let root_c = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let dir_c = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+        if dir_c.starts_with(&root_c) {
+            return Err(format!(
+                "CLAUDETTE_RESEARCH_DIR ({}) is inside the target tree {}; \
+                 choose a path outside it",
+                dir.display(),
+                root.display()
+            ));
+        }
+        return Ok(dir);
+    }
+
+    // Default: ~/.claudette/research/<repo-dirname>-<YYYY-MM-DD>/
+    let repo_name = root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    let date = current_date_str();
+
+    let home = env_config::home_dir();
+    Ok(home
+        .join(".claudette")
+        .join("research")
+        .join(format!("{repo_name}-{date}")))
+}
+
+/// Set `CLAUDETTE_OFFLINE=1` unless already set.
+fn force_offline_for_run() {
+    if std::env::var(crate::egress::OFFLINE_ENV).is_err() {
+        std::env::set_var(crate::egress::OFFLINE_ENV, "1");
+    }
+}
+
+/// Read `CLAUDETTE_RESEARCH_BATCH_FILES`, parse, clamp 1..=8, default DEFAULT_BATCH_FILES.
+fn batch_files_from_env() -> usize {
+    std::env::var("CLAUDETTE_RESEARCH_BATCH_FILES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(crate::run::research::DEFAULT_BATCH_FILES)
+        .clamp(1, 8)
+}
+
+/// Read `CLAUDETTE_RESEARCH_MAX_BATCHES`, Some(n) if positive integer, else None.
+fn max_batches_from_env() -> Option<usize> {
+    std::env::var("CLAUDETTE_RESEARCH_MAX_BATCHES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+}
+
+/// Resume decision per SPEC §8.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResumeAction {
+    Fresh,
+    ResumeAt(usize),
+    RefuseChanged,
+    RefuseDone,
+}
+
+/// Compute the resume action given existing progress and a manifest hash.
+fn resume_action(existing: Option<&Progress>, manifest_hash: &str) -> ResumeAction {
+    let Some(prog) = existing else {
+        return ResumeAction::Fresh;
+    };
+    if prog.manifest_hash != manifest_hash {
+        return ResumeAction::RefuseChanged;
+    }
+    if prog.phase == Phase::Done {
+        return ResumeAction::RefuseDone;
+    }
+    match prog.next_pending() {
+        Some(id) => ResumeAction::ResumeAt(id),
+        None => ResumeAction::Fresh, // all done but phase != Done → treat as fresh batches
+    }
+}
+
+/// Format the FINDINGS.md run header (SPEC §10).
+fn findings_md_run_header(
+    root: &std::path::Path,
+    output_dir: &std::path::Path,
+    manifest: &Manifest,
+) -> String {
+    let total_files = manifest.files.len();
+    let skipped_oversize = manifest
+        .skipped
+        .iter()
+        .filter(|s| s.reason == "oversize")
+        .count();
+    let skipped_unreadable = manifest
+        .skipped
+        .iter()
+        .filter(|s| s.reason == "unreadable")
+        .count();
+
+    format!(
+        "# Deep Research Findings\n\
+         \n\
+         **Target:** `{}`  \n\
+         **Output dir:** `{}`  \n\
+         **Date:** {}  \n\
+         **Files reviewed:** {total_files}  \n\
+         **Skipped (oversize):** {skipped_oversize}  \n\
+         **Skipped (unreadable):** {skipped_unreadable}\n",
+        root.display(),
+        output_dir.display(),
+        current_date_str()
+    )
+}
+
+fn current_date_str() -> String {
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}
+
+/// Format a batch block for FINDINGS.md.
+fn findings_md_batch_block(
+    batch_id: usize,
+    files: &[(String, usize)],
+    parsed: &ParsedBatch,
+) -> String {
+    let mut out = format!("\n## Batch {}\n\n", batch_id);
+    for (path, lines) in files {
+        let _ = writeln!(out, "  - `{path}` ({lines} lines)");
+    }
+    out.push_str("### Verdict\n");
+    out.push_str(&parsed.verdict);
+    if !parsed.findings.is_empty() {
+        out.push_str("\n\n### Findings\n");
+        for (i, f) in parsed.findings.iter().enumerate() {
+            let file_line = match f.line {
+                Some(l) => format!("{}:{}", f.file, l),
+                None => f.file.clone(),
+            };
+            let _ = write!(
+                out,
+                "\n#### Finding {}\n\n- **File:** `{}`\n- **Severity:** {}\n- **Category:** {}\n- **Claim:** {}\n- **Evidence:**\n  ```\n{}\n```\n- **Failure:** {}\n",
+                i + 1,
+                file_line,
+                f.severity,
+                f.category,
+                f.claim,
+                f.evidence,
+                f.failure,
+            );
+        }
+    } else {
+        out.push_str("\n\nNo findings.\n");
+    }
+    out
+}
+
+/// Format a skipped-batch note for FINDINGS.md.
+fn findings_md_skipped_note(batch_id: usize) -> String {
+    format!(
+        "\n## Batch {} — SKIPPED\n\nBatch could not be parsed after retries.\n",
+        batch_id
+    )
+}
+
+/// Classify a raw model response into an attempt outcome.
+#[derive(Debug)]
+pub(crate) enum AttemptOutcome {
+    Parsed(ParsedBatch),
+    Empty,
+    ParseError(String),
+}
+
+fn classify_attempt(text: &str, root: &std::path::Path) -> AttemptOutcome {
+    if text.trim().is_empty() {
+        return AttemptOutcome::Empty;
+    }
+    match parse_batch_output(text, root) {
+        Ok(parsed) => AttemptOutcome::Parsed(parsed),
+        Err(e) => AttemptOutcome::ParseError(e),
+    }
+}
+
+/// The main driver: `claudette --research` entry point.
+#[allow(clippy::too_many_lines)]
+pub fn run_deep_research(focus: &str) -> anyhow::Result<()> {
+    // 1. Force offline, resolve root and output dir.
+    force_offline_for_run();
+    let root = resolve_target_root().map_err(|e| anyhow::anyhow!("{}", e))?;
+    let output_dir = resolve_output_dir(&root).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    // Ensure output dir is not inside the target tree.
+    if output_dir.starts_with(&root) {
+        return Err(anyhow::anyhow!(
+            "CLAUDETTE_RESEARCH_DIR resolves inside the target tree — refuse to avoid write surface"
+        ));
+    }
+    std::fs::create_dir_all(&output_dir)
+        .map_err(|e| anyhow::anyhow!("failed to create output dir: {e}"))?;
+
+    // 2. Build or load manifest.json.
+    let manifest =
+        build_manifest(&root, batch_files_from_env()).map_err(|e| anyhow::anyhow!("{}", e))?;
+    let manifest_json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| anyhow::anyhow!("failed to serialize manifest: {e}"))?;
+    std::fs::write(output_dir.join("manifest.json"), &manifest_json)
+        .map_err(|e| anyhow::anyhow!("failed to write manifest: {e}"))?;
+
+    // 3. Load or init progress.json.
+    let progress_path = output_dir.join("progress.json");
+    let existing_progress = Progress::load(&progress_path).map_err(|e| anyhow::anyhow!(e))?;
+    let resume = resume_action(existing_progress.as_ref(), &manifest.hash);
+
+    match resume {
+        ResumeAction::RefuseChanged => {
+            return Err(anyhow::anyhow!(
+                "Manifest hash changed since last run. Delete {} or set CLAUDETTE_RESEARCH_DIR to start over.",
+                output_dir.display()
+            ));
+        }
+        ResumeAction::RefuseDone => {
+            return Err(anyhow::anyhow!(
+                "Previous run completed (phase=done). Check REPORT.md in {}. Set CLAUDETTE_RESEARCH_DIR for a fresh run.",
+                output_dir.display()
+            ));
+        }
+        _ => {}
+    }
+
+    let mut progress = match resume {
+        ResumeAction::Fresh => {
+            let started = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |d| d.as_secs());
+            Progress::new(&manifest, started)
+        }
+        ResumeAction::ResumeAt(id) => {
+            // ResumeAt is only produced when existing progress was present.
+            let prog = existing_progress.expect("ResumeAt implies existing progress");
+            eprintln!("resuming at batch {}", id);
+            prog
+        }
+        _ => unreachable!(),
+    };
+
+    // Write findings header for fresh runs.
+    if matches!(resume, ResumeAction::Fresh) {
+        let header = findings_md_run_header(&root, &output_dir, &manifest);
+        std::fs::write(output_dir.join("FINDINGS.md"), header)
+            .map_err(|e| anyhow::anyhow!("failed to write FINDINGS.md: {e}"))?;
+    }
+
+    // Init empty findings store for fresh runs.
+    let mut findings_store = match resume {
+        ResumeAction::Fresh => FindingsStore::new(),
+        _ => FindingsStore::load(&output_dir.join("findings.json"))
+            .map_err(|e| anyhow::anyhow!(e))?
+            .unwrap_or_else(FindingsStore::new),
+    };
+
+    // 4. Print header (SPEC §10).
+    eprintln!("Deep research: {}", root.display());
+    eprintln!("Output dir: {}", output_dir.display());
+    eprintln!(
+        "Files: {} | Batches: {}",
+        manifest.files.len(),
+        manifest.batches.len()
+    );
+    eprintln!("Offline mode enforced");
+    eprintln!("Read-only permission tier (write/exec/network denied)");
+
+    // 5. Batch loop.
+    let max_batches = max_batches_from_env();
+    let mut batches_done = 0usize;
+    let mut batches_skipped = 0usize;
+    let mut total_findings = 0usize;
+    let mut high_count = 0usize;
+
+    // Determine starting batch id.
+    let start_id = match resume {
+        ResumeAction::ResumeAt(id) => id,
+        _ => manifest.batches[0].id,
+    };
+
+    for batch in &manifest.batches {
+        if batch.id < start_id {
+            continue; // already done from previous run
+        }
+        if let Some(max) = max_batches {
+            if batches_done >= max {
+                break; // stopped by max_batches knob
+            }
+        }
+
+        let files: Vec<(String, usize)> = batch
+            .files
+            .iter()
+            .filter_map(|rel_path| {
+                manifest
+                    .files
+                    .iter()
+                    .find(|f| f.rel_path == *rel_path)
+                    .map(|mf| (mf.rel_path.clone(), mf.lines))
+            })
+            .collect();
+
+        let system_prompt = vec![RESEARCH_BRIEFING.replace("{root}", &root.display().to_string())];
+
+        // Up to 2 attempts.
+        let mut attempt_count: u32 = 0;
+        let mut parsed_batch: Option<ParsedBatch> = None;
+        let mut batch_status = BatchStatus {
+            id: batch.id,
+            state: BatchState::Pending,
+            attempts: 0,
+            findings: 0,
+            wall_secs: 0,
+        };
+
+        loop {
+            attempt_count += 1;
+            batch_status.attempts = attempt_count;
+            let start = std::time::SystemTime::now();
+
+            // Build runtime and run one turn.
+            let session = Session::new();
+            let mut runtime = build_research_runtime(session, system_prompt.clone());
+            let prompt = batch_prompt(batch.id, manifest.batches.len(), &files, focus);
+
+            // Run the turn — this is a blocking call that streams to stdout.
+            // A turn error (empty-stream flake, backend hiccup) yields no text,
+            // which classify_attempt treats as Empty (retry, then skip).
+            let text = match crate::brain_selector::run_turn_with_fallback(
+                &mut runtime,
+                &prompt,
+                &mut None,
+            ) {
+                Ok(summary) => crate::run::extract_assistant_text(&summary),
+                Err(_) => String::new(),
+            };
+
+            batch_status.wall_secs += start.elapsed().map_or(0, |d| d.as_secs());
+
+            match classify_attempt(&text, &root) {
+                AttemptOutcome::Parsed(pb) => {
+                    parsed_batch = Some(pb);
+                    break;
+                }
+                AttemptOutcome::Empty if attempt_count == 1 => {
+                    // Empty on the first attempt: loop around for a second try.
+                }
+                AttemptOutcome::ParseError(_) if attempt_count == 1 => {
+                    // Retry with appended line.
+                    let session2 = Session::new();
+                    let mut runtime2 = build_research_runtime(session2, system_prompt.clone());
+                    let prompt_with_retry = format!(
+                        "{}\n\nYour previous output did not match the required format. Re-output now, format only.",
+                        batch_prompt(batch.id, manifest.batches.len(), &files, focus)
+                    );
+                    let text2 = match crate::brain_selector::run_turn_with_fallback(
+                        &mut runtime2,
+                        &prompt_with_retry,
+                        &mut None,
+                    ) {
+                        Ok(summary2) => crate::run::extract_assistant_text(&summary2),
+                        Err(_) => String::new(),
+                    };
+                    batch_status.wall_secs += start.elapsed().map_or(0, |d| d.as_secs());
+
+                    match classify_attempt(&text2, &root) {
+                        AttemptOutcome::Parsed(pb) => {
+                            parsed_batch = Some(pb);
+                            break;
+                        }
+                        _ => {
+                            // Second failure → skip.
+                            batch_status.state = BatchState::Skipped;
+                            batches_skipped += 1;
+                            std::fs::write(
+                                output_dir.join("FINDINGS.md"),
+                                format!(
+                                    "{}\n{}",
+                                    std::fs::read_to_string(output_dir.join("FINDINGS.md"))
+                                        .unwrap_or_default(),
+                                    findings_md_skipped_note(batch.id)
+                                ),
+                            )
+                            .ok();
+                            break;
+                        }
+                    }
+                }
+                _ => {
+                    // Empty on attempt 2, or parse error on attempt 2 → skip.
+                    batch_status.state = BatchState::Skipped;
+                    batches_skipped += 1;
+                    std::fs::write(
+                        output_dir.join("FINDINGS.md"),
+                        format!(
+                            "{}\n{}",
+                            std::fs::read_to_string(output_dir.join("FINDINGS.md"))
+                                .unwrap_or_default(),
+                            findings_md_skipped_note(batch.id)
+                        ),
+                    )
+                    .ok();
+                    break;
+                }
+            }
+        }
+
+        if let Some(pb) = parsed_batch {
+            // Success: append to FINDINGS.md and findings.json.
+            std::fs::write(
+                output_dir.join("FINDINGS.md"),
+                format!(
+                    "{}{}",
+                    std::fs::read_to_string(output_dir.join("FINDINGS.md")).unwrap_or_default(),
+                    findings_md_batch_block(batch.id, &files, &pb)
+                ),
+            )
+            .ok();
+
+            findings_store.append_batch(batch.id, &pb.findings);
+            findings_store.save(&output_dir.join("findings.json")).ok();
+
+            batch_status.state = BatchState::Done;
+            batch_status.findings = pb.findings.len();
+            total_findings += pb.findings.len();
+            high_count += pb
+                .findings
+                .iter()
+                .filter(|f| f.severity == Severity::High)
+                .count();
+        }
+
+        // Capture the fields used by the stderr line before `batch_status`
+        // is moved into the progress vector below.
+        let batch_findings = batch_status.findings;
+        let batch_wall = batch_status.wall_secs;
+
+        // Update progress.
+        if let Some(status) = progress.batches.iter_mut().find(|b| b.id == batch.id) {
+            *status = batch_status;
+        }
+        progress.save(&progress_path).ok();
+
+        batches_done += 1;
+
+        // Per-batch stderr line (SPEC §10).
+        eprintln!(
+            "[{}/{}] {} — {} findings ({} HIGH) — {}s",
+            batches_done,
+            manifest.batches.len(),
+            root.display(),
+            batch_findings,
+            high_count,
+            batch_wall,
+        );
+    }
+
+    // 6. After batch loop: set phase = Verify if all pending done (not max-batches-capped).
+    let all_done = progress
+        .batches
+        .iter()
+        .all(|b| b.state == BatchState::Done || b.state == BatchState::Skipped);
+    if all_done && max_batches.is_none() {
+        progress.phase = Phase::Verify;
+    }
+    progress.save(&progress_path).ok();
+
+    // 7. Footer (SPEC §10).
+    eprintln!(
+        "\nDeep research complete: {} batches, {} skipped, {} findings ({} HIGH)",
+        batches_done, batches_skipped, total_findings, high_count
+    );
+    eprintln!("Output dir: {}", output_dir.display());
+
+    Ok(())
 }
 
 // ── Tests (step 9) ────────────────────────────────────────────────────────
@@ -1209,5 +1810,183 @@ failure: n/a
         assert_eq!(loaded.findings[2].id, 3);
 
         cleanup(&dir);
+    }
+
+    /// batch_prompt_lists_files_and_counts — two files → both path (N) lines present, header shows Batch 1/5, focus line present iff focus non-empty.
+    #[test]
+    fn batch_prompt_lists_files_and_counts() {
+        let files = vec![
+            ("src/main.rs".to_string(), 42),
+            ("src/lib.rs".to_string(), 37),
+        ];
+
+        // With focus.
+        let with_focus = batch_prompt(1, 5, &files, "focus on error handling");
+        assert!(with_focus.contains("Batch 1/5"));
+        assert!(with_focus.contains("src/main.rs (42 lines)"));
+        assert!(with_focus.contains("src/lib.rs (37 lines)"));
+        assert!(with_focus.contains("focus on error handling"));
+
+        // Without focus.
+        let no_focus = batch_prompt(1, 5, &files, "");
+        assert!(no_focus.contains("Batch 1/5"));
+        assert!(no_focus.contains("src/main.rs (42 lines)"));
+        assert!(!no_focus.contains("focus on error handling"));
+    }
+
+    /// findings_md_header_and_append_format — header names the root + counts; a batch block round-trips the verdict + a finding.
+    #[test]
+    fn findings_md_header_and_append_format() {
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+        fs::write(dir.join("a.rs"), "x\n").unwrap();
+
+        let manifest = build_manifest(&dir, DEFAULT_BATCH_FILES).expect("build");
+        let header = findings_md_run_header(&dir, &dir.join("output"), &manifest);
+        assert!(header.contains("Deep Research Findings"));
+        assert!(header.contains("**Files reviewed:** 1"));
+
+        // Build a finding.
+        fs::create_dir_all(dir.join("src")).unwrap();
+        fs::write(dir.join("src/good.rs"), "fn main() {}\n").unwrap();
+
+        let output = r"### BATCH VERDICT
+All good.
+
+### FINDING
+file: src/good.rs
+severity: high
+category: bug
+claim: test claim
+evidence: the code
+failure: bad thing happens";
+
+        let parsed = parse_batch_output(output, &dir).expect("parse");
+        let files = vec![("src/good.rs".to_string(), 1)];
+        let block = findings_md_batch_block(2, &files, &parsed);
+        assert!(block.contains("Batch 2"));
+        assert!(block.contains("All good."));
+        assert!(block.contains("test claim"));
+
+        cleanup(&dir);
+    }
+
+    /// classify_attempt_empty_parse_ok — empty → Empty; valid → Parsed; bad format → ParseError.
+    #[test]
+    fn classify_attempt_empty_parse_ok() {
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+        fs::write(dir.join("a.rs"), "x\n").unwrap();
+
+        assert!(matches!(classify_attempt("", &dir), AttemptOutcome::Empty));
+        assert!(matches!(
+            classify_attempt("   \n  ", &dir),
+            AttemptOutcome::Empty
+        ));
+
+        let valid = r"### BATCH VERDICT
+ok";
+        match classify_attempt(valid, &dir) {
+            AttemptOutcome::Parsed(pb) => assert_eq!(pb.verdict, "ok"),
+            other => panic!("expected Parsed, got {:?}", other),
+        }
+
+        match classify_attempt("not a verdict", &dir) {
+            AttemptOutcome::ParseError(_) => {} // expected
+            other => panic!("expected ParseError, got {:?}", other),
+        }
+
+        cleanup(&dir);
+    }
+
+    /// resume_action_matrix — covers all four outcomes.
+    #[test]
+    fn resume_action_matrix() {
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+        // Four files at 3-per-batch → two batches, so a resumed run has a
+        // pending batch 2 once batch 1 is marked done.
+        for name in ["a.rs", "b.rs", "c.rs", "d.rs"] {
+            fs::write(dir.join(name), "x\n").unwrap();
+        }
+        let manifest = build_manifest(&dir, DEFAULT_BATCH_FILES).expect("build");
+
+        // No existing progress → Fresh.
+        assert_eq!(resume_action(None, &manifest.hash), ResumeAction::Fresh);
+
+        // Hash mismatch → RefuseChanged.
+        let prog = Progress::new(&manifest, 0);
+        assert_eq!(
+            resume_action(Some(&prog), "different_hash"),
+            ResumeAction::RefuseChanged
+        );
+
+        // Phase Done → RefuseDone.
+        let mut done_prog = prog;
+        done_prog.phase = Phase::Done;
+        assert_eq!(
+            resume_action(Some(&done_prog), &manifest.hash),
+            ResumeAction::RefuseDone
+        );
+
+        // Phase Batches, pending batch exists → ResumeAt.
+        let mut resume_prog = Progress::new(&manifest, 0);
+        resume_prog.batches[0].state = BatchState::Done;
+        assert_eq!(
+            resume_action(Some(&resume_prog), &manifest.hash),
+            ResumeAction::ResumeAt(2)
+        );
+
+        cleanup(&dir);
+    }
+
+    /// output_dir_default_and_override — override honored as-is; default ends with <repo>-<date>.
+    #[test]
+    fn output_dir_default_and_override() {
+        let _guard = crate::test_env_lock();
+
+        // Override.
+        std::env::set_var("CLAUDETTE_RESEARCH_DIR", "/custom/output");
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+        fs::write(dir.join("a.rs"), "x\n").unwrap();
+        assert_eq!(
+            resolve_output_dir(&dir).expect("override"),
+            std::path::PathBuf::from("/custom/output")
+        );
+
+        // Default.
+        std::env::remove_var("CLAUDETTE_RESEARCH_DIR");
+        let result = resolve_output_dir(&dir).expect("default");
+        let result_str = result.to_string_lossy();
+        assert!(result_str.contains(".claudette"));
+        assert!(result_str.contains("research"));
+
+        cleanup(&dir);
+    }
+
+    /// force_offline_for_run_sets_env — unset → becomes "1"; a pre-set value is left untouched.
+    #[test]
+    fn force_offline_for_run_sets_env() {
+        let _guard = crate::test_env_lock();
+
+        // Unset → set to "1".
+        std::env::remove_var(crate::egress::OFFLINE_ENV);
+        force_offline_for_run();
+        assert_eq!(
+            std::env::var(crate::egress::OFFLINE_ENV).ok(),
+            Some("1".to_string())
+        );
+
+        // Pre-set value left untouched.
+        std::env::set_var(crate::egress::OFFLINE_ENV, "0");
+        force_offline_for_run();
+        assert_eq!(
+            std::env::var(crate::egress::OFFLINE_ENV).ok(),
+            Some("0".to_string())
+        );
+
+        // Clean up.
+        std::env::remove_var(crate::egress::OFFLINE_ENV);
     }
 }

--- a/crates/claudette/src/run/runtime_build.rs
+++ b/crates/claudette/src/run/runtime_build.rs
@@ -312,6 +312,55 @@ pub(crate) fn build_forge_role_runtime(
         })
 }
 
+/// Build a fresh runtime for one deep-research batch: the active brain with
+/// read-only tools (Files/Search/Semantic) and a HARD `ReadOnly` permission
+/// tier. The tier cap denies every write/exec/network tool at dispatch —
+/// before any prompter — regardless of which tool name the model invents
+/// (role-isolation lesson, roast RC-B). No prompter is wired (all permitted
+/// tools are ReadOnly-tier, so nothing needs approval); `CLAUDETTE_FORGE_
+/// AUTO_APPROVE` deliberately has NO effect here (research never builds an
+/// Allow-mode policy).
+pub(crate) fn build_research_runtime(
+    session: Session,
+    system_prompt: Vec<String>,
+) -> ConversationRuntime<OllamaApiClient, AgentToolExecutor> {
+    let brain = model_config::active().brain;
+
+    let mut reg = ToolRegistry::new();
+    for group in [ToolGroup::Files, ToolGroup::Search, ToolGroup::Semantic] {
+        reg.enable(group);
+    }
+    let registry = Arc::new(Mutex::new(reg));
+
+    let api_client = OllamaApiClient::with_registry(brain.model.clone(), registry.clone())
+        .with_context(brain.num_ctx)
+        .with_max_predict(brain.num_predict)
+        .with_text_callback(stdout_text_callback());
+
+    let hinter_registry = Arc::clone(&registry);
+    let executor = AgentToolExecutor::with_registry(registry);
+    let policy = research_permission_policy();
+
+    ConversationRuntime::new(session, api_client, executor, policy, system_prompt)
+        .with_max_iterations(max_iterations())
+        .with_auto_compaction_input_tokens_threshold(u32::MAX)
+        .with_unknown_tool_hinter(move |name: &str| {
+            ToolGroup::parse(name).map_or_else(Vec::new, |group| {
+                let reg = match hinter_registry.lock() {
+                    Ok(g) => g,
+                    Err(p) => p.into_inner(),
+                };
+                reg.group_tool_names(group)
+            })
+        })
+}
+
+/// The permission policy for a deep-research runtime: the ambient policy,
+/// hard-capped at `ReadOnly`. Factored out so the cap is directly testable.
+pub(crate) fn research_permission_policy() -> PermissionPolicy {
+    build_permission_policy().with_max_tier(crate::PermissionMode::ReadOnly)
+}
+
 /// v0b helper: resolve any forge role's model from `~/.claudettes-forge/
 /// models.toml` (or env overrides). Returns `None` on any failure — the
 /// caller falls back to claudette's active brain model. Best-effort; a
@@ -576,5 +625,24 @@ mod tests {
         assert_eq!(p.role, forge::types::Role::Coder);
         assert!(!p.voice.is_empty(), "codex7 should have a voice");
         assert!(!p.backstory.is_empty(), "codex7 should have backstory");
+    }
+
+    /// The research permission policy caps at `ReadOnly`: every write/exec
+    /// tool is denied at the tier ceiling before any prompter is consulted,
+    /// regardless of the ambient mode (role-isolation guard, roast RC-B).
+    #[test]
+    fn research_policy_is_read_only_capped() {
+        let _guard = crate::test_env_lock();
+        let policy = research_permission_policy();
+        assert_eq!(policy.max_tier(), PermissionMode::ReadOnly);
+        for tool in ["write_file", "bash", "apply_diff", "git_commit"] {
+            assert!(
+                matches!(
+                    policy.authorize(tool, "{}", None),
+                    crate::PermissionOutcome::Deny { .. }
+                ),
+                "{tool} must be denied under the ReadOnly cap"
+            );
+        }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,21 @@ Two layers enforce it: an HTTP-layer guard in the reqwest path checks the destin
 | `CLAUDETTE_MAX_FIX_ROUNDS` | `3` | Cap on Coder→Verifier fix-loop rounds in `--forge`. Default 3 is the empirical sweet spot for local 8b coders. Raise to 4–6 if you've pinned a stronger Verifier model and want it to keep pushing back. Clamped at 10. |
 | `CLAUDETTE_FORGE_ABORT_WINDOW_SECS` | `3` | Grace window (seconds) to Ctrl-C out of a forge run before it starts working. Set `0` to skip the pause in CI / scripted runs. Clamped at 30. |
 
+## Deep research (`--research`)
+
+`--research` runs an unattended, read-only review loop over the target repo
+(`CLAUDETTE_WORKSPACE`, else the git toplevel). The read-only and offline
+guarantees are enforced at the permission layer, not by prompt: the runtime is
+capped at a hard `ReadOnly` tier — every write / exec / network tool is denied
+at dispatch, before any prompter — and the run forces `--offline`. Findings are
+checkpointed under `~/.claudette/research/`, so an interrupted run resumes.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLAUDETTE_RESEARCH_DIR` | `~/.claudette/research/<repo>-<date>/` | Output directory override for `--research` (used as-is; must be outside the target tree). |
+| `CLAUDETTE_RESEARCH_MAX_BATCHES` | unlimited | Stop a `--research` run after N batches (smoke tests / partial runs). |
+| `CLAUDETTE_RESEARCH_BATCH_FILES` | `3` | Max files per review batch (clamped `1`–`8`). |
+
 ## Tokens (per-tool)
 
 | Variable | Purpose |


### PR DESCRIPTION
Second slice of deep-research mode (`plans/deep-research-2026-07-17/SPEC.md`) — the runnable `claudette --research` batches phase.

## What lands
- `--research` CLI flag (parse + dispatch + help + test); forces `--offline`.
- `build_research_runtime` — a hard **ReadOnly-tier** runtime (Files/Search/Semantic groups; every write/exec/network tool denied at dispatch, before any prompter). Factored `research_permission_policy()` for a direct unit test.
- Resumable batch driver loop: fresh `Session`/runtime per batch, `run_turn_with_fallback` → `extract_assistant_text` → `classify_attempt`, 2-attempt retry then skip (a bad batch never aborts the run).
- Output dir resolution refuses a `CLAUDETTE_RESEARCH_DIR` inside the target tree (the read-only promise covers the whole repo).
- 3 knobs (`CLAUDETTE_RESEARCH_DIR` / `_MAX_BATCHES` / `_BATCH_FILES`) + `docs/configuration.md` rows.

Runs the **batches phase end to end**; verify, synthesize, and `REPORT.md` land in R3.

## Validation
- `fmt` + `clippy -D warnings` (incl. pedantic) clean.
- `cargo test` 1074/0, `cargo test --all-features` 1161/0.
- Live smoke (tiny repo, champion brain): manifest/progress/findings/`FINDINGS.md` written, offline forced, repo untouched, output outside the tree.

## Known follow-up (not a regression here)
The live smoke surfaced that the **R1 finding parser under-captures** real model output (line ranges like `path:6-7` were dropped; code-fence markers leaked into evidence). That's pre-existing R1 code the card scoped out; a hardening card (`R2b`) is queued before R3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)