### PR TITLE
fix: the four things a new user hits before Claudette works

### DIFF
--- a/crates/claudette/src/brain_selector.rs
+++ b/crates/claudette/src/brain_selector.rs
@@ -65,18 +65,125 @@ impl StuckReason {
     }
 }
 
-/// Iteration-count heuristic for the "no text at max iter" signal. If the
-/// primary runtime ran at least this many iterations AND produced no text,
-/// treat it as stuck. `11` is two short of the configured `max_iterations
-/// = 15` in `build_runtime_with_brain` — catches the real stalls
-/// (long tool chains that never emit final text) without firing on
-/// ordinary single-tool turns.
-const MAX_ITER_STUCK_THRESHOLD: usize = 11;
+/// How far short of the iteration cap the "no text at max iter" signal
+/// fires. The intent has always been "nearly out of iterations and still
+/// nothing to say", expressed as a margin below the cap rather than an
+/// absolute count — the original `11` was written against
+/// `max_iterations = 15` and silently became a 27%-of-budget tripwire when
+/// the cap moved to 40, diagnosing ordinary long tool chains as stalls and
+/// replaying them wholesale on the bigger brain.
+const MAX_ITER_STUCK_MARGIN: usize = 4;
+
+/// Absolute floor for the stuck threshold, so a small `CLAUDETTE_MAX_ITERATIONS`
+/// can't drive it down to "escalate on the second tool call".
+const MAX_ITER_STUCK_FLOOR: usize = 11;
+
+/// Iteration count at or above which a text-free turn counts as stuck,
+/// derived from the cap actually in force.
+fn max_iter_stuck_threshold() -> usize {
+    crate::run::max_iterations()
+        .saturating_sub(MAX_ITER_STUCK_MARGIN)
+        .max(MAX_ITER_STUCK_FLOOR)
+}
 
 /// Minimum streak of consecutive `is_error` tool results before we treat
 /// it as "the brain can't recover". Three is the threshold the Sprint 14
 /// plan locked in — two in a row happens during normal path-guessing.
 const TOOL_ERROR_STREAK_THRESHOLD: usize = 3;
+
+/// Why an otherwise-configured fallback brain was not used for this turn.
+///
+/// The tiered-brain design assumes Ollama on a small card: escalating pulls
+/// a second model into memory for one turn, then evicts it. That assumption
+/// breaks badly on the setup the README now recommends for 16 GB — LM Studio
+/// with one large model resident — because escalating asks the server to
+/// JIT-load a *second* model, which evicts the brain the user deliberately
+/// loaded. `~/.claudette/models.toml` does not exist on a fresh install, so
+/// `Preset::Auto` supplies `fallback_brain = qwen3.5:9b` to every new user
+/// whether or not they have ever heard of it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FallbackSkip {
+    /// The fallback resolves to the same model as the primary. Escalating
+    /// would replay the whole turn against an identical brain for an
+    /// identical result, at double the latency.
+    SameAsPrimary,
+    /// The backend does not serve the fallback model. Escalating would make
+    /// the server fetch it: a JIT load (LM Studio — evicts the resident
+    /// model) or a multi-gigabyte pull (Ollama). Neither is something to do
+    /// behind the user's back mid-turn.
+    NotServed,
+}
+
+impl FallbackSkip {
+    fn explain(self, fallback: &str) -> String {
+        match self {
+            FallbackSkip::SameAsPrimary => {
+                format!("fallback brain '{fallback}' is the same model as the primary")
+            }
+            FallbackSkip::NotServed => {
+                format!("fallback brain '{fallback}' is not loaded on the backend")
+            }
+        }
+    }
+}
+
+/// Decide whether escalation must be skipped. Pure — `served` is passed in
+/// so this is unit-testable with no backend in the loop.
+///
+/// `served == None` (probe failed) and `served == Some(&[])` (backend
+/// answered but listed nothing) both mean "can't tell", and both fail
+/// **open**: an unreachable probe must not silently disable a working
+/// fallback. The startup probe already refuses to launch against an
+/// LM Studio with no model loaded, so the empty case is not load-bearing
+/// here.
+fn fallback_skip_reason(
+    primary: &str,
+    fallback: &str,
+    served: Option<&[String]>,
+) -> Option<FallbackSkip> {
+    // Reuse doctor's loose matcher so `qwen3.5:9b` and `qwen3.5:9b:latest`
+    // count as the same model on both sides of the comparison.
+    if crate::doctor::model_present(&[primary.to_string()], fallback) {
+        return Some(FallbackSkip::SameAsPrimary);
+    }
+    match served {
+        Some(names) if !names.is_empty() && !crate::doctor::model_present(names, fallback) => {
+            Some(FallbackSkip::NotServed)
+        }
+        _ => None,
+    }
+}
+
+/// Model ids the backend is currently serving, fetched once per process.
+///
+/// Cached because this sits on the escalation path, which can fire on many
+/// turns in a row. A cache that goes stale mid-session can only produce a
+/// *skipped* escalation, never a surprise model load — the safe direction.
+fn served_model_names() -> Option<&'static Vec<String>> {
+    static CACHE: std::sync::OnceLock<Option<Vec<String>>> = std::sync::OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let openai_compat = crate::api::resolve_openai_compat();
+            let base = crate::api::resolve_ollama_url();
+            let url = if openai_compat {
+                format!("{base}/v1/models")
+            } else {
+                format!("{base}/api/tags")
+            };
+            let client = reqwest::blocking::Client::builder()
+                .timeout(std::time::Duration::from_secs(4))
+                .build()
+                .ok()?;
+            let body = client
+                .get(&url)
+                .send()
+                .ok()?
+                .json::<serde_json::Value>()
+                .ok()?;
+            Some(crate::doctor::extract_model_names(&body, openai_compat))
+        })
+        .as_ref()
+}
 
 /// Run a turn with automatic 4b → fallback → revert escalation.
 ///
@@ -100,16 +207,29 @@ pub fn run_turn_with_fallback(
         return run_turn_with_retry(runtime, input, prompter_reborrow(prompter));
     };
 
-    // Snapshot BEFORE letting the primary mutate the session. If we
-    // escalate, we rewind from here so the fallback doesn't see a
-    // duplicated user message or a stuck assistant turn.
-    let pre_turn_session: Session = runtime.session().clone();
-
     // Capture the primary model name BEFORE the turn — the same value the
     // runtime was built against, and the one we want to record in the
     // fallback log. The active config is the source of truth because
     // `ConversationRuntime` doesn't expose its api_client.
     let primary_model = model_config::active().brain.model.clone();
+
+    // Decide up front whether escalation is even usable. Doing it here — and
+    // not at the stuck-signal site — means an unusable fallback also skips
+    // the pre-turn session clone below, so the passthrough stays as cheap as
+    // the no-fallback-configured path.
+    if let Some(skip) = fallback_skip_reason(
+        &primary_model,
+        &fallback_cfg.model,
+        served_model_names().map(Vec::as_slice),
+    ) {
+        warn_fallback_disabled_once(skip, &fallback_cfg.model);
+        return run_turn_with_retry(runtime, input, prompter_reborrow(prompter));
+    }
+
+    // Snapshot BEFORE letting the primary mutate the session. If we
+    // escalate, we rewind from here so the fallback doesn't see a
+    // duplicated user message or a stuck assistant turn.
+    let pre_turn_session: Session = runtime.session().clone();
 
     // Scope each reborrow to a short-lived block so its lifetime ends
     // before the next `run_turn_with_retry` call needs a fresh one.
@@ -160,6 +280,22 @@ pub fn run_turn_with_fallback(
     fallback_result
 }
 
+/// Tell the user once per process that the configured fallback brain is
+/// inert, and how to silence it. Once, not per turn: this fires on the
+/// escalation path, which a genuinely struggling model can hit repeatedly,
+/// and a repeated warning would bury the turn output it is attached to.
+fn warn_fallback_disabled_once(skip: FallbackSkip, fallback: &str) {
+    static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    eprintln!(
+        "  \u{25B8} tiered brain off: {reason} — staying on the primary. \
+         Set CLAUDETTE_FALLBACK_BRAIN_MODEL to a loaded model, or /preset fast to silence this.",
+        reason = skip.explain(fallback),
+    );
+}
+
 /// Inspect a primary-brain turn result for stuck signals. Returns `Some`
 /// if the fallback should fire. Pure function — no side effects, so it
 /// can be unit-tested without a real Ollama in the loop.
@@ -181,7 +317,7 @@ fn diagnose_summary(summary: &TurnSummary) -> Option<StuckReason> {
         return None;
     }
     let text_blocks = count_text_blocks(&summary.assistant_messages);
-    if text_blocks == 0 && summary.iterations >= MAX_ITER_STUCK_THRESHOLD {
+    if text_blocks == 0 && summary.iterations >= max_iter_stuck_threshold() {
         return Some(StuckReason::NoTextAtMaxIter);
     }
     if max_consecutive_tool_errors(&summary.tool_results) >= TOOL_ERROR_STREAK_THRESHOLD {
@@ -420,6 +556,59 @@ mod tests {
         }
     }
 
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn fallback_to_the_same_model_is_skipped() {
+        assert_eq!(
+            fallback_skip_reason("qwen3.5:9b", "qwen3.5:9b", None),
+            Some(FallbackSkip::SameAsPrimary),
+        );
+        // The loose matcher makes the `:latest` spelling the same model too.
+        assert_eq!(
+            fallback_skip_reason("qwen3.5:9b", "qwen3.5:9b:latest", None),
+            Some(FallbackSkip::SameAsPrimary),
+        );
+    }
+
+    #[test]
+    fn fallback_not_loaded_on_the_backend_is_skipped() {
+        // The shipped hazard: a fresh install has no ~/.claudette/models.toml,
+        // so Preset::Auto hands every new user fallback_brain = qwen3.5:9b.
+        // On the 16 GB LM Studio setup the README recommends, escalating
+        // would JIT-load a second model and evict the resident champion.
+        let served = names(&["qwen3.6-35b-a3b-mtp"]);
+        assert_eq!(
+            fallback_skip_reason("qwen3.6-35b-a3b-mtp", "qwen3.5:9b", Some(&served)),
+            Some(FallbackSkip::NotServed),
+        );
+    }
+
+    #[test]
+    fn fallback_that_is_loaded_still_escalates() {
+        // A user who deliberately loaded both models wants the tiered brain.
+        let served = names(&["qwen3.5:4b", "qwen3.5:9b"]);
+        assert_eq!(
+            fallback_skip_reason("qwen3.5:4b", "qwen3.5:9b", Some(&served)),
+            None,
+        );
+    }
+
+    #[test]
+    fn unknown_backend_inventory_fails_open() {
+        // A probe that failed (None) or answered with nothing (empty) must
+        // not silently disable a working fallback — the safe default here is
+        // the previous behavior, since the caller only reaches this path
+        // after a real stuck signal.
+        assert_eq!(fallback_skip_reason("qwen3.5:4b", "qwen3.5:9b", None), None);
+        assert_eq!(
+            fallback_skip_reason("qwen3.5:4b", "qwen3.5:9b", Some(&[])),
+            None,
+        );
+    }
+
     #[test]
     fn diagnose_empty_response_from_err_message() {
         let r: Result<TurnSummary, String> = Err("no content in response".to_string());
@@ -444,16 +633,65 @@ mod tests {
         assert_eq!(diagnose(&Ok(summary)), None);
     }
 
+    // These pin the *relationship* to the iteration cap, not a magic number.
+    // Hardcoding `13`/`8` is what let the threshold rot: they were written
+    // against `max_iterations = 15` and kept passing after the cap moved to
+    // 40, while the production heuristic had quietly become a 27%-of-budget
+    // tripwire.
     #[test]
     fn diagnose_empty_text_at_max_iter_escalates() {
-        let summary = make_summary(vec![], vec![], 13);
+        let summary = make_summary(vec![], vec![], max_iter_stuck_threshold());
         assert_eq!(diagnose(&Ok(summary)), Some(StuckReason::NoTextAtMaxIter));
     }
 
     #[test]
     fn diagnose_empty_text_under_threshold_does_not_escalate() {
-        let summary = make_summary(vec![], vec![], 8);
+        let summary = make_summary(vec![], vec![], max_iter_stuck_threshold() - 1);
         assert_eq!(diagnose(&Ok(summary)), None);
+    }
+
+    #[test]
+    fn stuck_threshold_tracks_the_iteration_cap() {
+        let _guard = crate::test_env_lock();
+        let prev = std::env::var("CLAUDETTE_MAX_ITERATIONS").ok();
+
+        std::env::set_var("CLAUDETTE_MAX_ITERATIONS", "40");
+        assert_eq!(max_iter_stuck_threshold(), 36, "cap 40 - margin 4");
+
+        std::env::set_var("CLAUDETTE_MAX_ITERATIONS", "15");
+        assert_eq!(
+            max_iter_stuck_threshold(),
+            11,
+            "the historical cap/threshold pair"
+        );
+
+        // The floor keeps a tiny cap from turning the heuristic into
+        // "escalate on the second tool call".
+        std::env::set_var("CLAUDETTE_MAX_ITERATIONS", "6");
+        assert_eq!(max_iter_stuck_threshold(), MAX_ITER_STUCK_FLOOR);
+
+        match prev {
+            Some(v) => std::env::set_var("CLAUDETTE_MAX_ITERATIONS", v),
+            None => std::env::remove_var("CLAUDETTE_MAX_ITERATIONS"),
+        }
+    }
+
+    #[test]
+    fn long_legitimate_tool_chain_is_not_diagnosed_as_stuck_at_the_default_cap() {
+        // The regression this fix exists for: a 12-round tool chain that
+        // hasn't emitted text yet is ordinary work at a cap of 40, but the
+        // frozen `11` diagnosed it as a stall and replayed the entire turn
+        // on the bigger brain — a 5-10s model swap plus a full re-run.
+        let _guard = crate::test_env_lock();
+        let prev = std::env::var("CLAUDETTE_MAX_ITERATIONS").ok();
+        std::env::remove_var("CLAUDETTE_MAX_ITERATIONS");
+
+        let summary = make_summary(vec![], vec![], 12);
+        assert_eq!(diagnose(&Ok(summary)), None);
+
+        if let Some(v) = prev {
+            std::env::set_var("CLAUDETTE_MAX_ITERATIONS", v);
+        }
     }
 
     #[test]
@@ -463,7 +701,7 @@ mod tests {
                 text: "   \n ".into(),
             }],
             vec![],
-            12,
+            max_iter_stuck_threshold(),
         );
         assert_eq!(diagnose(&Ok(summary)), Some(StuckReason::NoTextAtMaxIter));
     }

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -70,11 +70,11 @@ struct CliArgs {
     /// previous "run --telegram and accidentally expose the bot to
     /// anyone who guesses the username" footgun.
     allow_any_chat: bool,
-    /// `--forge`: run the trailing prompt in forge-mode inside the active
-    /// brownfield mission. Errors if no mission is active. v0a is single-
-    /// stage: one model turn against a pre-enabled toolset, ending at
-    /// `mission_submit` (auto-PR). The prompt text is taken from
-    /// `prompt_words`.
+    /// `--forge`: run the trailing prompt through the forge pipeline
+    /// (v0c: Planner → Coder → Verifier → fix-loop → Submitter, with a real
+    /// build+test gate each round). Uses the active brownfield mission, or
+    /// auto-bootstraps an ephemeral one in the current repo when there is
+    /// none. The prompt text is taken from `prompt_words`.
     forge: bool,
     /// `--doctor`: run flat diagnostic probes (Ollama reachable, brain
     /// pulled, recall embed model loaded, OAuth tokens valid, voice deps,
@@ -90,6 +90,71 @@ struct CliArgs {
     /// conversation, findings checkpointed to `~/.claudette/research/`).
     /// Trailing prompt words become an optional focus hint. Forces offline.
     research: bool,
+    /// Args that look like flags but match nothing. Collected rather than
+    /// swallowed into `prompt_words`: before this, `claudette --setpu` sent
+    /// "--setpu" to the model as a prompt and printed a chatty reply, so a
+    /// typo in the one command new users are told to run looked like the
+    /// tool working. `main()` reports these and exits 2.
+    unknown_flags: Vec<String>,
+}
+
+/// Every flag `parse_args` accepts, for the unknown-flag "did you mean".
+/// Kept next to the parser so a new flag that misses this list only costs a
+/// suggestion, never a false rejection — the match arms remain the single
+/// source of truth for what is actually accepted.
+const KNOWN_FLAGS: &[&str] = &[
+    "--help",
+    "-h",
+    "--version",
+    "-V",
+    "--resume",
+    "-r",
+    "--telegram",
+    "-t",
+    "--tui",
+    "--chat",
+    "--auth-google",
+    "--revoke",
+    "--briefing",
+    "--time",
+    "--days",
+    "--forge",
+    "--doctor",
+    "--setup",
+    "--research",
+    "--faceless",
+    "--offline",
+];
+
+/// True when `arg` should be read as a flag rather than prompt text.
+///
+/// Deliberately narrow, because the prompt is positional and a false
+/// positive would reject legitimate input: a token only counts as a flag if
+/// it starts with `-`, has something after the dash, contains no whitespace
+/// (`"--wat is this"` is one quoted prompt word, not a flag), and is not a
+/// negative number (`-5` in an unquoted arithmetic prompt).
+fn looks_like_flag(arg: &str) -> bool {
+    arg.starts_with('-')
+        && arg.len() > 1
+        && !arg.contains(char::is_whitespace)
+        && arg.parse::<f64>().is_err()
+}
+
+/// Closest known flags to `unknown`, nearest first, capped at 2. Uses the
+/// same Levenshtein the permission layer uses for tool-name suggestions.
+///
+/// Distance 2 covers the realistic typo classes — one transposition
+/// (`--setpu`, `--reserach`), one dropped or doubled char (`--offlin`), one
+/// substitution (`--docter`) — while keeping unrelated flags out. At 3,
+/// `--setpu` also "suggested" `--help`, which is noise dressed as help.
+fn suggest_flags(unknown: &str) -> Vec<&'static str> {
+    let mut scored: Vec<(u32, &'static str)> = KNOWN_FLAGS
+        .iter()
+        .map(|f| (claudette::permissions::levenshtein(unknown, f), *f))
+        .filter(|(d, _)| *d <= 2)
+        .collect();
+    scored.sort_by_key(|(d, f)| (*d, *f));
+    scored.into_iter().take(2).map(|(_, f)| f).collect()
 }
 
 /// Help text printed on `--help` / `-h`. One source of truth; the README
@@ -112,11 +177,14 @@ MODES (pick one; default is interactive REPL):
                          (Chat / Tools / Notes / Todos / HW tabs). Demo-only:
                          has known rendering rough edges (doubled text, tool
                          pane, footer). The REPL is the supported daily driver.
-    --forge \"<prompt>\"   Run the prompt in forge-mode inside the active
-                         brownfield mission. Errors if no mission is active —
-                         start one with /brownfield <repo> first. v0a runs a
-                         single brain turn with file/search/git/advanced/github
-                         tools pre-enabled and exits at mission_submit (auto-PR).
+    --forge \"<prompt>\"   Run the prompt through the autonomous forge pipeline:
+                         Planner -> Coder -> Verifier -> fix-loop -> Submitter.
+                         The Verifier builds and runs the real test suite each
+                         round, so a diff that breaks the build or a test can't
+                         pass. Runs in the active brownfield mission, or
+                         bootstraps a throwaway one in the current repo if
+                         there is none. You approve the plan and the full diff
+                         before any PR opens.
     --research [FOCUS]   Unattended read-only review of the repo (CLAUDETTE_
                          WORKSPACE or the git toplevel). Writes a findings
                          report to ~/.claudette/research/. Forces --offline.
@@ -228,6 +296,26 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    // ── Unknown flags ─────────────────────────────────────────────────
+    // After --help/--version so those still work alongside a typo, but
+    // before every subsystem: a mistyped flag must never reach the model
+    // as prompt text.
+    if !args.unknown_flags.is_empty() {
+        for flag in &args.unknown_flags {
+            eprintln!("{} unknown option: {flag}", theme::warn(theme::WARN_GLYPH));
+            let suggestions = suggest_flags(flag);
+            if !suggestions.is_empty() {
+                eprintln!("  ↳ did you mean {}?", suggestions.join(" or "));
+            }
+        }
+        eprintln!("  ↳ `claudette --help` lists every option.");
+        eprintln!(
+            "  ↳ to send this text to the model, quote it or use `--`: claudette -- {}",
+            args.unknown_flags.join(" ")
+        );
+        return ExitCode::from(2);
+    }
+
     // ── Workspace-roots startup probe ─────────────────────────────────
     // Catches the 2026-04-28 wrapper-forgot-CLAUDETTE_WORKSPACE class of
     // bug at startup rather than first read attempt. Prints to stderr
@@ -260,6 +348,8 @@ fn main() -> ExitCode {
         doctor,
         setup,
         research,
+        // Already consumed above: a non-empty list exits 2 before we get here.
+        unknown_flags: _,
     } = args;
 
     // ── Offline-mode banner ───────────────────────────────────────────
@@ -503,6 +593,9 @@ fn main() -> ExitCode {
 fn parse_args(args: &[String]) -> CliArgs {
     let mut out = CliArgs::default();
     let mut expect = ExpectNext::Nothing;
+    // Set by a bare `--`: everything after it is prompt text, even if it
+    // starts with a dash.
+    let mut end_of_flags = false;
 
     // Also check env var for chat IDs. The literal string "any" (any
     // casing) sets the accept-all sentinel, identical to `--chat any`.
@@ -557,6 +650,10 @@ fn parse_args(args: &[String]) -> CliArgs {
             }
             ExpectNext::Nothing => {}
         }
+        if end_of_flags {
+            out.prompt_words.push(arg.clone());
+            continue;
+        }
         match arg.as_str() {
             "--help" | "-h" => out.help = true,
             "--version" | "-V" => out.version = true,
@@ -589,6 +686,10 @@ fn parse_args(args: &[String]) -> CliArgs {
                 // `CLAUDETTE_OFFLINE=1`. See `egress.rs`.
                 std::env::set_var(claudette::egress::OFFLINE_ENV, "1");
             }
+            // `--` ends flag parsing, POSIX-style, so a prompt that really
+            // does start with a dash stays reachable: `claudette -- --tui`.
+            "--" => end_of_flags = true,
+            other if looks_like_flag(other) => out.unknown_flags.push(other.to_string()),
             _ => out.prompt_words.push(arg.clone()),
         }
     }
@@ -895,6 +996,67 @@ mod tests {
             std::env::set_var("CLAUDETTE_TELEGRAM_CHAT", v);
         }
         out
+    }
+
+    #[test]
+    fn parse_args_typo_flag_is_rejected_not_sent_to_the_model() {
+        // The regression: `claudette --setpu` used to push "--setpu" into
+        // prompt_words, so a typo in the first command new users are told to
+        // run produced a chatty model reply instead of an error.
+        let a = parse_args_clean(&["--setpu".into()]);
+        assert_eq!(a.unknown_flags, vec!["--setpu".to_string()]);
+        assert!(a.prompt_words.is_empty());
+        assert!(!a.setup);
+    }
+
+    #[test]
+    fn suggest_flags_finds_the_intended_flag() {
+        assert!(suggest_flags("--setpu").contains(&"--setup"));
+        assert!(suggest_flags("--reserach").contains(&"--research"));
+        assert!(suggest_flags("--offlin").contains(&"--offline"));
+        assert!(suggest_flags("--docter").contains(&"--doctor"));
+        // Nothing close enough: better to say nothing than to guess wildly.
+        assert!(suggest_flags("--zzzzzzzzzzzz").is_empty());
+    }
+
+    #[test]
+    fn parse_args_double_dash_ends_flag_parsing() {
+        // The escape hatch the error message points at, so a prompt that
+        // genuinely starts with a dash is still reachable.
+        let a = parse_args_clean(&["--".into(), "--tui".into(), "means".into()]);
+        assert!(!a.tui, "--tui after -- is prompt text, not a flag");
+        assert!(a.unknown_flags.is_empty());
+        assert_eq!(
+            a.prompt_words,
+            vec!["--tui".to_string(), "means".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_args_does_not_mistake_prompt_text_for_flags() {
+        // A quoted prompt containing a dash, and unquoted negative numbers,
+        // must stay prompt text — a false positive here would reject valid
+        // input, which is worse than the bug being fixed.
+        let a = parse_args_clean(&["--wat is this".into(), "-5".into(), "-".into()]);
+        assert!(
+            a.unknown_flags.is_empty(),
+            "got unexpected unknown flags: {:?}",
+            a.unknown_flags
+        );
+        assert_eq!(a.prompt_words.len(), 3);
+    }
+
+    #[test]
+    fn parse_args_known_flags_list_matches_the_parser() {
+        // Guard against KNOWN_FLAGS drifting from the match arms: every
+        // listed flag must actually parse without landing in unknown_flags.
+        for flag in KNOWN_FLAGS {
+            let a = parse_args_clean(&[(*flag).to_string()]);
+            assert!(
+                a.unknown_flags.is_empty(),
+                "{flag} is in KNOWN_FLAGS but the parser rejects it"
+            );
+        }
     }
 
     #[test]

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -56,6 +56,11 @@ pub(crate) use runtime_build::{
 
 // Interactive agent REPL loop. Extracted to `run/repl.rs` (Wave C6);
 // re-exported so `lib.rs` / `main.rs` keep resolving `run::run_agent_repl`.
+// REPL line editing (history, arrows, tab completion). Split out of
+// `repl.rs` so the editing rules are a pure, unit-testable state machine
+// rather than logic tangled with the turn loop.
+mod line_editor;
+
 mod repl;
 pub use repl::run_agent_repl;
 

--- a/crates/claudette/src/run/line_editor.rs
+++ b/crates/claudette/src/run/line_editor.rs
@@ -1,0 +1,724 @@
+//! Line editing for the REPL prompt.
+//!
+//! Before this, `run/repl.rs` read input with a bare `stdin().read_line`,
+//! so pressing Up in the first thirty seconds of using Claudette printed
+//! `^[[A` — the single loudest "this is unpolished" signal in the product,
+//! and invisible in the docs.
+//!
+//! Built on `crossterm`, which is already an unconditional dependency (the
+//! TUI uses it), rather than pulling in `rustyline`/`reedline`: a new
+//! dependency here would have to clear `deny.toml`'s license allow-list and
+//! duplicate-version bans for a feature this size.
+//!
+//! Design: [`LineState`] is a pure state machine over ([`EditAction`],
+//! buffer, cursor) with no terminal in sight, so every editing rule is unit
+//! testable. The terminal loop in [`LineEditor::read_line`] does nothing but
+//! translate key events into actions and redraw.
+//!
+//! **Non-TTY input falls back to plain `read_line`.** This is load-bearing,
+//! not a nicety: the eval battery runs `claudette "<prompt>" < /dev/null`,
+//! CI pipes input, and `--research` runs unattended. Raw mode on a
+//! non-terminal would break all three.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::PathBuf;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::{cursor, queue, style, terminal};
+
+/// Max history entries kept in memory and on disk. Generous enough to cover
+/// a long session, small enough that the file stays trivial to read and
+/// rewrite wholesale.
+const MAX_HISTORY: usize = 500;
+
+/// Every slash command the REPL accepts, for Tab completion. Aliases are
+/// included because completing `/cl` to `/clear` should work as readily as
+/// completing `/cle`.
+const SLASH_COMMANDS: &[&str] = &[
+    "/brain",
+    "/brownfield",
+    "/capabilities",
+    "/clear",
+    "/compact",
+    "/cost",
+    "/diff",
+    "/exit",
+    "/forge",
+    "/help",
+    "/load",
+    "/memory",
+    "/mission_exit",
+    "/model",
+    "/models",
+    "/preset",
+    "/recall",
+    "/reload",
+    "/save",
+    "/sessions",
+    "/status",
+    "/tools",
+    "/undo",
+];
+
+/// One editing operation. Deliberately terminal-agnostic so the state
+/// machine can be driven from tests without a tty.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EditAction {
+    Insert(char),
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Home,
+    End,
+    /// Delete the word before the cursor (Ctrl+W).
+    DeleteWordBack,
+    /// Discard everything before the cursor (Ctrl+U).
+    KillToStart,
+    /// Discard everything from the cursor on (Ctrl+K).
+    KillToEnd,
+    HistoryPrev,
+    HistoryNext,
+    /// Tab: complete a leading slash command.
+    Complete,
+    Submit,
+    /// Ctrl+C: abandon this line, keep the REPL running.
+    Cancel,
+    /// Ctrl+D on an empty line: end of input.
+    Eof,
+    Noop,
+}
+
+/// What [`LineState::apply`] wants the caller to do next.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EditOutcome {
+    /// Keep editing; redraw.
+    Continue,
+    /// The user pressed Enter — take the buffer.
+    Submit,
+    /// The user pressed Ctrl+C — drop the buffer, prompt again.
+    Cancel,
+    /// The user pressed Ctrl+D on an empty line — the REPL should exit.
+    Eof,
+}
+
+/// Buffer + cursor + history cursor. `cursor` is a **character** index, not
+/// a byte offset, so multi-byte input (Hebrew, emoji, CJK) can't split a
+/// char or panic on a byte boundary.
+#[derive(Debug, Default)]
+pub(crate) struct LineState {
+    pub(crate) buf: String,
+    pub(crate) cursor: usize,
+    /// Position in history while browsing: `None` = editing a fresh line.
+    history_idx: Option<usize>,
+    /// The in-progress line stashed when history browsing started, so
+    /// Down past the newest entry restores what you were typing.
+    stash: String,
+}
+
+impl LineState {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn char_count(&self) -> usize {
+        self.buf.chars().count()
+    }
+
+    /// Byte offset of character index `idx`. `idx == char_count` yields the
+    /// buffer length, so this is safe to use as a splice point.
+    fn byte_of(&self, idx: usize) -> usize {
+        self.buf
+            .char_indices()
+            .nth(idx)
+            .map_or(self.buf.len(), |(b, _)| b)
+    }
+
+    /// Apply one action. Returns what the caller should do next.
+    pub(crate) fn apply(&mut self, action: EditAction, history: &[String]) -> EditOutcome {
+        match action {
+            EditAction::Insert(c) => {
+                let at = self.byte_of(self.cursor);
+                self.buf.insert(at, c);
+                self.cursor += 1;
+            }
+            EditAction::Backspace => {
+                if self.cursor > 0 {
+                    let from = self.byte_of(self.cursor - 1);
+                    let to = self.byte_of(self.cursor);
+                    self.buf.replace_range(from..to, "");
+                    self.cursor -= 1;
+                }
+            }
+            EditAction::Delete => {
+                if self.cursor < self.char_count() {
+                    let from = self.byte_of(self.cursor);
+                    let to = self.byte_of(self.cursor + 1);
+                    self.buf.replace_range(from..to, "");
+                }
+            }
+            EditAction::Left => self.cursor = self.cursor.saturating_sub(1),
+            EditAction::Right => self.cursor = (self.cursor + 1).min(self.char_count()),
+            EditAction::Home => self.cursor = 0,
+            EditAction::End => self.cursor = self.char_count(),
+            EditAction::DeleteWordBack => {
+                // Skip trailing spaces, then the word itself — the readline
+                // behaviour muscle memory expects.
+                let chars: Vec<char> = self.buf.chars().collect();
+                let mut start = self.cursor;
+                while start > 0 && chars[start - 1].is_whitespace() {
+                    start -= 1;
+                }
+                while start > 0 && !chars[start - 1].is_whitespace() {
+                    start -= 1;
+                }
+                let from = self.byte_of(start);
+                let to = self.byte_of(self.cursor);
+                self.buf.replace_range(from..to, "");
+                self.cursor = start;
+            }
+            EditAction::KillToStart => {
+                let to = self.byte_of(self.cursor);
+                self.buf.replace_range(0..to, "");
+                self.cursor = 0;
+            }
+            EditAction::KillToEnd => {
+                let from = self.byte_of(self.cursor);
+                self.buf.truncate(from);
+                self.cursor = self.char_count();
+            }
+            EditAction::HistoryPrev => self.browse_history(history, true),
+            EditAction::HistoryNext => self.browse_history(history, false),
+            EditAction::Complete => self.complete(),
+            EditAction::Submit => return EditOutcome::Submit,
+            EditAction::Cancel => return EditOutcome::Cancel,
+            EditAction::Eof => {
+                // Ctrl+D mid-line is a no-op, matching every shell: it only
+                // means end-of-input on an empty line.
+                if self.buf.is_empty() {
+                    return EditOutcome::Eof;
+                }
+            }
+            EditAction::Noop => {}
+        }
+        EditOutcome::Continue
+    }
+
+    /// Walk history. `back` moves toward older entries. `history` is
+    /// oldest-first, so index 0 is the oldest.
+    fn browse_history(&mut self, history: &[String], back: bool) {
+        if history.is_empty() {
+            return;
+        }
+        let next = match (self.history_idx, back) {
+            // Entering history from a fresh line: stash it, land on newest.
+            (None, true) => {
+                self.stash = std::mem::take(&mut self.buf);
+                Some(history.len() - 1)
+            }
+            (None, false) => return, // Already at the newest; nothing below.
+            (Some(0), true) => Some(0), // Clamp at the oldest.
+            (Some(i), true) => Some(i - 1),
+            (Some(i), false) => {
+                if i + 1 >= history.len() {
+                    // Past the newest: restore the line we were typing.
+                    self.buf = std::mem::take(&mut self.stash);
+                    self.cursor = self.char_count();
+                    self.history_idx = None;
+                    return;
+                }
+                Some(i + 1)
+            }
+        };
+        if let Some(i) = next {
+            if let Some(entry) = history.get(i) {
+                self.buf.clone_from(entry);
+                self.cursor = self.char_count();
+                self.history_idx = Some(i);
+            }
+        }
+    }
+
+    /// Tab-complete a leading slash command. Only fires when the buffer is
+    /// a single `/`-prefixed token and the cursor is at its end — completing
+    /// mid-argument would be guesswork.
+    fn complete(&mut self) {
+        if !self.buf.starts_with('/')
+            || self.buf.contains(char::is_whitespace)
+            || self.cursor != self.char_count()
+        {
+            return;
+        }
+        let matches: Vec<&&str> = SLASH_COMMANDS
+            .iter()
+            .filter(|c| c.starts_with(&self.buf))
+            .collect();
+        let completed = match matches.as_slice() {
+            [only] => (**only).to_string(),
+            // Several candidates: fill in the longest shared prefix, which
+            // is what makes repeated Tab feel like progress rather than a
+            // dead key.
+            many if many.len() > 1 => {
+                let first = *many[0];
+                let mut end = first.len();
+                for m in many {
+                    end = end.min(
+                        first
+                            .char_indices()
+                            .zip(m.chars())
+                            .take_while(|((_, a), b)| a == b)
+                            .last()
+                            .map_or(0, |((i, a), _)| i + a.len_utf8()),
+                    );
+                }
+                first[..end].to_string()
+            }
+            _ => return,
+        };
+        if completed.len() > self.buf.len() {
+            self.buf = completed;
+            self.cursor = self.char_count();
+        }
+    }
+}
+
+/// Map a crossterm key event to an [`EditAction`].
+pub(crate) fn action_for(key: KeyEvent) -> EditAction {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match (key.code, ctrl) {
+        (KeyCode::Enter, _) => EditAction::Submit,
+        (KeyCode::Backspace, _) => EditAction::Backspace,
+        (KeyCode::Delete, _) => EditAction::Delete,
+        (KeyCode::Left, false) => EditAction::Left,
+        (KeyCode::Right, false) => EditAction::Right,
+        (KeyCode::Up, _) => EditAction::HistoryPrev,
+        (KeyCode::Down, _) => EditAction::HistoryNext,
+        (KeyCode::Home, _) => EditAction::Home,
+        (KeyCode::End, _) => EditAction::End,
+        (KeyCode::Tab, _) => EditAction::Complete,
+        (KeyCode::Char('a'), true) => EditAction::Home,
+        (KeyCode::Char('e'), true) => EditAction::End,
+        (KeyCode::Char('b'), true) => EditAction::Left,
+        (KeyCode::Char('f'), true) => EditAction::Right,
+        (KeyCode::Char('w'), true) => EditAction::DeleteWordBack,
+        (KeyCode::Char('u'), true) => EditAction::KillToStart,
+        (KeyCode::Char('k'), true) => EditAction::KillToEnd,
+        (KeyCode::Char('p'), true) => EditAction::HistoryPrev,
+        (KeyCode::Char('n'), true) => EditAction::HistoryNext,
+        (KeyCode::Char('c'), true) => EditAction::Cancel,
+        (KeyCode::Char('d'), true) => EditAction::Eof,
+        // Ctrl+<other> must not type a literal character.
+        (KeyCode::Char(_), true) => EditAction::Noop,
+        (KeyCode::Char(c), false) => EditAction::Insert(c),
+        _ => EditAction::Noop,
+    }
+}
+
+/// What one `read_line` call produced.
+pub(crate) enum ReadOutcome {
+    Line(String),
+    /// Ctrl+C: prompt again without running a turn.
+    Interrupted,
+    /// Ctrl+D on an empty line, or EOF on piped input.
+    Eof,
+}
+
+/// Owns the history list and its backing file.
+pub(crate) struct LineEditor {
+    history: Vec<String>,
+    path: Option<PathBuf>,
+    /// False when stdin or stderr is not a terminal — the whole editor
+    /// degrades to `read_line` in that case.
+    interactive: bool,
+}
+
+impl LineEditor {
+    pub(crate) fn new() -> Self {
+        let interactive = io::stdin().is_terminal() && io::stderr().is_terminal();
+        let path = crate::env_config::home_dir()
+            .join(".claudette")
+            .join("repl_history");
+        let history = load_history(&path);
+        Self {
+            history,
+            path: Some(path),
+            interactive,
+        }
+    }
+
+    /// Record a submitted line. Consecutive duplicates are collapsed so
+    /// holding Up doesn't walk through the same command repeatedly.
+    pub(crate) fn push_history(&mut self, line: &str) {
+        let line = line.trim();
+        if line.is_empty() || self.history.last().map(String::as_str) == Some(line) {
+            return;
+        }
+        self.history.push(line.to_string());
+        if self.history.len() > MAX_HISTORY {
+            let excess = self.history.len() - MAX_HISTORY;
+            self.history.drain(0..excess);
+        }
+        if let Some(p) = &self.path {
+            save_history(p, &self.history);
+        }
+    }
+
+    /// Read one line, rendering `prompt` (whose *visible* width is
+    /// `prompt_width` — the string itself carries ANSI colour codes that
+    /// occupy no columns).
+    pub(crate) fn read_line(&mut self, prompt: &str, prompt_width: u16) -> io::Result<ReadOutcome> {
+        if !self.interactive {
+            let mut buf = String::new();
+            return match io::stdin().read_line(&mut buf)? {
+                0 => Ok(ReadOutcome::Eof),
+                _ => Ok(ReadOutcome::Line(buf)),
+            };
+        }
+        self.read_line_raw(prompt, prompt_width)
+    }
+
+    fn read_line_raw(&mut self, prompt: &str, prompt_width: u16) -> io::Result<ReadOutcome> {
+        let mut err = io::stderr();
+        write!(err, "{prompt}")?;
+        err.flush()?;
+
+        terminal::enable_raw_mode()?;
+        // Raw mode must come off on every path, including the `?` early
+        // returns below — otherwise a transient terminal error leaves the
+        // user's shell in raw mode with no echo.
+        let _restore = scopeguard::guard((), |()| {
+            let _ = terminal::disable_raw_mode();
+        });
+
+        let mut state = LineState::new();
+        let mut prev_rows: u16 = 0;
+
+        loop {
+            let key = match event::read()? {
+                // `Release`/`Repeat` arrive on Windows; acting on both press
+                // and release would double every keystroke.
+                Event::Key(k) if k.kind == KeyEventKind::Press => k,
+                Event::Paste(text) => {
+                    for c in text.chars().filter(|c| *c != '\n' && *c != '\r') {
+                        state.apply(EditAction::Insert(c), &self.history);
+                    }
+                    prev_rows = redraw(&mut err, prompt, prompt_width, &state, prev_rows)?;
+                    continue;
+                }
+                Event::Resize(_, _) => {
+                    prev_rows = redraw(&mut err, prompt, prompt_width, &state, prev_rows)?;
+                    continue;
+                }
+                _ => continue,
+            };
+
+            match state.apply(action_for(key), &self.history) {
+                EditOutcome::Continue => {
+                    prev_rows = redraw(&mut err, prompt, prompt_width, &state, prev_rows)?;
+                }
+                EditOutcome::Submit => {
+                    writeln!(err)?;
+                    err.flush()?;
+                    return Ok(ReadOutcome::Line(state.buf));
+                }
+                EditOutcome::Cancel => {
+                    writeln!(err)?;
+                    err.flush()?;
+                    return Ok(ReadOutcome::Interrupted);
+                }
+                EditOutcome::Eof => {
+                    writeln!(err)?;
+                    err.flush()?;
+                    return Ok(ReadOutcome::Eof);
+                }
+            }
+        }
+    }
+}
+
+/// Repaint the prompt line(s) and place the cursor. Returns how many rows
+/// the line now occupies, which the next redraw needs in order to climb back
+/// to the start of a wrapped line before clearing.
+fn redraw(
+    err: &mut io::Stderr,
+    prompt: &str,
+    prompt_width: u16,
+    state: &LineState,
+    prev_rows: u16,
+) -> io::Result<u16> {
+    let cols = terminal::size().map_or(80, |(c, _)| c).max(1);
+    let total = prompt_width as usize + state.buf.chars().count();
+    let rows = u16::try_from(total / cols as usize).unwrap_or(0);
+
+    if prev_rows > 0 {
+        queue!(err, cursor::MoveUp(prev_rows))?;
+    }
+    queue!(
+        err,
+        cursor::MoveToColumn(0),
+        terminal::Clear(terminal::ClearType::FromCursorDown),
+        style::Print(prompt),
+        style::Print(&state.buf),
+    )?;
+
+    // Park the cursor where the caret belongs. Done as an absolute move from
+    // the start of the input area so wrapped lines land correctly.
+    let caret = prompt_width as usize + state.cursor;
+    let caret_row = u16::try_from(caret / cols as usize).unwrap_or(0);
+    let caret_col = u16::try_from(caret % cols as usize).unwrap_or(0);
+    if rows > caret_row {
+        queue!(err, cursor::MoveUp(rows - caret_row))?;
+    }
+    queue!(err, cursor::MoveToColumn(caret_col))?;
+    err.flush()?;
+    Ok(caret_row)
+}
+
+fn load_history(path: &std::path::Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if out.len() > MAX_HISTORY {
+        let excess = out.len() - MAX_HISTORY;
+        out.drain(0..excess);
+    }
+    out
+}
+
+/// Best-effort persist. A history file we can't write is not worth
+/// interrupting the session over — and it may legitimately be read-only on
+/// a locked-down box.
+fn save_history(path: &std::path::Path, history: &[String]) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, history.join("\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hist(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn state_with(buf: &str, cursor: usize) -> LineState {
+        LineState {
+            buf: buf.to_string(),
+            cursor,
+            ..LineState::default()
+        }
+    }
+
+    fn apply_all(s: &mut LineState, actions: &[EditAction], history: &[String]) {
+        for a in actions {
+            s.apply(a.clone(), history);
+        }
+    }
+
+    #[test]
+    fn typing_inserts_at_the_cursor() {
+        let mut s = LineState::new();
+        apply_all(
+            &mut s,
+            &[
+                EditAction::Insert('a'),
+                EditAction::Insert('c'),
+                EditAction::Left,
+                EditAction::Insert('b'),
+            ],
+            &[],
+        );
+        assert_eq!(s.buf, "abc");
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn editing_is_char_based_not_byte_based() {
+        // A byte-indexed cursor would split these and panic. Hebrew is a
+        // first-class case here: the system prompt answers in it.
+        let mut s = state_with("שלום", 4);
+        s.apply(EditAction::Backspace, &[]);
+        assert_eq!(s.buf, "שלו");
+        s.apply(EditAction::Home, &[]);
+        s.apply(EditAction::Delete, &[]);
+        assert_eq!(s.buf, "לו");
+
+        let mut e = state_with("a🎉b", 3);
+        e.apply(EditAction::Backspace, &[]);
+        assert_eq!(e.buf, "a🎉");
+    }
+
+    #[test]
+    fn backspace_and_delete_at_the_edges_are_noops() {
+        let mut s = state_with("ab", 0);
+        assert_eq!(s.apply(EditAction::Backspace, &[]), EditOutcome::Continue);
+        assert_eq!(s.buf, "ab");
+        let mut e = state_with("ab", 2);
+        e.apply(EditAction::Delete, &[]);
+        assert_eq!(e.buf, "ab");
+    }
+
+    #[test]
+    fn ctrl_w_deletes_the_previous_word_including_trailing_space() {
+        let mut s = state_with("git commit now ", 15);
+        s.apply(EditAction::DeleteWordBack, &[]);
+        assert_eq!(s.buf, "git commit ");
+        s.apply(EditAction::DeleteWordBack, &[]);
+        assert_eq!(s.buf, "git ");
+    }
+
+    #[test]
+    fn kill_to_start_and_end_respect_the_cursor() {
+        let mut s = state_with("hello world", 6);
+        s.apply(EditAction::KillToStart, &[]);
+        assert_eq!(s.buf, "world");
+        assert_eq!(s.cursor, 0);
+
+        let mut e = state_with("hello world", 5);
+        e.apply(EditAction::KillToEnd, &[]);
+        assert_eq!(e.buf, "hello");
+        assert_eq!(e.cursor, 5);
+    }
+
+    #[test]
+    fn up_walks_back_through_history_and_down_returns_the_draft() {
+        // The behaviour the raw read_line couldn't do at all: this is the
+        // regression guard for "press Up, get ^[[A".
+        let h = hist(&["first", "second"]);
+        let mut s = LineState::new();
+        apply_all(
+            &mut s,
+            &[EditAction::Insert('d'), EditAction::Insert('r')],
+            &h,
+        );
+
+        s.apply(EditAction::HistoryPrev, &h);
+        assert_eq!(s.buf, "second", "Up lands on the newest entry");
+        s.apply(EditAction::HistoryPrev, &h);
+        assert_eq!(s.buf, "first");
+        s.apply(EditAction::HistoryPrev, &h);
+        assert_eq!(s.buf, "first", "clamps at the oldest");
+
+        s.apply(EditAction::HistoryNext, &h);
+        assert_eq!(s.buf, "second");
+        s.apply(EditAction::HistoryNext, &h);
+        assert_eq!(s.buf, "dr", "past the newest, the draft comes back");
+        assert_eq!(s.cursor, 2);
+    }
+
+    #[test]
+    fn history_navigation_on_empty_history_is_a_noop() {
+        let mut s = state_with("typing", 6);
+        s.apply(EditAction::HistoryPrev, &[]);
+        assert_eq!(s.buf, "typing");
+    }
+
+    #[test]
+    fn tab_completes_a_unique_slash_command() {
+        let mut s = state_with("/brow", 5);
+        s.apply(EditAction::Complete, &[]);
+        assert_eq!(s.buf, "/brownfield");
+        assert_eq!(s.cursor, 11);
+    }
+
+    #[test]
+    fn tab_fills_the_shared_prefix_when_several_commands_match() {
+        // /model and /models both match — completing to the shared prefix
+        // is progress; completing to either would be a wrong guess.
+        let mut s = state_with("/mod", 4);
+        s.apply(EditAction::Complete, &[]);
+        assert_eq!(s.buf, "/model");
+    }
+
+    #[test]
+    fn tab_does_not_complete_plain_prose_or_mid_argument() {
+        let mut s = state_with("what is", 7);
+        s.apply(EditAction::Complete, &[]);
+        assert_eq!(s.buf, "what is", "prose must not gain a slash command");
+
+        let mut e = state_with("/save my-", 9);
+        e.apply(EditAction::Complete, &[]);
+        assert_eq!(e.buf, "/save my-", "arguments are not command names");
+    }
+
+    #[test]
+    fn ctrl_d_only_ends_input_on_an_empty_line() {
+        let mut s = state_with("half typed", 10);
+        assert_eq!(s.apply(EditAction::Eof, &[]), EditOutcome::Continue);
+        assert_eq!(s.buf, "half typed", "Ctrl+D mid-line must not discard it");
+
+        let mut e = LineState::new();
+        assert_eq!(e.apply(EditAction::Eof, &[]), EditOutcome::Eof);
+    }
+
+    #[test]
+    fn ctrl_c_cancels_and_enter_submits() {
+        let mut s = state_with("oops", 4);
+        assert_eq!(s.apply(EditAction::Cancel, &[]), EditOutcome::Cancel);
+        let mut e = state_with("go", 2);
+        assert_eq!(e.apply(EditAction::Submit, &[]), EditOutcome::Submit);
+    }
+
+    #[test]
+    fn control_chords_never_type_a_literal_character() {
+        // Ctrl+Z / Ctrl+L etc. must not end up in the buffer as text.
+        for c in ['z', 'l', 'q', 'r'] {
+            let action = action_for(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL));
+            assert_eq!(action, EditAction::Noop, "ctrl+{c} should be inert");
+        }
+        assert_eq!(
+            action_for(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)),
+            EditAction::Insert('a'),
+        );
+    }
+
+    #[test]
+    fn key_bindings_map_to_the_expected_actions() {
+        let ctrl = |c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL);
+        assert_eq!(action_for(ctrl('a')), EditAction::Home);
+        assert_eq!(action_for(ctrl('e')), EditAction::End);
+        assert_eq!(action_for(ctrl('w')), EditAction::DeleteWordBack);
+        assert_eq!(action_for(ctrl('u')), EditAction::KillToStart);
+        assert_eq!(action_for(ctrl('k')), EditAction::KillToEnd);
+        assert_eq!(action_for(ctrl('c')), EditAction::Cancel);
+        assert_eq!(action_for(ctrl('d')), EditAction::Eof);
+        assert_eq!(
+            action_for(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+            EditAction::HistoryPrev,
+        );
+    }
+
+    #[test]
+    fn history_file_round_trips_and_is_capped() {
+        let dir = std::env::temp_dir().join(format!("claudette-hist-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("repl_history");
+
+        let many: Vec<String> = (0..MAX_HISTORY + 50).map(|i| format!("cmd {i}")).collect();
+        save_history(&path, &many);
+        let loaded = load_history(&path);
+        assert_eq!(loaded.len(), MAX_HISTORY, "oldest entries are dropped");
+        assert_eq!(
+            loaded.last().map(String::as_str),
+            Some(format!("cmd {}", MAX_HISTORY + 49).as_str()),
+            "the newest entry survives",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_history_file_loads_empty_rather_than_failing() {
+        let path = std::env::temp_dir().join("claudette-nonexistent-history-file");
+        let _ = std::fs::remove_file(&path);
+        assert!(load_history(&path).is_empty());
+    }
+}

--- a/crates/claudette/src/run/repl.rs
+++ b/crates/claudette/src/run/repl.rs
@@ -7,8 +7,6 @@
 //! `use`s below are the external crate paths.
 use super::*;
 
-use std::io::{self, Write};
-
 use crate::commands::{dispatch_slash_command, parse_slash_command, ReplState, SlashOutcome};
 use crate::theme;
 
@@ -99,39 +97,35 @@ pub fn run_agent_repl(opts: SessionOptions) -> Result<()> {
 
     eprintln!();
 
-    loop {
-        // Print prompt.
-        {
-            let stderr = io::stderr();
-            let mut err = stderr.lock();
-            write!(err, "{} ", theme::accent(theme::PROMPT_ARROW))?;
-            err.flush()?;
-        }
+    // History, arrows, and tab completion. Degrades to a plain `read_line`
+    // when stdin/stderr isn't a terminal, so piped input, CI, and the eval
+    // battery (`claudette "<prompt>" < /dev/null`) behave exactly as before.
+    let mut editor = crate::run::line_editor::LineEditor::new();
+    let prompt = format!("{} ", theme::accent(theme::PROMPT_ARROW));
 
-        // Read one line WITHOUT holding the stdin lock across run_turn.
-        // The CliPrompter needs stdin access for [y/N] confirmation
-        // prompts, so we must drop the lock before entering the runtime.
-        let line = {
-            let stdin = io::stdin();
-            let mut buf = String::new();
-            match stdin.read_line(&mut buf) {
-                Ok(0) => {
-                    eprintln!();
-                    break; // EOF
-                }
-                Ok(_) => buf,
-                Err(e) => {
-                    eprintln!("stdin error: {e}");
-                    break;
-                }
+    loop {
+        // The editor owns stdin only for the duration of this call, and
+        // never across run_turn — the CliPrompter needs stdin for its
+        // [y/N] confirmations.
+        let line = match editor.read_line(&prompt, 2) {
+            Ok(crate::run::line_editor::ReadOutcome::Line(l)) => l,
+            // Ctrl+C: abandon the half-typed line, keep the session.
+            Ok(crate::run::line_editor::ReadOutcome::Interrupted) => continue,
+            Ok(crate::run::line_editor::ReadOutcome::Eof) => {
+                eprintln!();
+                break;
+            }
+            Err(e) => {
+                eprintln!("stdin error: {e}");
+                break;
             }
         };
-        // stdin lock is now dropped — safe for the prompter to read.
 
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
         }
+        editor.push_history(trimmed);
         if matches!(trimmed, "exit" | "quit" | ":q") {
             break;
         }

--- a/crates/claudette/src/runtime/permissions.rs
+++ b/crates/claudette/src/runtime/permissions.rs
@@ -292,7 +292,12 @@ impl PermissionPolicy {
 
 /// Iterative Levenshtein distance, two-row variant. `O(m*n)` time, `O(min(m,n))`
 /// space. Operates on chars so non-ASCII names aren't penalised by byte length.
-fn levenshtein(a: &str, b: &str) -> u32 {
+///
+/// `pub` rather than private because the `claudette` binary is a separate
+/// crate from this library and drives its unknown-flag "did you mean" from
+/// the same function — one implementation for tool-name and flag-name typo
+/// suggestions instead of two that could drift apart.
+pub fn levenshtein(a: &str, b: &str) -> u32 {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();
     if a.is_empty() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,9 +18,15 @@ src/
 │   ├── prompt.rs       — ProjectContext discovery (cwd, git status, instruction files)
 │   ├── config.rs       — Optional configuration loaders (settings.json: hooks, model)
 │   └── json.rs         — Hand-rolled JSON for the no-serde-dep runtime paths
-├── api.rs            — OllamaApiClient: /api/chat streamer, truncation, budget math, probe
-├── run.rs            — Runtime builder, REPL loop, autosave, session compaction, forge pipeline
-├── executor.rs       — SecretaryToolExecutor: enable_tools meta-tool + dispatch
+│   └── context_evict.rs — Stale tool-result stubbing on the outgoing payload (opt-in)
+├── api.rs            — OllamaApiClient: /api/chat + /v1/chat/completions streamers, truncation, budget math, probe
+├── run.rs            — Mode dispatch + turn retry; the pieces below were split out of it
+├── run/              — repl.rs (REPL loop + autosave), runtime_build.rs (every runtime
+│                       builder + the permission policy), compaction_policy.rs (thresholds,
+│                       max_iterations), forge_run.rs (the 5-phase pipeline),
+│                       research.rs (deep-research batches), cli_prompter.rs ([y/N] gate),
+│                       recall_index.rs (post-turn indexing + embed probe)
+├── executor.rs       — AgentToolExecutor: enable_tools meta-tool + dispatch
 ├── tools.rs          — Aggregates per-group schemas + routes dispatch_tool() through each sub-module
 ├── tools/            — One module per tool cluster (calendar, facts, file_ops, git, github, gmail, ide, notes, registry, schedule, search, shell, telegram, todos, web_search)
 ├── tool_groups.rs    — ToolRegistry + the 20 on-demand tool-group definitions
@@ -39,12 +45,48 @@ src/
 ├── voice.rs          — Whisper transcription pipeline
 ├── tts.rs            — edge-tts TTS integration
 ├── theme.rs          — Colored output, emoji glyphs, TTY detection
+├── doctor.rs         — `--doctor`: ten flat diagnostic probes with copy-paste fixes
+├── setup.rs          — `--setup`: the five-step first-run wizard (TTY-gated)
+├── firstrun.rs       — Backend-failure classifier + the post-first-success nudge
+├── egress.rs         — The `--offline` air-gap guard (in-process HTTP + subprocesses)
+├── env_config.rs     — Env primitives (home_dir, is_truthy, is_enabled)
+├── security_review.rs — Deterministic added-lines scan for the forge gate (opt-in)
+├── transcript.rs     — Mutating-action log + trash-backed /undo and /diff
+├── recall.rs         — Cross-session semantic memory (sqlite + local embeddings)
+├── missions.rs       — Brownfield mission state + path routing
+├── redact.rs         — Secret redaction for logs and transcripts
+├── hw.rs             — GPU / VRAM / temperature probes
+├── status.rs         — REPL activity spinner (TTY-only)
+├── image_attach.rs   — Image attachment handling for multimodal turns
+├── diff_preview.rs   — Colored unified diff for the [y/N] edit gate
 ├── tui.rs            — Ratatui TUI app, 5 tabs, render loop
 ├── tui_events.rs     — TUI event enums (worker ↔ render channel)
 ├── tui_executor.rs   — ToolExecutor wrapper that fires TUI events
 ├── tui_worker.rs     — Worker thread that owns the ConversationRuntime
 └── forge/            — Forge-mode plumbing (personas, role-map, types) — folded back in v0.5.1
 ```
+
+## Storage layout
+
+Everything Claudette persists lives under `~/.claudette/` (resolved by
+`env_config::home_dir()`). Nothing is written outside it without a prompt.
+
+| Path | Written by | Notes |
+|------|-----------|-------|
+| `sessions/last.json` | every REPL turn | Autosaved. `--resume` reads it; override with `CLAUDETTE_SESSION`. |
+| `sessions/<name>.json` | `/save` | Named snapshots, managed by `/sessions`. |
+| `CLAUDETTE.MD` | you | User memory, injected as background information. 800-char cap; `/reload` re-reads it. |
+| `recall.sqlite` | the async indexer | Cross-session semantic memory (local embeddings, 50k-row FIFO). Tool calls and results are deliberately **not** indexed. |
+| `transcript/actions.jsonl` | every *mutating* tool call | ReadOnly calls are never logged. Backs `/undo` and `/diff`. |
+| `trash/` | deletes and overwrites | Timestamped originals — the restore source for `/undo`. |
+| `notes/*.md` | `note_create` | One hand-editable markdown file per note. |
+| `todos.json` | the todo tools | Also live-editable from the TUI Todos tab. |
+| `missions/` | `mission_start` | Brownfield clones + `active_mission.json`. Non-ephemeral missions survive a restart. |
+| `research/<repo>-<date>/` | `--research` | Manifest, progress, findings, `REPORT.md`. Resumable. |
+| `secrets/*.token` | OAuth + token storage | `0600` on Unix, ACL-tightened on Windows. |
+| `schedule.jsonl` | the scheduler | Recurring entries. Only the Telegram consumer loop fires them. |
+| `.env` | you | The only dotenv auto-loaded. A CWD `.env` is deliberately **not** read. |
+| `.onboarded` | first success | Sentinel for the one-time "what's next?" nudge. |
 
 ## The on-demand tool-group contract
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,6 @@
 # Claudette vs. the open-source AI agent landscape
 
-_As of June 2026._
+_As of July 2026._
 
 "Open claw" ≈ **opencode** (SST) — the most-cited open-source alternative to Claude Code. This doc
 compares Claudette against opencode and the other leading open-source AI coding / agent tools so

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,8 @@ These are read by the one-line install scripts, not by the binary itself:
 | `CLAUDETTE_OPENAI_COMPAT` | unset | Set to `1` to talk to an OpenAI-compatible server (LM Studio, vLLM, llama.cpp's `--api`) instead of native Ollama. Brain calls switch to `/v1/chat/completions`; recall embeddings switch to `/v1/embeddings`. `OLLAMA_HOST` doubles as the compat-server URL. |
 | `CLAUDETTE_SKIP_OLLAMA_PROBE` | unset | Set to `1` to skip the Ollama startup probe (CI / offline). |
 | `CLAUDETTE_SKIP_LM_STUDIO_PROBE` | unset | Set to `1` to skip the LM Studio probe (only used when `CLAUDETTE_OPENAI_COMPAT=1`). The probe checks `/v1/models` returns a non-empty model list — set this if you load models post-launch. |
-| `CLAUDETTE_FALLBACK_BRAIN_MODEL` | `qwen3.5:9b` (Auto preset) | Brain to fall back to on stuck signals. |
+| `CLAUDETTE_FALLBACK_BRAIN_MODEL` | `qwen3.5:9b` (Auto preset) | Brain to escalate to on stuck signals. Escalation is **skipped** — with a one-line notice — when this resolves to the same model as the brain, or when the backend isn't already serving it. That guard matters on LM Studio: loading a second model there evicts the one you deliberately loaded, so Claudette will not do it behind your back mid-turn. Set it empty (`CLAUDETTE_FALLBACK_BRAIN_MODEL=`) or use `/preset fast` to turn the tiered brain off entirely. |
+| `CLAUDETTE_FACELESS` | unset | Set to `1` (or pass `--faceless`) to drop the persona overlay — Eva in assistant mode, CodeX-7 for the forge Coder. Identity strings only; no effect on tools or permissions. |
 | `CLAUDETTE_WORKSPACE` | unset | Extra read roots outside `$HOME`, colon-separated on Unix, semicolon-separated on Windows. Example: `D:\dev\claudette` for developing Claudette itself. Reads under `$HOME` and under a `$HOME`-rooted CWD are always allowed regardless. |
 
 ### Recommended brain

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -151,6 +151,10 @@ exact allow-list. See [Air-gapped, and enforced](../README.md#-air-gapped-and-en
 
 ## The TUI in 60 seconds
 
+> **Experimental — demo-only.** The TUI has known rendering rough edges
+> (doubled text, tool pane, footer). The REPL is the supported daily driver;
+> reach for `--tui` to show Claudette off, not to live in it.
+
 ```bash
 claudette --tui
 ```
@@ -170,7 +174,10 @@ Five tabs across the top — switch with number keys or cycle with `Tab` /
   input box is empty, so you can still type "1pm").
 - **Slash commands work here too** — `/help`, `/brownfield`, `/forge`, `/recall`,
   everything the REPL has.
-- **`Ctrl+V`** pastes an image or text block into your next message.
+- **`Alt+V`** pastes an image or text block into your next message. (Not `Ctrl+V`
+  — Windows Terminal and most modern terminals intercept that at the terminal
+  level and paste the clipboard's *text* form, so the keypress never reaches
+  Claudette.)
 - **`Ctrl+C`** (or `Ctrl+D`) quits.
 
 ## Forge: hands-off code changes with a review gate

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,27 @@ binary has no cloud code, so it errors with a one-line reinstall hint instead.
 | `--help`, `-h` | Show the flag reference and exit. |
 | `--version`, `-V` | Show the Claudette version and exit. |
 
+## REPL line editing
+
+The prompt is a real line editor. History persists across sessions in
+`~/.claudette/repl_history` (last 500 entries, consecutive duplicates
+collapsed).
+
+| Key | Effect |
+|-----|--------|
+| `↑` / `↓`, `Ctrl+P` / `Ctrl+N` | Walk history. Going past the newest entry restores the line you were typing. |
+| `←` / `→`, `Ctrl+B` / `Ctrl+F` | Move the cursor. |
+| `Ctrl+A` / `Ctrl+E`, `Home` / `End` | Jump to start / end of line. |
+| `Ctrl+W` | Delete the word before the cursor. |
+| `Ctrl+U` / `Ctrl+K` | Delete to the start / end of the line. |
+| `Tab` | Complete a leading slash command (fills the shared prefix when several match). |
+| `Ctrl+C` | Abandon the current line, keep the session. |
+| `Ctrl+D` | On an empty line, leave the REPL. Mid-line it does nothing. |
+
+When stdin or stderr isn't a terminal — piped input, CI, the eval battery —
+the editor steps aside and input is read plainly, so scripted use is
+unchanged.
+
 ## Slash commands (REPL + TUI)
 
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,8 +12,12 @@ binary has no cloud code, so it errors with a one-line reinstall hint instead.
 |------|--------|
 | `--resume`, `-r` | Continue the most recent saved session. |
 | `--telegram`, `-t` | **(integrations)** Run as a Telegram bot (needs `TELEGRAM_BOT_TOKEN`). |
-| `--tui` | Launch the fullscreen TUI. |
-| `--forge "<prompt>"` | Run forge-mode (Planner → Coder → Verifier pipeline) against the active brownfield mission. Requires an active mission — start one with `/brownfield <repo>` or `mission_start` first. |
+| `--tui` | **(experimental)** Launch the fullscreen TUI. Demo-only — known rendering rough edges; the REPL is the supported daily driver. |
+| `--setup` | Guided first-run wizard: detect the backend, read your VRAM, offer to pull the fitting brain, then run a closing `--doctor` pass. Needs a TTY; refused under `--offline`. |
+| `--doctor` | Run the diagnostic probes (backend reachable, brain pulled, recall embeddings, build toolchains, OAuth, voice, secrets dir) and exit. Each failure prints a copy-paste `↳ fix:` line. Non-zero exit if any probe hard-failed. |
+| `--offline` | Enforced air-gap: hard-block every outbound call except your local model server and loopback. `bash` / `bash_background` are refused wholesale. See [PRIVACY.md](../PRIVACY.md). |
+| `--faceless` | Drop the persona overlay (Eva in assistant mode, CodeX-7 for the forge Coder). Same surface as `CLAUDETTE_FACELESS=1`. |
+| `--forge "<prompt>"` | Run the autonomous forge pipeline: Planner → Coder → Verifier → fix-loop → Submitter, with a real build+test gate every round. Uses the active brownfield mission, or bootstraps an ephemeral one in the current repo when there is none. You approve the plan and the full diff before any PR opens. |
 | `--research [focus]` | Unattended read-only review of the repo you are in: fresh conversation per 2–3-file batch, findings checkpointed under `~/.claudette/research/`, HIGH/MEDIUM findings verified, final `REPORT.md`. Forces offline; re-run the same command to resume. Trailing words become an optional focus hint. See [research.md](research.md). |
 | `--chat <id>` | Restrict Telegram bot to a specific chat ID. Repeatable, or set `CLAUDETTE_TELEGRAM_CHAT` to a comma-separated list. The bot **default-denies** when no allowlist is provided. |
 | `--chat any` | Explicit accept-all: serve every incoming Telegram chat. Required to start the bot with no allowlist. Prints a loud warning. |
@@ -39,25 +43,32 @@ binary has no cloud code, so it errors with a one-line reinstall hint instead.
 /memory              Show CLAUDETTE.MD contents.
 /reload              Re-read CLAUDETTE.MD into the system prompt.
 /sessions, /ls       List saved sessions.
+/sessions delete <name>  Delete a saved session (aliases: rm, remove).
+/sessions rename <old> <new>  Rename a saved session (alias: mv).
 /save <name>         Save the current session under <name>.
 /load <name>         Load a named session.
 /compact             Force context compaction now.
 /clear               Reset to a fresh session.
 /capabilities        Full configuration dump.
 /recall <query>      Search past conversations across sessions (semantic).
-/undo                Restore the last destructive action (delete/overwrite) from ~/.claudette/trash/.
+/recall reprobe      Re-run the embedding probe after fixing a recall problem.
+/undo                Restore everything the last turn changed, from ~/.claudette/trash/.
+/undo one            Restore only the single most recent action.
+/diff                Colored unified diff of what the last turn changed on disk.
 /brownfield <target> Clone a repo and make it the active mission (one-shot).
 /forge <prompt>      Run the forge pipeline against the active mission.
+/mission_exit        Clear the active mission (unblocks /forge after a failed clone).
 /exit                Leave the REPL.
 ```
 
 ## Telegram-mode slash commands
 
-A subset of the REPL commands works identically inside Telegram chats: `/help`, `/status`, `/compact`, `/clear`, `/save`, `/load`. `/exit` and the destructive DangerFullAccess commands are blocked.
+Telegram handles a small, explicit set: `/start`, `/status`, `/compact`, `/clear`, plus the Telegram-only commands below. Anything else you type with a leading slash — including `/help`, `/save`, and `/load` — is **not** a command here; it falls through to the model as ordinary text. `/exit` and the destructive DangerFullAccess commands are blocked.
 
-Three additional commands are **Telegram-only** (they have no effect in the REPL or TUI):
+Four additional commands are **Telegram-only** (they have no effect in the REPL or TUI):
 
 ```
+/start               Greeting + what this bot can do.
 /voice               Toggle voice output (edge-tts on / off).
 /lang he|en          Switch voice transcription + TTS language.
 /briefing            Run the morning briefing now (calendar + weather + VIP unread).


### PR DESCRIPTION
Four things a **new** user hits in their first session, none of which David hits because his machine is already configured. Ordered by how early a fresh install trips over them.

## 1. The tiered fallback evicts the model you just loaded (`779c4fa`)

A fresh install has no `~/.claudette/models.toml`, so `model_config` resolves `Preset::Auto` and hands every new user `fallback_brain = qwen3.5:9b` — whether or not they have ever heard of it. On the 16 GB LM Studio setup the README recommends, three consecutive tool errors are enough to make Claudette issue a chat request for a model the server does not have loaded. LM Studio JIT-loads it, **evicting the 13.6 GB champion the user deliberately loaded**, and replays the turn on a brain that had to be paged in first.

The tiered-brain design assumed Ollama on a small card, where pulling a second model for one turn is exactly right. That assumption was never re-checked against the LM Studio path.

Two guards before escalation, in `run_turn_with_fallback`:

- **SameAsPrimary** — fallback resolves to the primary. Escalating replays the whole turn against an identical brain for an identical result at double the latency.
- **NotServed** — the backend does not list the fallback. Escalating makes the server fetch it: a JIT load on LM Studio, or a multi-gigabyte pull on Ollama. Neither is something to do behind the user's back mid-turn.

Both are checked before the pre-turn session clone, so an unusable fallback costs the same as having none configured. The inventory probe is fetched once per process and reuses `doctor::extract_model_names` / `model_present` rather than adding a second parser for the same two response shapes. **A failed or empty probe fails open** — an unreachable backend must not silently disable a working fallback — and a stale cache can only skip an escalation, never cause a surprise model load.

Also in this commit: `MAX_ITER_STUCK_THRESHOLD` was frozen at 11 and documented as "two short of the configured `max_iterations = 15`". The cap is now 40, so the heuristic had quietly become a 27%-of-budget tripwire that diagnosed ordinary long tool chains as stalls and replayed them wholesale on the bigger brain. It is now derived from the cap in force (`cap - 4`, floored at 11), reproducing the historical pair exactly at cap 15. The two tests covering it hardcoded 13 and 8 iterations, which is why the rot was invisible — they kept passing after the cap moved. They now express the relationship to the cap.

## 2. A typo in the first documented command looks like success (`28654cc`)

`parse_args` ended in a catch-all that pushed any unrecognised token into `prompt_words`. So `claudette --setpu` did not error — it sent `"--setpu"` to the model and printed a chatty reply. A typo in the first command the README tells a new user to run looked like the tool working.

- Flag-shaped args matching nothing are collected into `CliArgs::unknown_flags` and reported with a Levenshtein "did you mean", exit 2. The check sits after `--help`/`--version` so those still work alongside a typo, and before every subsystem so a mistyped flag never reaches a model.
- `--` now ends flag parsing, so a prompt genuinely starting with a dash is still reachable. The error message points at it.
- The detector is **deliberately narrow**, because the prompt is positional and a false positive rejects valid input: a token is a flag only if it starts with `-`, has content after the dash, contains no whitespace (`--wat is this` is one quoted prompt word) and is not a negative number.

Distance 2 covers the realistic typo classes (transposition `--setpu`/`--reserach`, dropped char `--offlin`, substitution `--docter`) without noise — at 3, `--setpu` also "suggested" `--help`. Suggestions reuse `permissions::levenshtein` rather than adding a second copy; it becomes `pub` because the binary is a separate crate from the library. A KNOWN_FLAGS-vs-parser test guards the list against drift.

`--help`'s description of the flagship feature is corrected here too. It still described forge as "v0a runs a single brain turn … exits at `mission_submit`" and claimed `--forge` errors without an active mission. **Both have been false since v0c**: the pipeline is Planner → Coder → Verifier → fix-loop → Submitter with a real build+test gate each round, and it auto-bootstraps an ephemeral mission. Anyone reaching for the headline feature from `--help` was misled about what it does and how to start it.

## 3. Six doc claims the binary does not honour (`62ff2b8`)

- `quickstart.md` told TUI users to press **Ctrl+V** to attach an image. The binding is **Alt+V**, and `tui.rs` carries a comment explaining why: Windows Terminal and most modern terminals intercept Ctrl+V at the terminal level, so the keypress never reaches Claudette. Following the doc *could not* work.
- `usage.md` said `/help`, `/save` and `/load` "work identically inside Telegram". `telegram_mode` handles `/start`, `/status`, `/compact`, `/clear`, `/voice`, `/lang`, `/briefing`; everything else falls through to the model as ordinary text.
- The "every CLI flag" table omitted `--setup`, `--doctor`, `--offline` and `--faceless` — including the two the README front-loads — and the slash list omitted `/diff`, `/undo one`, `/recall reprobe`, `/sessions delete|rename`, `/mission_exit`.
- `usage.md` still described `--forge` as requiring an active mission (see above).
- `quickstart.md`'s TUI tour carried no experimental caveat, contradicting `--help`, the README table and the TUI's own in-app notice.
- `CLAUDETTE_FACELESS` appeared only under `docs/archive/`, the tree explicitly labelled superseded. The doc-drift guard passed on that technicality while the knob was, for users, undocumented.

`architecture.md`'s module tree was a version behind: it named `run.rs` as owner of the REPL and forge pipeline (both split into `run/`), called the executor `SecretaryToolExecutor` (renamed `AgentToolExecutor`), and listed none of `doctor`, `setup`, `firstrun`, `egress`, `env_config`, `security_review`, `transcript`, `recall`, `missions`, `redact`, `hw`, `status`, `image_attach`, `diff_preview`.

`docs/README.md` advertised `architecture.md` as covering "storage layout" and it had no such section. Rather than weaken the index entry, this adds the section — every path under `~/.claudette/`, what writes it, and the two deliberate absences worth knowing (recall does not index tool results; a CWD `.env` is never auto-loaded).

## 4. The REPL prompt was a bare `read_line` (`80c8571`)

Pressing Up in the first thirty seconds of using Claudette printed `^[[A`. No history, no cursor movement, no completion — the loudest "this is unpolished" signal in the product, and invisible in the docs because nothing claimed otherwise.

Adds `run/line_editor.rs`:

- **History across sessions** in `~/.claudette/repl_history` (500 entries, consecutive duplicates collapsed). Up/Down walk it; going past the newest entry restores the line you were part-way through typing.
- **Cursor movement** (arrows, Ctrl+A/E/B/F, Home/End), Ctrl+W word-delete, Ctrl+U/Ctrl+K line-kill, Ctrl+C to abandon a line without losing the session, Ctrl+D to leave on an empty line only.
- **Tab completion** for slash commands, filling the longest shared prefix when several match, so repeated Tab feels like progress rather than a dead key.

Built on **crossterm**, already an unconditional dependency via the TUI, rather than rustyline or reedline — a new dependency here would have to clear `deny.toml`'s license allow-list and duplicate-version bans for a feature this size.

`LineState` is a pure state machine over `(action, buffer, cursor)` with no terminal in it, so all 16 tests run without a tty. The cursor is a **character index, not a byte offset**: a byte-indexed cursor would panic on the Hebrew the system prompt explicitly answers in, and there is a test for exactly that.

Raw mode is unwound through a scopeguard so a transient terminal error can't leave the user's shell with no echo.

---

## What is and is not verified

⚠️ **The interactive raw-mode path is unverified.** What is tested is the `LineState` machine (16 tests, no tty) and the non-TTY fallback. Actually driving a terminal — that Up really recalls history, that Tab really completes, that the scopeguard really restores the shell on a mid-edit error — has **not** been exercised. It needs a PTY harness, which is the same gap that blocks fresh-user E2E validation of `--setup`. Treat the key bindings as *implemented and reasoned about*, not *observed working*.

The non-TTY fallback is load-bearing rather than a nicety — the eval battery runs `claudette "<prompt>" </dev/null`, CI pipes input, and `--research` runs unattended. That path **is** verified end-to-end: piped stdin still exits cleanly on EOF and still dispatches slash commands.

## Gate

`cargo fmt --all --check` clean · `cargo clippy --all-targets --no-deps -- -D warnings` clean · **1154 passed, 0 failed, 6 ignored**. No new env vars beyond `CLAUDETTE_FACELESS`, which this PR *documents* rather than adds, so the `every_env_var_is_documented` guard is satisfied.

## Scope note

This branch deliberately does **not** touch `main` beyond these four fixes. `602ca72` remains the unfixed control for the deep-research model A/B; none of the 56 triaged research findings are addressed here.
