### PR TITLE
docs(research): document deep-research mode (docs/research.md + surfacing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ bumps are non-breaking bugfixes only.
 
 ### Added
 
+- **Deep-research mode: `claudette --research` — an unattended, read-only
+  repo audit.** Batches of 2–3 files are each reviewed in a fresh
+  conversation (a stateless outer loop, so long runs cannot drift), findings
+  are checkpointed to `~/.claudette/research/<repo>-<date>/` after every
+  batch, every HIGH/MEDIUM finding is re-verified in its own conversation
+  (`CONFIRMED` / `RETRACTED` / `UNVERIFIED`), and a final synthesize pass
+  writes a ranked, triage-ready `REPORT.md`. Read-only is enforced at the
+  permission layer (mutating tools are denied at dispatch, not by prompt) and
+  the run forces `--offline`; interrupt it any time — re-running the same
+  command resumes at the first unfinished batch. Knobs:
+  `CLAUDETTE_RESEARCH_DIR`, `CLAUDETTE_RESEARCH_MAX_BATCHES`,
+  `CLAUDETTE_RESEARCH_BATCH_FILES`. See `docs/research.md`.
+
 - **`repo_map` now extracts Kotlin definitions** (`.kt` / `.kts`): top-level
   and member `fun`, `class` (incl. `data` / `enum` / `sealed` / `annotation` /
   `value`), `interface` (incl. `fun interface`), and `object` / `companion

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ Prefer not to pipe curl into a shell? Grab a [prebuilt release](https://github.c
 |------|---------|-----|
 | **REPL** | `claudette` | Conversational shell; autosaves every turn |
 | **One-shot** | `claudette "..."` | Print a reply and exit; pipe-friendly |
+| **Deep research** | `claudette --research` | Unattended read-only repo audit → verified findings + `REPORT.md`; forces `--offline` |
 | **TUI** _(experimental)_ | `claudette --tui` | Demo-only fullscreen UI, 5 tabs; known rendering rough edges — the REPL is the daily driver |
 | **Telegram** | `claudette --telegram` | Voice-capable chat from your phone |
 | **VS Code** | [`editor/vscode/`](editor/vscode/README.md) | Send a selection or the open file to Claudette without leaving the editor |
 
 - **80+ tools across 20 opt-in groups.** The model turns a group on (`enable_tools("git")`) only when it needs it, so the base schema stays ~200 tokens however many tools exist. Point Claudette at a repo and the coding core - files, search, tests - is pre-enabled.
 - **Forge - an autonomous code pipeline.** `claudette --forge "<task>"` runs Planner → Coder → Verifier → fix-loop → Submitter. The Verifier actually builds and runs the tests each round (`cargo`, `go`, `pytest`, `npm`), so a diff that doesn't compile or breaks a test can't pass - and no PR opens until you approve the plan and the full diff. → [docs/forge.md](docs/forge.md)
+- **Deep research - an unattended read-only audit.** `claudette --research` reviews the whole repo in fresh 2-3-file conversations, re-verifies every HIGH/MEDIUM finding, and writes a ranked, triage-ready `REPORT.md`. Read-only is enforced at the permission layer - not by prompt - and the run forces `--offline`. → [docs/research.md](docs/research.md)
 - **Brownfield missions.** `mission_start("owner/repo")` clones a repo, routes file ops into it, and `mission_submit` branches, commits, pushes, and opens the PR - one tool chain.
 - **Also a personal assistant.** Notes, todos, calendar, Gmail, weather, web search, and a Telegram bot with voice in (Whisper) and out (edge-tts, English or Hebrew).
 - **Tiered brain, recall, vision.** Auto-escalates the 4B model to 9B only on real stuck signals; `/recall` searches every past session through a local embedding index; image attachments work when the loaded model is multimodal.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 
 - [architecture.md](architecture.md) — module layout, tool-group contract, storage layout
 - [forge.md](forge.md) — the Planner → Coder → Verifier pipeline, brownfield missions, `models.toml`
+- [research.md](research.md) — deep-research mode: the unattended read-only audit loop, its guarantees, output files, resume, knobs
 - [comparison.md](comparison.md) — honest side-by-side vs. opencode / Aider / OpenHands / Cline / Continue
 
 ## Setup & deployment

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,0 +1,84 @@
+# Deep-research mode (`--research`)
+
+`claudette --research` points Claudette at the repo you are in and runs an
+unattended, hours-capable, **strictly read-only** code review: every file in
+2–3-file batches, each batch a fresh conversation, findings checkpointed to
+disk after every step, HIGH/MEDIUM findings re-verified, and a final
+triage-ready `REPORT.md`.
+
+```sh
+cd your-repo
+claudette --research                 # review everything
+claudette --research error handling  # trailing words = optional focus hint
+```
+
+Interrupt it any time (Ctrl-C, reboot, backend crash) — re-running the same
+command resumes at the first unfinished batch.
+
+## The guarantees
+
+- **Read-only, enforced at the permission layer — not by prompt.** The
+  research runtime is capped at the read-only permission tier: `write_file`,
+  `apply_diff`, `bash`, the git-writing tools, and every other mutating tool
+  are denied at dispatch no matter what the model asks for. The reviewer
+  model never writes a byte; the driver writes all output files itself.
+- **Offline, forced.** The run sets `CLAUDETTE_OFFLINE=1` (unless you already
+  set it yourself): outbound network is hard-blocked except the local model
+  backend. Your code is reviewed by your own GPU; nothing leaves the machine.
+- **A bad batch never kills the run.** A batch whose review fails to parse
+  twice is recorded as skipped with a note in `FINDINGS.md`, and the run
+  moves on.
+
+## How a run works
+
+1. **Manifest.** The driver walks the repo (`.gitignore` respected), plans
+   batches of at most 3 files / 48 KB grouped by directory, and writes
+   `manifest.json`. Files over 256 KB are skipped with a note.
+2. **Batches.** Each batch is reviewed in a *fresh* conversation — no context
+   carries over, so a long run cannot drift or spiral. The reviewer must use
+   a rigid finding format: severity (`HIGH`/`MEDIUM`/`LOW`/`INFO`), category
+   (`bug`, `error-handling`, `security`, `dead-code`, `docs-drift`,
+   `test-gap`, `smell`), claim, evidence, and a **mandatory failure
+   scenario** — at most 5 findings per batch, and an explicit batch verdict
+   even when clean. Findings land in `findings.json` and the human-readable
+   `FINDINGS.md`; progress is checkpointed after every batch. Two format
+   attempts, then the batch is skipped.
+3. **Verify.** Every HIGH/MEDIUM finding is re-examined in its own fresh
+   conversation that re-reads the cited file and answers `CONFIRMED` or
+   `RETRACTED` (unparseable twice → `UNVERIFIED`). The verify briefing
+   rewards retracting weak findings over defending them. LOW/INFO findings
+   skip verification.
+4. **Synthesize.** One final conversation receives the full findings table
+   and writes the report body; the driver writes `REPORT.md` — a generated
+   metadata header (target, date, model, coverage, finding counts) above the
+   model's ranked, triage-ready report.
+
+## Output files
+
+Everything lands in `~/.claudette/research/<repo>-<date>/` (override with
+`CLAUDETTE_RESEARCH_DIR`; the directory must be outside the reviewed repo):
+
+| File | What it is |
+|------|------------|
+| `manifest.json` | File list + batch plan + content hash (resume safety) |
+| `progress.json` | Phase + per-batch state; checkpointed continuously |
+| `findings.json` | Structured findings with verdicts (machine-readable) |
+| `FINDINGS.md` | Append-only human log, written as batches complete |
+| `REPORT.md` | The final ranked report — read this one |
+
+## Resume
+
+Re-run `claudette --research` in the same repo and it picks up at the first
+unfinished batch (or the verify/synthesize phase if all batches are done).
+If the repo changed since the manifest was built, the hash no longer matches
+and the run refuses — delete the output directory or point
+`CLAUDETTE_RESEARCH_DIR` somewhere fresh. A completed run (`phase = done`)
+also refuses and points you at its `REPORT.md`.
+
+## Knobs
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `CLAUDETTE_RESEARCH_DIR` | `~/.claudette/research/<repo>-<date>/` | Output directory override (used as-is; must be outside the target tree). |
+| `CLAUDETTE_RESEARCH_MAX_BATCHES` | unlimited | Stop after N batches — smoke tests / partial runs. A capped run stays in the batches phase; re-running continues it. |
+| `CLAUDETTE_RESEARCH_BATCH_FILES` | `3` | Max files per review batch (clamped `1`–`8`). |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ binary has no cloud code, so it errors with a one-line reinstall hint instead.
 | `--telegram`, `-t` | **(integrations)** Run as a Telegram bot (needs `TELEGRAM_BOT_TOKEN`). |
 | `--tui` | Launch the fullscreen TUI. |
 | `--forge "<prompt>"` | Run forge-mode (Planner → Coder → Verifier pipeline) against the active brownfield mission. Requires an active mission — start one with `/brownfield <repo>` or `mission_start` first. |
+| `--research [focus]` | Unattended read-only review of the repo you are in: fresh conversation per 2–3-file batch, findings checkpointed under `~/.claudette/research/`, HIGH/MEDIUM findings verified, final `REPORT.md`. Forces offline; re-run the same command to resume. Trailing words become an optional focus hint. See [research.md](research.md). |
 | `--chat <id>` | Restrict Telegram bot to a specific chat ID. Repeatable, or set `CLAUDETTE_TELEGRAM_CHAT` to a comma-separated list. The bot **default-denies** when no allowlist is provided. |
 | `--chat any` | Explicit accept-all: serve every incoming Telegram chat. Required to start the bot with no allowlist. Prints a loud warning. |
 | `--auth-google [scope]` | **(integrations)** Run the loopback OAuth flow. Scope is `calendar` (default) or `gmail`. Stores tokens under `~/.claudette/secrets/`. |


### PR DESCRIPTION
R4 — the final deep-research card (SPEC §13, docs-only). Completes the `--research` feature for v0.17.0.

- **New `docs/research.md`**: what the mode is, the two guarantees (read-only enforced at the permission layer, offline forced), the four-phase run walkthrough (manifest → batches → verify → synthesize), output files, resume semantics, and the three knobs.
- **Surfacing**: docs-index row, README mode-table row + feature bullet, `--research [focus]` row in usage.md's flag table, and the v0.17.0 CHANGELOG entry.

Gate: fmt clean, clippy `--all-targets --all-features -D warnings` exit 0, `cargo test` 1081/0, `cargo test --all-features` 1168/0 (doc-guard tests included).

Follows R1 #199, R2 #201, R2b #202, R3 #203 — with this, the deep-research feature is code- and docs-complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpMa27HsPRWq2aM12wPW9L