### PR TITLE
fix(test): serialise secrets env-race that flaked read_secret_file_fallback on CI

### DIFF
--- a/crates/claudette/src/secrets.rs
+++ b/crates/claudette/src/secrets.rs
@@ -330,7 +330,9 @@ mod tests {
     #[test]
     fn read_secret_picks_up_env_var() {
         // Test the short-form env var path. Use a unique name so we don't
-        // collide with real tokens.
+        // collide with real tokens. Hold the env lock so our `set_var` can't
+        // race a sibling test's `with_temp_home` HOME swap.
+        let _lock = crate::test_env_lock();
         let var_name = "ZZZTESTUNIQUE42_TOKEN";
         std::env::set_var(var_name, "test-token-value");
         let result = read_secret("zzztestunique42");
@@ -340,6 +342,7 @@ mod tests {
 
     #[test]
     fn read_secret_trims_whitespace() {
+        let _lock = crate::test_env_lock();
         let var_name = "ZZZTESTTRIM99_TOKEN";
         std::env::set_var(var_name, "  spaced-token  \n");
         let result = read_secret("zzztesttrim99");
@@ -349,6 +352,7 @@ mod tests {
 
     #[test]
     fn read_secret_rejects_empty_env_var() {
+        let _lock = crate::test_env_lock();
         let var_name = "ZZZTESTEMPTY77_TOKEN";
         std::env::set_var(var_name, "   ");
         let result = read_secret("zzztestempty77");
@@ -358,15 +362,20 @@ mod tests {
 
     #[test]
     fn read_secret_file_fallback() {
-        // Write a temp token file and verify it's picked up.
-        let dir = secrets_dir();
-        let _ = std::fs::create_dir_all(&dir);
-        let path = dir.join("zzztestfile88.token");
-        std::fs::write(&path, "file-based-token\n").unwrap();
+        // Write a temp token file and verify it's picked up. Runs under an
+        // isolated temp HOME (which holds `test_env_lock` for the closure) so a
+        // sibling test swapping HOME can't move `secrets_dir()` between our
+        // write and our read — the race that previously flaked this on CI.
+        crate::with_temp_home(|_home| {
+            let dir = secrets_dir();
+            let _ = std::fs::create_dir_all(&dir);
+            let path = dir.join("zzztestfile88.token");
+            std::fs::write(&path, "file-based-token\n").unwrap();
 
-        let result = read_secret("zzztestfile88");
-        let _ = std::fs::remove_file(&path);
-        assert_eq!(result.unwrap(), "file-based-token");
+            let result = read_secret("zzztestfile88");
+            let _ = std::fs::remove_file(&path);
+            assert_eq!(result.unwrap(), "file-based-token");
+        });
     }
 
     #[cfg(not(unix))]


### PR DESCRIPTION
## Problem

Main's `test (ubuntu-latest)` job went red on the R7 merge commit — the `--all-features` run failed `secrets::tests::read_secret_file_fallback` (panic at `secrets.rs:369`). The default (non-all-features) run passed 1095/0, and the failure is unrelated to R7.

## Root cause

`read_secret_file_fallback` writes a token file to `secrets_dir()` (= `env_config::home_dir()/.claudette/secrets`) and then reads it back via `read_secret`, which recomputes `secrets_dir()`. It held **no env lock**. The sibling tests `load_chat_ids_empty_when_no_file` and `save_and_load_chat_id_roundtrip` call `with_temp_home()`, which swaps `HOME`/`USERPROFILE` under `test_env_lock`. When those ran concurrently, the write landed in the real home's secrets dir while the read looked in the temp home (or vice-versa) → file not found → `unwrap()` panic. Same env-race class as the prior `#198` / `google_auth` flakes.

## Fix

- Run `read_secret_file_fallback` inside `with_temp_home(...)` — isolates `HOME` and holds `test_env_lock` for the whole closure, so `secrets_dir()` is stable across the write and the read.
- Take `test_env_lock()` in the three env-var-setting secrets tests (`read_secret_picks_up_env_var`, `read_secret_trims_whitespace`, `read_secret_rejects_empty_env_var`) so their `set_var` can't race the `with_temp_home` HOME swap at the process-global env table.

No production code changed — test-only serialisation.

## Verified

`cargo fmt` · `clippy --all-targets --all-features -D warnings` · `secrets::` tests 3× under `--all-features` (stable) · full `--all-features` suite 1178/0.