### PR TITLE
fix(egress): stop HTTP_PROXY exfiltrating the conversation under --offline

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -233,7 +233,7 @@ impl OllamaApiClient {
 
     fn build(model: String, tools: ToolsProvider) -> Self {
         let base_url = resolve_ollama_url();
-        let http = reqwest::blocking::Client::builder()
+        let http = crate::egress::local_http_builder()
             .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .expect("failed to build reqwest blocking client");
@@ -512,7 +512,7 @@ pub fn probe_ollama() -> Result<String, String> {
     if skip_ollama_flag || (openai_compat && skip_lm_studio_flag) {
         return Ok(url);
     }
-    let client = reqwest::blocking::Client::builder()
+    let client = crate::egress::local_http_builder()
         .timeout(Duration::from_secs(3))
         .build()
         .map_err(|e| format!("could not build probe client: {e}"))?;

--- a/crates/claudette/src/brain_selector.rs
+++ b/crates/claudette/src/brain_selector.rs
@@ -170,7 +170,7 @@ fn served_model_names() -> Option<&'static Vec<String>> {
             } else {
                 format!("{base}/api/tags")
             };
-            let client = reqwest::blocking::Client::builder()
+            let client = crate::egress::local_http_builder()
                 .timeout(std::time::Duration::from_secs(4))
                 .build()
                 .ok()?;

--- a/crates/claudette/src/doctor.rs
+++ b/crates/claudette/src/doctor.rs
@@ -295,7 +295,7 @@ fn probe_brain() -> Status {
     );
 
     // Reachability
-    let client = match reqwest::blocking::Client::builder()
+    let client = match crate::egress::local_http_builder()
         .timeout(Duration::from_secs(4))
         .build()
     {

--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -236,6 +236,79 @@ pub fn guard_subprocess(action: &str) -> Result<(), String> {
     ))
 }
 
+/// Proxy environment variables reqwest/hyper-util honour, in both the
+/// upper- and lower-case spellings the ecosystem accepts. Checked by
+/// [`proxy_vars_set`].
+pub const PROXY_ENV_VARS: &[&str] = &[
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+];
+
+/// Names of the proxy variables that are currently set to a non-empty value.
+/// Empty vec means no proxy is configured.
+#[must_use]
+pub fn proxy_vars_set() -> Vec<&'static str> {
+    PROXY_ENV_VARS
+        .iter()
+        .filter(|k| std::env::var(k).is_ok_and(|v| !v.trim().is_empty()))
+        .copied()
+        .collect()
+}
+
+/// The constructor every client that talks to the **local model backend**
+/// must use.
+///
+/// `.no_proxy()` is the whole point. `is_allowed_host` decides on the host
+/// string in the URL, but reqwest defaults to `auto_sys_proxy: true` and
+/// hyper-util's proxy matcher has no loopback bypass — so without this, a
+/// loopback URL passes the guard and the socket still goes to `$HTTP_PROXY`,
+/// carrying the entire conversation with it. That was demonstrated end-to-end
+/// while the `🔒 offline mode` banner was on screen (roast SEC-01).
+///
+/// Cloud-reaching clients deliberately do NOT use this: a corporate proxy is
+/// legitimate for `web_fetch`/GitHub/Gmail, and offline mode blocks those
+/// through [`guard`] instead.
+///
+/// No `#[must_use]`: `ClientBuilder` already carries it, and adding a second
+/// trips `clippy::double_must_use`.
+pub fn local_http_builder() -> reqwest::blocking::ClientBuilder {
+    reqwest::blocking::Client::builder().no_proxy()
+}
+
+/// Startup preflight for offline mode: refuse to run at all when a proxy is
+/// configured.
+///
+/// Under offline mode every allowed destination is loopback or the local
+/// backend, so a proxy is never legitimate — it can only move traffic
+/// off-box. Belt-and-braces with [`local_http_builder`]: that stops the
+/// local clients leaking, this stops the session starting in a posture whose
+/// banner would be a lie.
+///
+/// A no-op when offline mode is off.
+///
+/// # Errors
+/// Returns a message naming the offending variables when offline mode is on
+/// and any proxy variable is set.
+pub fn preflight_offline_proxy() -> Result<(), String> {
+    if !is_offline() {
+        return Ok(());
+    }
+    let set = proxy_vars_set();
+    if set.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "{BLOCK_PREFIX}: refusing to start — {} is set. A proxy would route \
+         even loopback traffic off this machine, so the air-gap could not be \
+         honoured. Unset it (or drop --offline) and re-run.",
+        set.join(", ")
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,12 +321,31 @@ mod tests {
     struct EnvGuard {
         offline: Option<String>,
         ollama: Option<String>,
+        /// Every proxy var, captured alongside the rest so restoration is
+        /// RAII and therefore panic-safe: a failing assert still hands the
+        /// next test a clean environment instead of leaking a proxy setting
+        /// into it.
+        proxies: Vec<(&'static str, Option<String>)>,
     }
     impl EnvGuard {
         fn capture() -> Self {
             Self {
                 offline: std::env::var(OFFLINE_ENV).ok(),
                 ollama: std::env::var("OLLAMA_HOST").ok(),
+                proxies: PROXY_ENV_VARS
+                    .iter()
+                    .map(|k| (*k, std::env::var(k).ok()))
+                    .collect(),
+            }
+        }
+
+        /// Clear every proxy var so a test asserts against a known-empty
+        /// baseline. Without this the proxy tests depend on the developer's
+        /// own environment — they would fail on exactly the corporate-proxy
+        /// machine this feature exists to protect.
+        fn clear_proxies() {
+            for k in PROXY_ENV_VARS {
+                std::env::remove_var(k);
             }
         }
     }
@@ -261,6 +353,9 @@ mod tests {
         fn drop(&mut self) {
             restore(OFFLINE_ENV, self.offline.as_deref());
             restore("OLLAMA_HOST", self.ollama.as_deref());
+            for (key, val) in &self.proxies {
+                restore(key, val.as_deref());
+            }
         }
     }
     fn restore(key: &str, val: Option<&str>) {
@@ -412,6 +507,95 @@ mod tests {
         assert!(
             lan.iter().any(|h| h == "192.168.1.50"),
             "LAN backend host listed: {lan:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_vars_set_detects_both_spellings() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        EnvGuard::clear_proxies();
+
+        // All unset → empty.
+        assert!(proxy_vars_set().is_empty(), "all unset should be empty");
+
+        // NOTE: assertions here use `contains`, never equality against an
+        // exact vec. Windows environment variables are case-INSENSITIVE, so
+        // `HTTP_PROXY` and `http_proxy` are the same variable there and
+        // setting one makes both spellings readable — while on Linux/macOS
+        // they are two independent variables. `contains` is the only
+        // assertion true on both, and Windows is in the CI matrix.
+
+        // An upper-case spelling is detected.
+        std::env::set_var("HTTP_PROXY", "http://p:8080");
+        assert!(
+            proxy_vars_set().contains(&"HTTP_PROXY"),
+            "HTTP_PROXY should be detected"
+        );
+
+        // A lower-case spelling is detected too.
+        EnvGuard::clear_proxies();
+        std::env::set_var("all_proxy", "http://p:8081");
+        let result = proxy_vars_set();
+        assert!(
+            result.contains(&"all_proxy") || result.contains(&"ALL_PROXY"),
+            "a lower-case spelling should be detected: {result:?}"
+        );
+
+        // An empty value must NOT count as configured — on Unix it reads
+        // back as `Ok("")`, on Windows it may be removed outright; either
+        // way it means "no proxy".
+        EnvGuard::clear_proxies();
+        std::env::set_var("HTTP_PROXY", "");
+        assert!(
+            proxy_vars_set().is_empty(),
+            "empty-string var must not count as set"
+        );
+    }
+
+    #[test]
+    fn preflight_is_noop_when_offline_off() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        EnvGuard::clear_proxies();
+
+        // Ensure offline is off.
+        std::env::remove_var(OFFLINE_ENV);
+        // Set a proxy var.
+        std::env::set_var("HTTP_PROXY", "http://p:8080");
+
+        // Should be Ok because offline mode is off.
+        assert!(preflight_offline_proxy().is_ok());
+    }
+
+    #[test]
+    fn preflight_refuses_offline_with_proxy() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _g = EnvGuard::capture();
+        EnvGuard::clear_proxies();
+
+        // Enable offline mode.
+        std::env::set_var(OFFLINE_ENV, "1");
+        // Set HTTPS_PROXY.
+        std::env::set_var("HTTPS_PROXY", "http://p:8080");
+
+        let result = preflight_offline_proxy();
+        assert!(result.is_err(), "should be Err when offline + proxy set");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.starts_with(BLOCK_PREFIX),
+            "message starts with BLOCK_PREFIX: {msg}"
+        );
+        assert!(
+            msg.contains("HTTPS_PROXY"),
+            "message names HTTPS_PROXY: {msg}"
+        );
+
+        // Unset the proxy var → should now be Ok.
+        std::env::remove_var("HTTPS_PROXY");
+        assert!(
+            preflight_offline_proxy().is_ok(),
+            "should be Ok after unsetting proxy"
         );
     }
 }

--- a/crates/claudette/src/firstrun.rs
+++ b/crates/claudette/src/firstrun.rs
@@ -65,7 +65,7 @@ pub fn classify_models_response(names: &[String], configured: &str) -> FirstRunC
 /// [`offer_fix_interactive`] does), so an offline session never probes.
 #[must_use]
 pub fn classify_backend(base_url: &str, openai_compat: bool, configured: &str) -> FirstRunCause {
-    let Ok(client) = reqwest::blocking::Client::builder()
+    let Ok(client) = crate::egress::local_http_builder()
         .timeout(Duration::from_secs(4))
         .build()
     else {

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -352,6 +352,18 @@ fn main() -> ExitCode {
         unknown_flags: _,
     } = args;
 
+    // ── Offline preflight: proxy vars ────────────────────────────────
+    // Must precede the banner. A configured proxy routes even loopback
+    // traffic off-box, so printing "the air-gap is enforced" and then
+    // running would be a false claim — this is exactly the path that was
+    // demonstrated exfiltrating a whole conversation (roast SEC-01).
+    // Refuse instead: a guard that cannot honour its condition must not
+    // allow.
+    if let Err(msg) = claudette::egress::preflight_offline_proxy() {
+        eprintln!("{} {}", theme::error(theme::ERR_GLYPH), theme::error(&msg));
+        return ExitCode::FAILURE;
+    }
+
     // ── Offline-mode banner ───────────────────────────────────────────
     // Loud, one-line confirmation that the air-gap is enforced this run.
     // `--doctor` prints its own dedicated offline section, so skip it here

--- a/crates/claudette/src/recall.rs
+++ b/crates/claudette/src/recall.rs
@@ -470,7 +470,7 @@ pub struct OllamaEmbedder {
 
 impl OllamaEmbedder {
     pub fn new() -> Result<Self, String> {
-        let client = reqwest::blocking::Client::builder()
+        let client = crate::egress::local_http_builder()
             // Embed calls themselves are fast (<100ms) but the first call
             // on a cold model triggers a load that can take ~2s on CPU.
             // Pulls are bounded by the separate ensure_model branch.
@@ -640,7 +640,7 @@ pub struct OpenAICompatEmbedder {
 
 impl OpenAICompatEmbedder {
     pub fn new() -> Result<Self, String> {
-        let client = reqwest::blocking::Client::builder()
+        let client = crate::egress::local_http_builder()
             .timeout(std::time::Duration::from_secs(60))
             .build()
             .map_err(|e| format!("recall: build http client: {e}"))?;

--- a/crates/claudette/src/tools/vision.rs
+++ b/crates/claudette/src/tools/vision.rs
@@ -217,7 +217,7 @@ fn run_image_describe(input: &str) -> Result<String, String> {
         }]
     });
 
-    let client = reqwest::blocking::Client::builder()
+    let client = crate::egress::local_http_builder()
         .timeout(std::time::Duration::from_secs(DESCRIBE_TIMEOUT_SECS))
         .build()
         .map_err(|e| format!("image_describe: build client failed: {e}"))?;

--- a/crates/claudette/src/tui.rs
+++ b/crates/claudette/src/tui.rs
@@ -568,7 +568,7 @@ fn hw_ollama_url() -> String {
 }
 
 fn poll_ollama(url: &str) -> Result<Vec<OllamaModel>, String> {
-    let client = reqwest::blocking::Client::builder()
+    let client = crate::egress::local_http_builder()
         .timeout(Duration::from_secs(1))
         .build()
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Roast `SEC-01`, **CRITICAL, demonstrated**. With `HTTP_PROXY` set, claudette printed the `🔒 offline mode` banner and then shipped the full system prompt and conversation to the proxy.

## Cause

`egress::is_allowed_host` decides on the **host string in the URL**. reqwest defaults to `auto_sys_proxy: true`, and hyper-util's proxy matcher has **no loopback bypass** — so `http://localhost:1234/...` passed the guard and the socket went to `$HTTP_PROXY` anyway. There were **zero** `.no_proxy()` calls in the crate.

This also silently broke the **default** (non-offline) posture: on any machine with a corporate proxy, traffic meant for the local model backend was routed off-box.

## The rule applied

Deliberately **not** a blanket `.no_proxy()` — a corporate proxy is legitimate for genuinely-cloud tools:

> A client that talks to the **local model backend** must never use a proxy.
> Offline mode must **refuse to start** if proxy variables are set at all.

All 14 reqwest builders were classified:

- **9 local** → new `egress::local_http_builder()` with `.no_proxy()`: `api.rs` (brain + probe), `brain_selector`, `doctor`, `firstrun`, `recall` ×2, `tui`, `tools/vision`.
- **5 cloud** → deliberately untouched: `telegram_mode`, `google_auth` ×2, `external_http_client`, `web_fetch`. Offline mode blocks these via `guard` instead.

`egress::preflight_offline_proxy()` is wired into `main.rs` **before** the banner, so the reassuring line is never printed in a posture that cannot honour it — *a guard that cannot honour its condition must refuse, not allow.*

## Verified behaviourally, not just by unit test

| scenario | result |
|---|---|
| `--offline` + `HTTP_PROXY` | **refuses, exit 1, no banner printed** |
| `--offline` + lower-case `http_proxy` | refuses |
| `--offline`, no proxy | runs normally, exit 0 |
| dead proxy set, offline **off** | `--doctor` still reports backend `reachable HTTP 200` — pre-fix that request went to the proxy |

Gate: `cargo fmt` clean, `clippy --all-targets -D warnings` clean, **1120 + 32 tests pass, 0 failed**.

## Note on the tests

The proxy tests clear every proxy variable to a known baseline first, and `EnvGuard` now restores them via `Drop`. Both matter: without the reset the tests depend on the developer's own environment and would fail on exactly the corporate-proxy machine this change protects.

Assertions use `contains` rather than vec equality because **Windows environment variables are case-insensitive** — `HTTP_PROXY` and `http_proxy` are one variable there and two on Unix. Windows is in the CI matrix, and the first draft of this test failed there for that reason.

## Out of scope

`README.md:3` ("your code **physically cannot** leave the machine") and `PRIVACY.md` are **untouched**. That rewording (`BENCH-11`) is a separate decision now unblocked by this PR.

Also noticed while classifying, **not** fixed here: `web_fetch` pins IPs via `resolve_to_addrs`, but a configured proxy would make that pinning moot — a possible SSRF-guard bypass worth its own card.