### PR TITLE
fix(undo): take a pre-image before apply_diff, apply_patch and edit_file

### DIFF
--- a/crates/claudette/src/tools/fuzzy_apply.rs
+++ b/crates/claudette/src/tools/fuzzy_apply.rs
@@ -105,6 +105,16 @@ fn run_apply_diff(input: &str) -> Result<String, String> {
                 );
                 return Err(msg);
             }
+            // Pre-image before the write so `/undo` can restore this file
+            // (roast EDIT-03: apply_diff had no snapshot, which made `/undo`
+            // a no-op for the primary edit path). Fail-closed: no snapshot,
+            // no write. The file is known to exist — it was read above.
+            crate::transcript::snapshot_to_trash(&path).map_err(|e| {
+                format!(
+                    "apply_diff: pre-image snapshot failed, refusing to edit {}: {e}",
+                    path.display()
+                )
+            })?;
             // Atomic write via sibling tmp + rename, matching apply_patch.
             let tmp = path.with_extension("claudette-diff.tmp");
             fs::write(&tmp, &new_content)
@@ -660,5 +670,41 @@ mod tests {
         let err = result.expect_err("identical before/after must be a no-op error");
         assert!(err.contains("no change"), "got: {err}");
         assert_eq!(after_disk, original, "file must not be modified by a no-op");
+    }
+
+    #[test]
+    fn apply_diff_snapshots_a_pre_image() {
+        crate::with_temp_home(|home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            let file = home.join("diffme.txt");
+            fs::write(&file, "alpha\nbeta\n").unwrap();
+            let input = json!({
+                "path": file.display().to_string(),
+                "before": "beta",
+                "after": "gamma",
+            })
+            .to_string();
+            run_apply_diff(&input).unwrap();
+
+            assert_eq!(fs::read_to_string(&file).unwrap(), "alpha\ngamma\n");
+            let trash = home.join(".claudette").join("trash");
+            let entries: Vec<_> = fs::read_dir(&trash)
+                .unwrap()
+                .map(|e| e.unwrap().path())
+                .collect();
+            assert_eq!(entries.len(), 1, "expected exactly one pre-image");
+            assert_eq!(
+                fs::read_to_string(&entries[0]).unwrap(),
+                "alpha\nbeta\n",
+                "pre-image must hold the ORIGINAL content"
+            );
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
     }
 }

--- a/crates/claudette/src/tools/patch.rs
+++ b/crates/claudette/src/tools/patch.rs
@@ -120,6 +120,17 @@ fn run_apply_patch(input: &str) -> Result<String, String> {
     // dry_run path lets the caller validate first, which is the bigger
     // win over a real two-phase commit.
     if !dry_run {
+        // Pre-image EVERY target before writing ANY of them (roast EDIT-03),
+        // so a snapshot failure on the last file cannot leave earlier files
+        // already overwritten and unrecoverable. Fail-closed.
+        for (path, _) in &pending {
+            crate::transcript::snapshot_to_trash(path).map_err(|e| {
+                format!(
+                    "apply_patch: pre-image snapshot failed, refusing to edit {}: {e}",
+                    path.display()
+                )
+            })?;
+        }
         for (path, content) in &pending {
             let tmp = path.with_extension("claudette-apply.tmp");
             fs::write(&tmp, content)
@@ -537,5 +548,82 @@ mod tests {
         // Good file must NOT have been touched — that's the atomic guarantee.
         assert_eq!(after_good.as_deref(), Some("alpha\n"));
         assert_eq!(after_bad.as_deref(), Some("this is wrong\n"));
+    }
+
+    #[test]
+    fn apply_patch_snapshots_a_pre_image() {
+        crate::with_temp_home(|home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            let file = home.join("patchme.txt");
+            fs::write(&file, "alpha\nbeta\n").unwrap();
+
+            // Build a unified diff targeting the temp HOME path.
+            let diff = format!(
+                "--- a/{}\n+++ b/{}\n@@ -1,2 +1,2 @@\n alpha\n-beta\n+gamma\n",
+                file.display(),
+                file.display()
+            );
+            let input = json!({ "diff": diff }).to_string();
+            run_apply_patch(&input).unwrap();
+
+            assert_eq!(fs::read_to_string(&file).unwrap(), "alpha\ngamma\n");
+            let trash = home.join(".claudette").join("trash");
+            let entries: Vec<_> = fs::read_dir(&trash)
+                .unwrap()
+                .map(|e| e.unwrap().path())
+                .collect();
+            assert_eq!(entries.len(), 1, "expected exactly one pre-image");
+            assert_eq!(
+                fs::read_to_string(&entries[0]).unwrap(),
+                "alpha\nbeta\n",
+                "pre-image must hold the ORIGINAL content"
+            );
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
+    }
+
+    #[test]
+    fn apply_patch_dry_run_makes_no_pre_image() {
+        crate::with_temp_home(|home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            let file = home.join("patchme-dry.txt");
+            fs::write(&file, "alpha\nbeta\n").unwrap();
+
+            let diff = format!(
+                "--- a/{}\n+++ b/{}\n@@ -1,2 +1,2 @@\n alpha\n-beta\n+gamma\n",
+                file.display(),
+                file.display()
+            );
+            let input = json!({ "diff": diff, "dry_run": true }).to_string();
+            run_apply_patch(&input).unwrap();
+
+            assert_eq!(
+                fs::read_to_string(&file).unwrap(),
+                "alpha\nbeta\n",
+                "file must be unchanged after dry_run"
+            );
+
+            let trash = home.join(".claudette").join("trash");
+            if trash.exists() {
+                let entries: Vec<_> = fs::read_dir(&trash)
+                    .unwrap()
+                    .map(|e| e.unwrap().path())
+                    .collect();
+                assert!(entries.is_empty(), "dry_run must not create trash entries");
+            }
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
     }
 }

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -460,6 +460,15 @@ fn run_edit_file(input: &str) -> Result<String, String> {
         ));
     }
 
+    // Pre-image before the write so `/undo` can restore this file
+    // (roast EDIT-03). Fail-closed: no snapshot, no write.
+    crate::transcript::snapshot_to_trash(&path).map_err(|e| {
+        format!(
+            "edit_file: pre-image snapshot failed, refusing to edit {}: {e}",
+            path.display()
+        )
+    })?;
+
     // Atomic write: serialise to a sibling tmp file, preserve the original
     // file's permissions, then rename. A mid-write crash leaves either the
     // original file intact or the tmp behind for manual recovery — never a
@@ -1244,5 +1253,41 @@ mod tests {
         let _ = fs::remove_file(&out_p);
         let _ = fs::remove_file(&err_p);
         let _ = fs::remove_file(&done_p);
+    }
+
+    #[test]
+    fn edit_file_snapshots_a_pre_image() {
+        crate::with_temp_home(|home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            let file = home.join("editme.txt");
+            fs::write(&file, "alpha\nbeta\n").unwrap();
+            let input = json!({
+                "path": file.display().to_string(),
+                "old_text": "beta",
+                "new_text": "gamma",
+            })
+            .to_string();
+            run_edit_file(&input).unwrap();
+
+            assert_eq!(fs::read_to_string(&file).unwrap(), "alpha\ngamma\n");
+            let trash = home.join(".claudette").join("trash");
+            let entries: Vec<_> = fs::read_dir(&trash)
+                .unwrap()
+                .map(|e| e.unwrap().path())
+                .collect();
+            assert_eq!(entries.len(), 1, "expected exactly one pre-image");
+            assert_eq!(
+                fs::read_to_string(&entries[0]).unwrap(),
+                "alpha\nbeta\n",
+                "pre-image must hold the ORIGINAL content"
+            );
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
     }
 }


### PR DESCRIPTION
Closes roast finding **EDIT-03** (CRITICAL).

## Problem

`snapshot_to_trash` had exactly **two** production call sites: `write_file` (`tools/file_ops.rs:261`) and `todo_delete` (`tools/todos.rs:253`).

`apply_diff`, `apply_patch` and `edit_file` — the primary edit paths — wrote straight to a tmp file and renamed, with **no pre-image**. `is_recoverable` requires `entry.undo.trash`, so a turn whose only action was `apply_diff` made `/undo` a true no-op that prints "use `/undo one`" — and `/undo one` then restores an *unrelated older file*. Meanwhile `docs/usage.md:76` advertises "Restore everything the last turn changed."

## Fix

Fail-closed `snapshot_to_trash` in all three, mirroring `write_file`: no pre-image, no write.

Placement keeps the trash clean rather than snapshotting on every attempt:
- `apply_diff` — after the no-op guard, so a diff producing identical content leaves no entry.
- `edit_file` — after the match-count check, so a 0-match or ambiguous edit leaves no entry.
- `apply_patch` — every target snapshotted in a pass **before** the write loop (not inline per-file), so a snapshot failure on file 3 cannot leave files 1–2 already overwritten and unrecoverable. Inside `if !dry_run`, so a dry run still touches nothing.

No executor wiring was needed: `take_pending_undo` is unconditional and `should_record` is policy-driven, so all three (`DangerFullAccess`) now carry an undo ref into `actions.jsonl` automatically.

## Tests

Four new tests — one per editor plus a dry-run negative — each asserting the file changed, exactly one trash entry exists, and that entry holds the **original** content.

`cargo fmt --all` clean · `cargo clippy --all-targets --no-deps -- -D warnings` clean · `cargo test --lib --bins` = 1117 + 32 passed, 0 failed.

## Known gap, deliberately left for a separate card

`set_pending_undo` is a thread-local holding only the **most recent** snapshot, so a multi-file `apply_patch` still records an undo ref for the last file only. The pre-images for the other files are all written to trash and recoverable by hand — but `/undo` will only walk back one of them. Fixing that means changing the undo record shape to a list, which is out of scope for the safety-net PR.