### PR TITLE
fix(runtime): an empty final turn must not destroy the turn's work

### DIFF
--- a/crates/claudette/src/brain_selector.rs
+++ b/crates/claudette/src/brain_selector.rs
@@ -544,6 +544,7 @@ mod tests {
             auto_compaction: None,
             hit_iteration_cap: false,
             synthesized_reply: None,
+            ended_without_reply: false,
         }
     }
 

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -565,6 +565,13 @@ fn main() -> ExitCode {
                         }
                     }
                 }
+                // A turn that ended without a closing message streams nothing and
+                // has no text block to print above — without this the run would
+                // finish in silence and look like it did nothing. Same contract
+                // the REPL honours (`run/repl.rs`).
+                if let Some(reply) = &summary.synthesized_reply {
+                    eprintln!("{}", theme::dim(reply));
+                }
                 eprintln!();
                 eprintln!(
                     "{} {}",

--- a/crates/claudette/src/main.rs
+++ b/crates/claudette/src/main.rs
@@ -581,6 +581,23 @@ fn main() -> ExitCode {
                         summary.iterations, summary.usage.input_tokens, summary.usage.output_tokens,
                     ))
                 );
+                // The turn's work is kept, but a model that stopped without ever
+                // delivering a reply has not shown it finished — it may equally
+                // have abandoned mid-task. Exiting 0 here would report success on
+                // a run that did nothing, which is exactly the silent-optimistic
+                // failure this codebase keeps getting bitten by. Surface it and
+                // let the caller decide.
+                if summary.ended_without_reply {
+                    eprintln!(
+                        "{} {}",
+                        theme::warn(theme::WARN_GLYPH),
+                        theme::warn(
+                            "the model stopped without a closing reply — its work above is kept, \
+                             but the task is NOT confirmed complete"
+                        )
+                    );
+                    return ExitCode::FAILURE;
+                }
                 ExitCode::SUCCESS
             }
             Err(e) => {

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -1128,6 +1128,7 @@ fn empty_turn_summary() -> TurnSummary {
         auto_compaction: None,
         hit_iteration_cap: false,
         synthesized_reply: None,
+        ended_without_reply: false,
     }
 }
 

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -480,8 +480,13 @@ where
             // forever, and the outer nudge retry in `run.rs` then restarted at the
             // *base* budget — making the third attempt weaker than the second.
             let mut attempt: u32 = 0;
+            // The ceiling actually granted to the last attempt — not the base
+            // budget. Reporting the base would understate what was already tried
+            // and send the user to raise a knob that had in fact been exceeded.
+            let mut last_ceiling = crate::api::current_num_predict();
             while turn_produced_no_content(&events) && attempt < EMPTY_TURN_MAX_RETRIES {
                 attempt += 1;
+                last_ceiling = empty_turn_retry_ceiling(attempt, crate::api::current_num_ctx());
                 let retry_request = ApiRequest {
                     system_prompt: request.system_prompt.clone(),
                     messages: apply_context_eviction(
@@ -489,15 +494,33 @@ where
                         num_ctx,
                         evict_trigger,
                     ),
-                    max_output_tokens: Some(empty_turn_retry_ceiling(
-                        attempt,
-                        crate::api::current_num_ctx(),
-                    )),
+                    max_output_tokens: Some(last_ceiling),
                 };
                 events = self.api_client.stream(&retry_request)?;
             }
             if turn_produced_no_content(&events) {
-                return Err(empty_turn_error(&events));
+                // A content-less turn *after* the model has already worked this
+                // turn is it signalling "done" without writing a closing message:
+                // the backend ends the turn `finish_reason=stop` carrying only
+                // reasoning. Aborting here throws away an entire turn's completed
+                // work — edits already on disk, tool results already in the
+                // session — and reports failure for a run that had, in substance,
+                // succeeded.
+                //
+                // Measured 2026-08-02: this killed 2 of 3 co-dev cards *after*
+                // every edit had landed, leaving half-written trees behind. The
+                // escalating budget retry cannot help — these turns stop cleanly,
+                // they do not run out of room.
+                //
+                // Only a turn that produced nothing at all is a genuine failure,
+                // so the honest error is kept for that case. Ending silently would
+                // be its own lie, so hand the caller a line to print — the same
+                // contract the iteration-cap landing uses.
+                if !assistant_messages.is_empty() {
+                    synthesized_reply = Some(empty_final_turn_note(&events));
+                    break;
+                }
+                return Err(empty_turn_error(&events, last_ceiling));
             }
             let (assistant_message, usage) = build_assistant_message(events)?;
             if let Some(usage) = usage {
@@ -975,13 +998,30 @@ fn empty_turn_retry_ceiling(attempt: u32, num_ctx: u32) -> u32 {
     scaled.min((num_ctx / 2).max(base))
 }
 
+/// Note handed to the caller when a turn ended on a content-less reply *after*
+/// doing real work. The work is kept; this exists so the turn does not end in
+/// silence and leave the user guessing whether anything happened.
+fn empty_final_turn_note(events: &[AssistantEvent]) -> String {
+    let reason = events
+        .iter()
+        .find_map(|event| match event {
+            AssistantEvent::StreamMeta { finish_reason, .. } => finish_reason.as_deref(),
+            _ => None,
+        })
+        .unwrap_or("none");
+    format!(
+        "[the model ended this turn without a closing message (finish_reason={reason}); \
+         its tool calls above completed and their results are kept]"
+    )
+}
+
 /// Build the abort error for a turn that produced no content after every
 /// retry, naming the actual cause instead of just the symptom.
 ///
 /// Keeps the substring `produced no content` — `run::run_turn_with_retry`
 /// matches on it to decide whether to fire the `enable_tools` nudge, and
 /// changing the wording silently would disable that outer recovery.
-fn empty_turn_error(events: &[AssistantEvent]) -> RuntimeError {
+fn empty_turn_error(events: &[AssistantEvent], budget: u32) -> RuntimeError {
     let meta = events.iter().find_map(|event| match event {
         AssistantEvent::StreamMeta {
             finish_reason,
@@ -989,7 +1029,6 @@ fn empty_turn_error(events: &[AssistantEvent]) -> RuntimeError {
         } => Some((finish_reason.as_deref(), *reasoning_chars)),
         _ => None,
     });
-    let budget = crate::api::current_num_predict();
 
     match meta {
         // The backend told us exactly what happened: generation was cut off at
@@ -1689,6 +1728,66 @@ mod tests {
         assert!(
             err.contains("CLAUDETTE_NUM_PREDICT"),
             "must name the knob that fixes it: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_turn_after_real_work_keeps_the_work_instead_of_aborting() {
+        // The failure that killed 2 of 3 co-dev cards on 2026-08-02: the model
+        // makes a tool call, gets its result, then ends the next turn cleanly
+        // with only reasoning and no closing message. Aborting there discarded a
+        // whole turn of completed edits and reported failure for work that had
+        // actually landed. The turn must now SUCCEED, keep the tool result, and
+        // hand the caller an honest line to print.
+        let silent = || {
+            vec![
+                AssistantEvent::StreamMeta {
+                    finish_reason: Some("stop".to_string()),
+                    reasoning_chars: 204,
+                },
+                AssistantEvent::MessageStop,
+            ]
+        };
+        let api = QueuedApi::new(vec![
+            // Iteration 1: a real tool call.
+            vec![
+                AssistantEvent::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "add".to_string(),
+                    input: r#"{"a":1,"b":2}"#.to_string(),
+                },
+                AssistantEvent::MessageStop,
+            ],
+            // Iteration 2 and its retries: clean, silent, no answer.
+            silent(),
+            silent(),
+            silent(),
+        ]);
+        let mut runtime = queued_runtime(api);
+
+        let summary = runtime
+            .run_turn("use add", None)
+            .expect("work already done must not be thrown away");
+
+        assert_eq!(
+            summary.tool_results.len(),
+            1,
+            "the completed tool result must survive"
+        );
+        assert!(
+            !summary.assistant_messages.is_empty(),
+            "the assistant message carrying the tool call must survive"
+        );
+        let note = summary
+            .synthesized_reply
+            .expect("caller needs a line to print, or the turn ends in silence");
+        assert!(
+            note.contains("finish_reason=stop"),
+            "note must name what happened: {note}"
+        );
+        assert!(
+            !summary.hit_iteration_cap,
+            "this is not an iteration-cap landing"
         );
     }
 

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -209,6 +209,20 @@ pub struct TurnSummary {
     /// nothing — the caller prints this instead. `None` when the landing
     /// produced real text (already streamed) or the cap was not hit.
     pub synthesized_reply: Option<String>,
+    /// Set when the turn ended on a content-less reply *after* doing real work:
+    /// the model stopped without writing a closing message.
+    ///
+    /// The work is kept — discarding a completed turn is never the right answer.
+    /// But "kept the work" is not the same as "the task is done", and the runtime
+    /// **cannot tell the two apart**: an empty final turn looks identical whether
+    /// the model finished or abandoned mid-task. Observed in the wild doing both,
+    /// including one run that announced its next step ("let me undo that and use
+    /// edit_file instead") and then simply stopped.
+    ///
+    /// So callers must not read a plain `Ok` as success. Single-shot exits
+    /// non-zero on this, because a turn that never delivered a reply has not
+    /// demonstrated it completed anything.
+    pub ended_without_reply: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -414,6 +428,7 @@ where
         let mut nudged_no_progress = false;
         let mut hit_iteration_cap = false;
         let mut synthesized_reply: Option<String> = None;
+        let mut ended_without_reply = false;
 
         loop {
             iterations += 1;
@@ -518,6 +533,7 @@ where
                 // contract the iteration-cap landing uses.
                 if !assistant_messages.is_empty() {
                     synthesized_reply = Some(empty_final_turn_note(&events));
+                    ended_without_reply = true;
                     break;
                 }
                 return Err(empty_turn_error(&events, last_ceiling));
@@ -794,6 +810,7 @@ where
             auto_compaction,
             hit_iteration_cap,
             synthesized_reply,
+            ended_without_reply,
         })
     }
 
@@ -1788,6 +1805,16 @@ mod tests {
         assert!(
             !summary.hit_iteration_cap,
             "this is not an iteration-cap landing"
+        );
+        // The work is kept, but the turn must NOT read as a clean success: the
+        // runtime cannot tell "finished" from "abandoned mid-task", and a caller
+        // that treats this as done will report success for a run that did
+        // nothing. Observed live: a model reverted its own edit, announced it
+        // would retry with another tool, then stopped — an empty patch that
+        // still compiled, so every gate passed.
+        assert!(
+            summary.ended_without_reply,
+            "an empty final turn must be flagged, not silently accepted as success"
         );
     }
 

--- a/crates/claudette/src/telegram_mode.rs
+++ b/crates/claudette/src/telegram_mode.rs
@@ -1312,6 +1312,7 @@ mod tests {
             auto_compaction: None,
             hit_iteration_cap: false,
             synthesized_reply: None,
+            ended_without_reply: false,
         };
         let text = extract_response_text(&summary);
         assert!(text.contains("no text"));


### PR DESCRIPTION
## What happened

A 3-card co-dev battery lost **2 of 3 cards** to this. In both cases every edit had
already landed on disk; the run then died on the next turn and left a tree that no
longer compiled.

The fatal was:

```
assistant stream produced no content — the backend ended the turn cleanly
(finish_reason=stop) with 204 chars of reasoning and no answer.
```

That is the model signalling *done* without writing a closing message. It is **not**
budget exhaustion — the escalating retry added earlier today cannot help, because
these turns stop cleanly rather than running out of room. It survived the base
attempt, both escalating retries, and the outer nudge turn.

## The fix

If earlier iterations of the turn produced assistant messages, an empty turn now
**breaks the loop and returns the completed work** instead of `Err`. A turn that
produced nothing at all is still a genuine failure and still aborts with the honest
error.

Ending silently would be its own lie, so the caller gets a line to print through
`synthesized_reply` — the same contract the iteration-cap landing already uses:

```
[the model ended this turn without a closing message (finish_reason=stop);
 its tool calls above completed and their results are kept]
```

⚠️ `run/repl.rs:200` prints that field independently of `hit_iteration_cap`, but
**single-shot never printed it at all** — which is exactly the path co-dev runs on,
so the note would have vanished where it matters most. `main.rs` now prints it too.

## Also: a truthfulness fix to today's earlier message

The abort added in #225 reported the **base** `num_predict` as the ceiling that was
hit, when escalation had already tried up to `num_ctx / 2`. On a real failure it said
*"hit its 16384-token output ceiling … Raise CLAUDETTE_NUM_PREDICT above 16384"* — for
a turn that had in fact already been granted 30720. It now reports the ceiling
actually granted to the last attempt.

## Verification

Gate: `cargo fmt --all` clean · `clippy --all-targets --no-deps -D warnings` clean ·
**1125 + 32 tests pass, 0 fail**.

New test `empty_turn_after_real_work_keeps_the_work_instead_of_aborting` reproduces the
exact shape that killed the cards — tool call, then a clean silent turn plus its
retries — and asserts the tool result survives, the assistant message survives, the
caller gets a printable note, and `hit_iteration_cap` is *not* set.