### PR TITLE
fix(test): make research fixture dirs actually unique on Windows

### DIFF
--- a/crates/claudette/src/run/research.rs
+++ b/crates/claudette/src/run/research.rs
@@ -1801,13 +1801,23 @@ fn run_synthesize_pass(
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    // A timestamp alone is not unique enough: Windows' system clock ticks at
+    // ~15.6ms, so tests that start within the same tick get the SAME nanos and
+    // therefore the same fixture directory. They then clobber each other's
+    // files and fail together on assertions about file counts. The counter is
+    // what actually guarantees uniqueness; the timestamp only keeps leftover
+    // directories from separate runs distinguishable.
+    static FIXTURE_SEQ: AtomicU64 = AtomicU64::new(0);
 
     fn fixture_dir() -> std::path::PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos());
-        std::env::temp_dir().join(format!("claudette-research-test-{nanos}"))
+        let seq = FIXTURE_SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("claudette-research-test-{nanos}-{seq}"))
     }
 
     fn setup_fixture(dir: &std::path::Path) {


### PR DESCRIPTION
## The flake

`fixture_dir()` in `run/research.rs` named its temp directory from `SystemTime` nanos alone:

```rust
std::env::temp_dir().join(format!("claudette-research-test-{nanos}"))
```

The Windows system clock ticks at ~15.6ms. Any two of the **19 tests** that call this helper and start within the same tick resolve to the **same directory**, then clobber each other's fixture files and fail together on assertions about file counts and ordering.

## The evidence

PR #212 was an npm lockfile bump (`brace-expansion`) that touched no Rust code, yet its `test (windows-latest)` job failed on two research tests **as a pair**:

```
test run::research::tests::manifest_excludes_recorded_not_dropped ... FAILED
test run::research::tests::manifest_filters_orders_and_counts ... FAILED
test result: FAILED. 1176 passed; 2 failed
```

Both panics were `assertion `left == right` failed` on file counts — the signature of two tests sharing a directory. Re-running the identical npm change after a rebase went green, confirming it was nondeterministic rather than a real break.

## The fix

Add a process-wide atomic counter to the directory name. The counter is what guarantees uniqueness; the timestamp is demoted to only keeping leftover directories from separate runs distinguishable.

## Verification

- `cargo test --all-features --lib run::research` → 42 passed, 0 failed
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all-features --lib` → no warnings