### PR TITLE
deps-dev: bump js-yaml 4.2.0 -> 4.3.0 in /editor/vscode

### DIFF
--- a/editor/vscode/package-lock.json
+++ b/editor/vscode/package-lock.json
@@ -2447,9 +2447,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
Closes the last open Dependabot alert (#12, **HIGH**): *js-yaml: YAML merge-key chains can force quadratic CPU consumption* — vulnerable `>=4.0.0 <4.3.0`, patched `4.3.0`. Disclosed 2026-07-26, after #215/#213/#212 had cleared the other four.

## Scope

`js-yaml` is a **transitive devDependency of `@vscode/vsce`** (the extension packaging tool). It is not in the shipped Rust binary, not in the crates.io package, and not in any air-gapped runtime path.

Because the dependents declare `^4.1.1`, the patched 4.3.0 is already inside the existing range — so this is a **lockfile-only** change, three lines:

```
-  "version": "4.2.0",
+  "version": "4.3.0",
```

## Why not Dependabot

Dependabot had not opened a security PR for this alert yet. `npm update js-yaml --package-lock-only` produces the same minimal result and now reports **0 vulnerabilities** for the subtree.