### PR TITLE
feat(research): scope control — exclude knob + docs/archive default + control-token warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Added
+
+- **`--research` scope control.** `CLAUDETTE_RESEARCH_EXCLUDE` skips
+  comma-separated paths / directory names (bare names match at any depth; paths
+  with a slash match that subtree), on top of a built-in `docs/archive` default
+  so stale archived docs stay out of reviews. Excluded files are recorded in
+  `manifest.json` and counted in the `FINDINGS.md` header, not silently dropped.
+  A run also warns at startup about files dense with chat-template control
+  tokens (e.g. `api/harmony.rs`), which reliably provoke content-less batches —
+  exclude them if the flake cost isn't worth the coverage.
+
 ## [0.17.0] - 2026-07-19
 
 ### Docs

--- a/crates/claudette/src/run/research.rs
+++ b/crates/claudette/src/run/research.rs
@@ -24,6 +24,13 @@ pub(crate) const EXCLUDE_FILES: &[&str] = &[
     "yarn.lock",
 ];
 
+/// Paths excluded from every `--research` run by default. Conservative on
+/// purpose: `docs/archive` is matched as a path prefix (not a bare segment) so
+/// it only catches the conventional stale-docs tree, never a real
+/// `src/archive/` source module. Operators add more via
+/// `CLAUDETTE_RESEARCH_EXCLUDE`.
+pub(crate) const DEFAULT_EXCLUDES: &[&str] = &["docs/archive"];
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ManifestFile {
     pub rel_path: String,
@@ -51,16 +58,38 @@ pub(crate) struct Manifest {
     pub skipped: Vec<SkippedFile>,
     pub batches: Vec<Batch>,
     pub hash: String,
+    /// Kept files whose content is dense with chat-template control tokens
+    /// (`<|channel|>`, `<|end|>`, …). These reliably provoke content-less
+    /// generation; the driver warns and points at `CLAUDETTE_RESEARCH_EXCLUDE`.
+    /// Informational only — not part of the resume `hash`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flagged_control_tokens: Vec<String>,
+}
+
+/// Build a deterministic review manifest from `root` with no scope excludes.
+/// Thin wrapper over [`build_manifest_with_excludes`]; the driver uses the
+/// `_with_excludes` form so operator/default excludes apply. Test-only — the
+/// production path always passes an exclude set.
+#[cfg(test)]
+pub(crate) fn build_manifest(
+    root: &std::path::Path,
+    max_batch_files: usize,
+) -> Result<Manifest, String> {
+    build_manifest_with_excludes(root, max_batch_files, &[])
 }
 
 /// Build a deterministic review manifest from `root`.
 ///
-/// Walks the directory tree (respecting `.gitignore`), collects eligible files,
-/// plans them into size-aware batches, and returns a [`Manifest`].
+/// Walks the directory tree (respecting `.gitignore`), drops files matching
+/// `excludes` (recorded as `skipped` with reason `"excluded"`), collects the
+/// eligible remainder, plans them into size-aware batches, flags any file whose
+/// content is dense with chat-template control tokens, and returns a
+/// [`Manifest`].
 #[allow(clippy::too_many_lines)] // card-prescribed algorithm, kept inline
-pub(crate) fn build_manifest(
+pub(crate) fn build_manifest_with_excludes(
     root: &std::path::Path,
     max_batch_files: usize,
+    excludes: &[String],
 ) -> Result<Manifest, String> {
     // Clamp max_batch_files to 1..=8.
     let max_batch_files = max_batch_files.clamp(1, 8);
@@ -79,6 +108,7 @@ pub(crate) fn build_manifest(
     // Collect eligible files.
     let mut kept: Vec<ManifestFile> = Vec::new();
     let mut skipped: Vec<SkippedFile> = Vec::new();
+    let mut flagged: Vec<String> = Vec::new();
 
     for entry in builder.build().flatten() {
         if !entry.file_type().is_some_and(|ft| ft.is_file()) {
@@ -109,6 +139,16 @@ pub(crate) fn build_manifest(
             |p| p.to_string_lossy().replace('\\', "/"),
         );
 
+        // Scope excludes (defaults + CLAUDETTE_RESEARCH_EXCLUDE). Recorded, not
+        // silently dropped, so coverage numbers stay honest.
+        if path_is_excluded(&rel_path, excludes) {
+            skipped.push(SkippedFile {
+                rel_path,
+                reason: "excluded".to_string(),
+            });
+            continue;
+        }
+
         // Metadata.
         let meta = std::fs::metadata(path).ok();
         let size = meta.as_ref().map_or(0, std::fs::Metadata::len);
@@ -137,6 +177,12 @@ pub(crate) fn build_manifest(
         };
 
         let lines = content.lines().count();
+
+        // Files dense with chat-template control tokens reliably provoke
+        // content-less generation; flag for the driver's warning.
+        if content_has_control_tokens(&content) {
+            flagged.push(rel_path.clone());
+        }
 
         kept.push(ManifestFile {
             rel_path,
@@ -197,12 +243,15 @@ pub(crate) fn build_manifest(
     let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let hash = manifest_hash(&kept);
 
+    flagged.sort();
+
     Ok(Manifest {
         root: canonical_root.to_string_lossy().to_string(),
         files: kept,
         skipped,
         batches,
         hash,
+        flagged_control_tokens: flagged,
     })
 }
 
@@ -219,6 +268,49 @@ pub(crate) fn manifest_hash(files: &[ManifestFile]) -> String {
         }
     }
     format!("{hash:016x}")
+}
+
+/// Parse a comma-separated exclude list into normalized entries: trimmed,
+/// backslashes → `/`, trailing `/` stripped, empties dropped. No env access.
+pub(crate) fn parse_exclude_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|e| e.trim().replace('\\', "/"))
+        .map(|e| e.trim_end_matches('/').to_string())
+        .filter(|e| !e.is_empty())
+        .collect()
+}
+
+/// The active exclude set for a run: [`DEFAULT_EXCLUDES`] plus whatever
+/// `CLAUDETTE_RESEARCH_EXCLUDE` contributes. The only env reader here.
+pub(crate) fn research_excludes() -> Vec<String> {
+    let mut excludes: Vec<String> = DEFAULT_EXCLUDES.iter().map(|s| (*s).to_string()).collect();
+    if let Ok(raw) = std::env::var("CLAUDETTE_RESEARCH_EXCLUDE") {
+        excludes.extend(parse_exclude_list(&raw));
+    }
+    excludes
+}
+
+/// `true` when `rel_path` (forward-slash, repo-relative) is covered by any
+/// exclude entry. An entry matches when the path equals it, sits under it as a
+/// directory (`entry/` prefix), or — for a bare entry with no `/` — has a path
+/// *segment* equal to it. So `harmony.rs` excludes the file at any depth and
+/// `archive` excludes any `archive/` directory, but `archive` leaves
+/// `archive.rs` (a distinct segment) alone.
+pub(crate) fn path_is_excluded(rel_path: &str, excludes: &[String]) -> bool {
+    excludes.iter().any(|e| {
+        if rel_path == e || rel_path.starts_with(&format!("{e}/")) {
+            return true;
+        }
+        !e.contains('/') && rel_path.split('/').any(|seg| seg == e)
+    })
+}
+
+/// `true` when `content` holds three or more `<|` sequences — the shape of
+/// Qwen/Harmony chat-template control tokens (`<|channel|>`, `<|end|>`, …).
+/// Cheap and dependency-free; ordinary source never trips it, token-dense
+/// files (e.g. `api/harmony.rs`) always do.
+pub(crate) fn content_has_control_tokens(content: &str) -> bool {
+    content.matches("<|").count() >= 3
 }
 
 // ── Finding types (step 6) ────────────────────────────────────────────────
@@ -950,6 +1042,11 @@ fn findings_md_run_header(
         .iter()
         .filter(|s| s.reason == "unreadable")
         .count();
+    let skipped_excluded = manifest
+        .skipped
+        .iter()
+        .filter(|s| s.reason == "excluded")
+        .count();
 
     format!(
         "# Deep Research Findings\n\
@@ -959,7 +1056,8 @@ fn findings_md_run_header(
          **Date:** {}  \n\
          **Files reviewed:** {total_files}  \n\
          **Skipped (oversize):** {skipped_oversize}  \n\
-         **Skipped (unreadable):** {skipped_unreadable}\n",
+         **Skipped (unreadable):** {skipped_unreadable}  \n\
+         **Skipped (excluded):** {skipped_excluded}\n",
         root.display(),
         output_dir.display(),
         current_date_str()
@@ -1107,7 +1205,21 @@ pub fn run_deep_research(focus: &str) -> anyhow::Result<()> {
 
     // 2. Build or load manifest.json.
     let manifest =
-        build_manifest(&root, batch_files_from_env()).map_err(|e| anyhow::anyhow!("{}", e))?;
+        build_manifest_with_excludes(&root, batch_files_from_env(), &research_excludes())
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+    if !manifest.flagged_control_tokens.is_empty() {
+        eprintln!(
+            "warning: {} file(s) are dense with chat-template control tokens and \
+             often provoke content-less batches (skips/retries):",
+            manifest.flagged_control_tokens.len()
+        );
+        for path in &manifest.flagged_control_tokens {
+            eprintln!("  {path}");
+        }
+        eprintln!(
+            "  exclude them with CLAUDETTE_RESEARCH_EXCLUDE if the flake cost isn't worth it."
+        );
+    }
     let manifest_json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| anyhow::anyhow!("failed to serialize manifest: {e}"))?;
     std::fs::write(output_dir.join("manifest.json"), &manifest_json)
@@ -1740,6 +1852,93 @@ mod tests {
 
         // Cargo.lock and photo.png should be filtered out (not in skipped).
         assert!(manifest.skipped.is_empty());
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn parse_exclude_list_normalizes() {
+        assert_eq!(
+            parse_exclude_list("docs/archive, plans ,,src\\x/"),
+            vec!["docs/archive", "plans", "src/x"]
+        );
+        assert!(parse_exclude_list("").is_empty());
+        assert!(parse_exclude_list("  , ").is_empty());
+    }
+
+    #[test]
+    fn path_is_excluded_matches_rules() {
+        let ex = vec!["docs/archive".to_string()];
+        // Path-prefix default: the archive tree is out, live docs stay in.
+        assert!(path_is_excluded("docs/archive/old.md", &ex));
+        assert!(path_is_excluded("docs/archive", &ex));
+        assert!(!path_is_excluded("docs/guide.md", &ex));
+        // docs/archive is a full path, not a bare name — a src/archive/ module
+        // is untouched.
+        assert!(!path_is_excluded("src/archive/mod.rs", &ex));
+
+        // Bare-name entry matches any path segment (a dir or the file itself)
+        // but not a longer segment that merely starts with it.
+        let bare = vec!["archive".to_string(), "harmony.rs".to_string()];
+        assert!(path_is_excluded("src/archive/x.rs", &bare));
+        assert!(path_is_excluded("crates/c/src/api/harmony.rs", &bare));
+        assert!(!path_is_excluded("src/archive.rs", &bare));
+        assert!(!path_is_excluded("src/harmony_impl.rs", &bare));
+    }
+
+    #[test]
+    fn content_has_control_tokens_detects_dense_tokens() {
+        assert!(content_has_control_tokens(
+            "<|channel|>analysis<|message|>real<|end|>"
+        ));
+        assert!(!content_has_control_tokens("if x < y && y > z"));
+        assert!(!content_has_control_tokens(
+            "<div><span>plain markup</span>"
+        ));
+        // Below the threshold of three.
+        assert!(!content_has_control_tokens("one <| and <| only two"));
+    }
+
+    /// Excluded files are recorded in `skipped` (reason "excluded"), absent from
+    /// `files`, while everything else is kept.
+    #[test]
+    fn manifest_excludes_recorded_not_dropped() {
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+
+        fs::write(dir.join("keep.rs"), "fn keep() {}\n").unwrap();
+        fs::create_dir_all(dir.join("docs/archive")).unwrap();
+        fs::write(dir.join("docs/archive/old.md"), "# stale\n").unwrap();
+
+        let excludes = vec!["docs/archive".to_string()];
+        let manifest =
+            build_manifest_with_excludes(&dir, DEFAULT_BATCH_FILES, &excludes).expect("build");
+
+        assert_eq!(manifest.files.len(), 1);
+        assert_eq!(manifest.files[0].rel_path, "keep.rs");
+        assert_eq!(manifest.skipped.len(), 1);
+        assert_eq!(manifest.skipped[0].rel_path, "docs/archive/old.md");
+        assert_eq!(manifest.skipped[0].reason, "excluded");
+
+        cleanup(&dir);
+    }
+
+    /// A file dense with chat-template control tokens is flagged (the 2-arg
+    /// wrapper applies no excludes, so the file is still kept).
+    #[test]
+    fn manifest_flags_control_token_files() {
+        let dir = fixture_dir();
+        setup_fixture(&dir);
+
+        fs::write(dir.join("clean.rs"), "fn clean() {}\n").unwrap();
+        fs::write(
+            dir.join("tokens.rs"),
+            "// leaks <|channel|>thought<|message|> and <|end|>\n",
+        )
+        .unwrap();
+
+        let manifest = build_manifest(&dir, DEFAULT_BATCH_FILES).expect("build");
+        assert_eq!(manifest.flagged_control_tokens, vec!["tokens.rs"]);
 
         cleanup(&dir);
     }
@@ -2545,6 +2744,7 @@ ok";
             skipped: vec![],
             batches: vec![],
             hash: "h".into(),
+            flagged_control_tokens: vec![],
         };
         let mut store = FindingsStore::new();
         store.append_batch(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,7 @@ checkpointed under `~/.claudette/research/`, so an interrupted run resumes.
 | `CLAUDETTE_RESEARCH_BATCH_FILES` | `3` | Max files per review batch (clamped `1`–`8`). |
 | `CLAUDETTE_RESEARCH_RETRY_SKIPPED` | unset | `1` on a `--research` resume re-queues previously skipped batches (flake recovery / validation). |
 | `CLAUDETTE_RESEARCH_RECOVER_CMD` | unset | Driver-side shell command run once per backend sick-episode during `--research` (e.g. `lms unload --all`); the model never sees it. |
+| `CLAUDETTE_RESEARCH_EXCLUDE` | unset | Comma-separated paths/directory names to skip in a `--research` run, on top of the built-in `docs/archive` default. Bare names (e.g. `harmony.rs`) match at any depth; paths with a slash (e.g. `docs/archive`) match that subtree only. |
 
 ## Tokens (per-tool)
 

--- a/docs/research.md
+++ b/docs/research.md
@@ -82,6 +82,35 @@ also refuses and points you at its `REPORT.md`.
 | `CLAUDETTE_RESEARCH_DIR` | `~/.claudette/research/<repo>-<date>/` | Output directory override (used as-is; must be outside the target tree). |
 | `CLAUDETTE_RESEARCH_MAX_BATCHES` | unlimited | Stop after N batches — smoke tests / partial runs. A capped run stays in the batches phase; re-running continues it. |
 | `CLAUDETTE_RESEARCH_BATCH_FILES` | `3` | Max files per review batch (clamped `1`–`8`). |
+| `CLAUDETTE_RESEARCH_EXCLUDE` | unset | Extra paths/dir names to skip, added to the `docs/archive` default. |
+
+## Scoping the review
+
+Gitignored paths (`.gitignore`, `.git/info/exclude`, hidden files) never reach
+the manifest. Beyond that, `docs/archive/` is excluded by default — archived
+docs are stale by design, and reviewing them just produces `docs-drift` findings
+against files nobody maintains. Add your own exclusions with
+`CLAUDETTE_RESEARCH_EXCLUDE`:
+
+```sh
+CLAUDETTE_RESEARCH_EXCLUDE=vendor,generated,harmony.rs claudette --research
+```
+
+An entry with a slash (`docs/archive`, `crates/foo/src/api`) is anchored at the
+repo root and matches exactly that path or the subtree beneath it; a bare name
+(`vendor`, `harmony.rs`) matches a directory or file of that name at *any* depth
+— but not a longer name that merely starts with it (`archive` never touches
+`archive.rs`). Excluded files are recorded in
+`manifest.json` and counted in the `FINDINGS.md` header, never silently dropped.
+To review something that lives under a default exclude, scope the whole run to
+that subtree with `CLAUDETTE_WORKSPACE=<subtree>` instead.
+
+Some source files are worth excluding for a different reason: a file dense with
+chat-template control tokens (`<|channel|>`, `<|end|>`, …) — for example a
+Harmony/Qwen separator-stripping utility that embeds those tokens in its doc
+comments and tests — reliably provokes content-less generation when the reviewer
+reads it, wasting retries. The run prints a warning naming any such file at
+startup; exclude it if the flake cost outweighs the coverage.
 
 ## Backend hiccups
 


### PR DESCRIPTION
## What

Deep-research (`--research`) gains two scope-control levers, addressing loose ends from the R6 validation campaign.

### 1. Exclude knob + conservative default
- `CLAUDETTE_RESEARCH_EXCLUDE` — comma-separated paths / directory names to skip, additive to a built-in `docs/archive` default (archived docs are stale by design; reviewing them just yields `docs-drift` findings against unmaintained files).
- Match rules: a **slash-entry** (`docs/archive`) is root-anchored (that path/subtree only, so it can't swallow a real `src/archive/` module); a **bare name** (`vendor`, `harmony.rs`) matches a dir/file of that name at any depth, but not a longer segment (`archive` never touches `archive.rs`).
- Excluded files are **recorded** in `manifest.json` (`skipped`, reason `"excluded"`) and counted in the `FINDINGS.md` header — never silently dropped, so coverage stays honest.

### 2. Control-token warning
The run warns at startup about files dense with chat-template control tokens (`<|channel|>`, `<|end|>`, …). These reliably provoke content-less generation when the reviewer reads them — `api/harmony.rs` is the reproducible case (it *strips* those tokens, so it embeds them verbatim). Warn-only: the file is real source, so the operator decides whether to exclude it. No batch-planner change (harmony.rs is already a solo batch).

## How
- Real builder renamed `build_manifest_with_excludes(root, mbf, excludes)`; the 2-arg `build_manifest` is now a `#[cfg(test)]` wrapper (zero churn to existing test call sites).
- `Manifest` gains `flagged_control_tokens: Vec<String>` (`#[serde(default, skip_serializing_if = "Vec::is_empty")]` — old manifests load; not part of the resume hash).

## Tests / gate
- +5 pure tests (parse, path matching, token detection, excluded-recorded, flagged).
- `cargo fmt` · `clippy --all-targets --all-features -D warnings` · `cargo test` 1091/0 · `--all-features` 1178/0.
- Behavioral smoke on this repo: default run 148→140 files / 84→81 batches (8 `docs/archive/` excluded); `CLAUDETTE_RESEARCH_EXCLUDE=harmony.rs` → 139 files, harmony absent from `files[]` and the flagged list.