### PR TITLE
fix(edit): gate write_file overwrites and log every file mutation

### DIFF
--- a/crates/claudette/src/diff_preview.rs
+++ b/crates/claudette/src/diff_preview.rs
@@ -26,6 +26,7 @@ pub fn render(tool_name: &str, input: &str) -> Option<Vec<String>> {
         "apply_diff" => render_replacement(input, "before", "after"),
         "edit_file" => render_replacement(input, "old_text", "new_text"),
         "apply_patch" => render_unified(input),
+        "write_file" => render_overwrite(input),
         _ => None,
     }
 }
@@ -74,6 +75,37 @@ pub fn render_file_change(path: &str, old: &str, new: &str) -> Vec<String> {
         out.push(theme::dim(&format!("  {line}")).to_string());
     }
     out
+}
+
+/// Render a `write_file` that would REPLACE an existing file: read what is on
+/// disk right now and diff it against the content about to land, so the `[y/N]`
+/// gate shows what is being LOST rather than a wall of new content.
+///
+/// `None` for a brand-new file (nothing to lose — the raw dump is the right
+/// rendering there) or when the target can't be resolved or read as text.
+fn render_overwrite(input: &str) -> Option<Vec<String>> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let path_str = v.get("path").and_then(Value::as_str)?;
+    let content = v.get("content").and_then(Value::as_str)?;
+    let target = crate::tools::file_ops::existing_write_target(path_str)?;
+    let existing = std::fs::read_to_string(&target).ok()?;
+
+    let mut out = render_file_change(&target.display().to_string(), &existing, content);
+    // Headline the size change right under the path header. A whole-file diff
+    // of a truncation is hundreds of `-` lines, and the one number that decides
+    // the answer must not be something the reviewer has to count.
+    out.insert(
+        1,
+        theme::warn(&format!(
+            "OVERWRITING an existing file: {} lines ({} bytes) → {} lines ({} bytes)",
+            existing.lines().count(),
+            existing.len(),
+            content.lines().count(),
+            content.len(),
+        ))
+        .to_string(),
+    );
+    Some(out)
 }
 
 /// Render an apply_patch unified diff with per-line coloring: file headers and
@@ -206,5 +238,40 @@ mod tests {
         assert!(render("apply_diff", "not json").is_none());
         assert!(render("apply_diff", r#"{"path":"f","before":"x"}"#).is_none());
         assert!(render("apply_patch", r#"{"dry_run":true}"#).is_none());
+    }
+
+    /// roast EDIT-04: an overwrite preview must show what is being LOST and
+    /// lead with the size change — a truncation is otherwise hundreds of `-`
+    /// lines the reviewer has to count.
+    #[test]
+    fn write_file_overwrite_previews_the_loss() {
+        crate::with_temp_home(|_home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            // A path with no file behind it: nothing to lose, no preview.
+            let create = r#"{"path":"nothing-here.txt","content":"new\n"}"#;
+            assert!(render("write_file", create).is_none());
+
+            let target = crate::tools::file_ops::existing_write_target("nothing-here.txt");
+            assert!(target.is_none());
+
+            // Now make the file exist, then aim a truncating write at it.
+            let dir = crate::tools::files_dir();
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("victim.txt"), "keep\nme\nplease\n").unwrap();
+
+            let out = render("write_file", r#"{"path":"victim.txt","content":"oops\n"}"#)
+                .expect("an existing target must render a preview");
+            let joined = out.join("\n");
+            assert!(joined.contains("OVERWRITING"), "no size headline: {joined}");
+            assert!(joined.contains("- keep"), "lost line not shown: {joined}");
+            assert!(joined.contains("+ oops"), "new line not shown: {joined}");
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
     }
 }

--- a/crates/claudette/src/runtime/permissions.rs
+++ b/crates/claudette/src/runtime/permissions.rs
@@ -217,6 +217,40 @@ impl PermissionPolicy {
         scored.into_iter().map(|(_, n)| n).take(max).collect()
     }
 
+    /// The tier this specific CALL needs: `required_mode_for` (name only) plus
+    /// the one input-dependent rule we have.
+    ///
+    /// `write_file` onto a path that ALREADY EXISTS is an edit, not a create,
+    /// and every other edit tool (`edit_file`, `apply_diff`, `apply_patch`) is
+    /// `DangerFullAccess`. Leaving it at `WorkspaceWrite` made the only tool
+    /// that can replace a whole file the only one that never prompts and never
+    /// previews (roast EDIT-04): an output-budget cut mid-generation yields a
+    /// partial `content`, and the whole file is silently replaced by it.
+    ///
+    /// Deliberately lenient when the input cannot be evaluated (unparseable
+    /// JSON, no `path`, a path that fails `validate_write_path`). That is NOT
+    /// the "a guard that cannot evaluate its condition must refuse" case — in
+    /// every one of those branches `run_write_file` returns `Err` before
+    /// touching the disk, so there is provably nothing to guard.
+    #[must_use]
+    pub fn effective_required_mode(&self, tool_name: &str, input: &str) -> PermissionMode {
+        let base = self.required_mode_for(tool_name);
+        if tool_name != "write_file" || base != PermissionMode::WorkspaceWrite {
+            return base;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(input) else {
+            return base;
+        };
+        let Some(path_str) = v.get("path").and_then(serde_json::Value::as_str) else {
+            return base;
+        };
+        if crate::tools::file_ops::existing_write_target(path_str).is_some() {
+            PermissionMode::DangerFullAccess
+        } else {
+            base
+        }
+    }
+
     #[must_use]
     pub fn authorize(
         &self,
@@ -225,7 +259,7 @@ impl PermissionPolicy {
         mut prompter: Option<&mut dyn PermissionPrompter>,
     ) -> PermissionOutcome {
         let current_mode = self.active_mode();
-        let required_mode = self.required_mode_for(tool_name);
+        let required_mode = self.effective_required_mode(tool_name, input);
 
         // Hard cap: deny without prompt when a tool's required tier exceeds
         // the policy's `max_tier`. Independent of `active_mode` so even an
@@ -602,5 +636,56 @@ mod tests {
 
         assert_eq!(outcome, PermissionOutcome::Allow);
         assert_eq!(prompter.seen.len(), 1, "prompter should still be invoked");
+    }
+
+    /// roast EDIT-04: `write_file` onto an EXISTING file is an edit, so it must
+    /// reach the danger tier — the same tier `edit_file` / `apply_diff` /
+    /// `apply_patch` already sit at. Creating a new file stays auto-allowed.
+    #[test]
+    fn write_file_escalates_to_danger_only_when_it_overwrites() {
+        crate::with_temp_home(|_home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            let policy = crate::run::build_permission_policy();
+
+            let create = r#"{"path":"brand-new.txt","content":"hello"}"#;
+            assert_eq!(
+                policy.effective_required_mode("write_file", create),
+                PermissionMode::WorkspaceWrite,
+                "creating a file must stay auto-allowed"
+            );
+            assert_eq!(
+                policy.authorize("write_file", create, None),
+                PermissionOutcome::Allow
+            );
+
+            // Create it, then aim at it again.
+            crate::tools::dispatch_tool("write_file", create).expect("create should succeed");
+
+            assert_eq!(
+                policy.effective_required_mode("write_file", create),
+                PermissionMode::DangerFullAccess,
+                "overwriting an existing file must reach the danger tier"
+            );
+            // Non-interactive session (no prompter) can no longer silently
+            // truncate it — exactly how edit_file already behaves there.
+            assert!(matches!(
+                policy.authorize("write_file", create, None),
+                PermissionOutcome::Deny { .. }
+            ));
+
+            // An input the gate cannot evaluate is left alone: run_write_file
+            // rejects it before touching the disk, so there is nothing to guard.
+            assert_eq!(
+                policy.effective_required_mode("write_file", "{}"),
+                PermissionMode::WorkspaceWrite
+            );
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
     }
 }

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -43,7 +43,7 @@ mod calendar {
 mod clipboard;
 mod dialog;
 mod facts;
-mod file_ops;
+pub(crate) mod file_ops;
 mod forge_tail;
 mod fuzzy_apply;
 mod git;
@@ -957,6 +957,37 @@ fn reject_write_symlink_escape(resolved: &Path, roots: &[PathBuf]) -> Result<(),
             target_canon.display()
         ))
     }
+}
+
+/// Emit one `▸` line for a completed file mutation, mirroring `apply_diff`'s
+/// call logging (`fuzzy_apply.rs`). Shared by `write_file`, `edit_file` and
+/// `apply_patch`, all three of which used to mutate files in COMPLETE silence:
+/// a live unattended run replaced a 710-line source file with a ~40-line
+/// fragment and the whole run log was 214 bytes (roast EDIT-04, reproduced
+/// 2026-08-02). Under `CLAUDETTE_AUTO_APPROVE=1` no permission prompt can
+/// fire, so this line is the only signal that anything happened at all.
+///
+/// `previous_bytes` is the size of what was replaced, or `None` for a newly
+/// created file. Losing more than half the file is printed in the warning
+/// colour: that is the signature of an output-budget cut mid-generation, and
+/// it is the one case worth interrupting a run for.
+pub(super) fn log_file_write(
+    tool: &str,
+    path: &Path,
+    previous_bytes: Option<usize>,
+    new_bytes: usize,
+) {
+    let line = match previous_bytes {
+        Some(before) => format!("{tool}: {} ({before} → {new_bytes} bytes)", path.display()),
+        None => format!("{tool}: {} (new, {new_bytes} bytes)", path.display()),
+    };
+    let shrank = previous_bytes.is_some_and(|before| new_bytes.saturating_mul(2) < before);
+    let body = if shrank {
+        crate::theme::warn(&format!("{line} — LOST MORE THAN HALF THE FILE"))
+    } else {
+        crate::theme::dim(&line)
+    };
+    eprintln!("  {} {}", crate::theme::dim("▸"), body);
 }
 
 /// Validate a write path. Allowed roots:

--- a/crates/claudette/src/tools/file_ops.rs
+++ b/crates/claudette/src/tools/file_ops.rs
@@ -199,35 +199,22 @@ fn run_read_file(input: &str) -> Result<String, String> {
     .to_string())
 }
 
-fn run_write_file(input: &str) -> Result<String, String> {
-    let v: Value = serde_json::from_str(input)
-        .map_err(|e| format!("write_file: invalid JSON ({e}): {input}"))?;
-    let path_str = v
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or("write_file: missing 'path'")?;
-    let content = v
-        .get("content")
-        .and_then(Value::as_str)
-        .ok_or("write_file: missing 'content'")?;
-
-    if content.len() > MAX_FILE_BYTES {
-        return Err(format!(
-            "write_file: content is {} bytes, exceeds {MAX_FILE_BYTES}-byte limit",
-            content.len()
-        ));
-    }
-
-    // Bare relative paths get resolved under either the active mission
-    // tree (T2) or the scratch sandbox, NOT against the process CWD.
-    // Reasoning: the model says "save it to dolphins-post.txt" and
-    // expects it to land somewhere reasonable. Pre-T2 we rooted bare
-    // relative paths under ~/.claudette/files/. T2 keeps that fallback
-    // but routes to the mission tree when a brownfield mission is
-    // active — matching the brain's likely intent ("save README.md"
-    // means *the project's* README, not a copy in scratch).
-    // Absolute and ~/-prefixed paths still flow through validate_write_path
-    // unchanged so the user can still explicitly target a sub-folder.
+/// Resolve the raw `path` argument `write_file` was given to the file it will
+/// actually touch. Extracted from `run_write_file` so the permission gate
+/// (`PermissionPolicy::effective_required_mode`) and the `[y/N]` preview
+/// (`diff_preview::render`) test the SAME path the write uses — a second copy
+/// of this logic would drift and gate the wrong file.
+///
+/// Bare relative paths get resolved under either the active mission tree (T2)
+/// or the scratch sandbox, NOT against the process CWD. Reasoning: the model
+/// says "save it to dolphins-post.txt" and expects it to land somewhere
+/// reasonable. Pre-T2 we rooted bare relative paths under ~/.claudette/files/.
+/// T2 keeps that fallback but routes to the mission tree when a brownfield
+/// mission is active — matching the brain's likely intent ("save README.md"
+/// means *the project's* README, not a copy in scratch). Absolute and
+/// ~/-prefixed paths still flow through validate_write_path unchanged so the
+/// user can still explicitly target a sub-folder.
+fn resolve_write_target(path_str: &str) -> Result<std::path::PathBuf, String> {
     let resolved_input = if Path::new(path_str).is_absolute()
         || path_str.starts_with("~/")
         || path_str.starts_with("~\\")
@@ -247,7 +234,43 @@ fn run_write_file(input: &str) -> Result<String, String> {
         };
         base.join(path_str).display().to_string()
     };
-    let path = validate_write_path(&resolved_input)?;
+    validate_write_path(&resolved_input)
+}
+
+/// The file `write_file` would OVERWRITE for this raw `path` argument, or
+/// `None` when the call would create something new.
+///
+/// `is_file()`, not `exists()`: a directory target makes `run_write_file` fail
+/// anyway, and a preview must never try to read one as text.
+///
+/// Returning `None` for an unresolvable path is deliberate and safe — those
+/// calls make `run_write_file` return `Err` before touching the disk, so there
+/// is nothing to gate.
+pub(crate) fn existing_write_target(path_str: &str) -> Option<std::path::PathBuf> {
+    let path = resolve_write_target(path_str).ok()?;
+    path.is_file().then_some(path)
+}
+
+fn run_write_file(input: &str) -> Result<String, String> {
+    let v: Value = serde_json::from_str(input)
+        .map_err(|e| format!("write_file: invalid JSON ({e}): {input}"))?;
+    let path_str = v
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or("write_file: missing 'path'")?;
+    let content = v
+        .get("content")
+        .and_then(Value::as_str)
+        .ok_or("write_file: missing 'content'")?;
+
+    if content.len() > MAX_FILE_BYTES {
+        return Err(format!(
+            "write_file: content is {} bytes, exceeds {MAX_FILE_BYTES}-byte limit",
+            content.len()
+        ));
+    }
+
+    let path = resolve_write_target(path_str)?;
 
     if let Some(parent) = path.parent() {
         ensure_dir(parent)?;
@@ -257,16 +280,22 @@ fn run_write_file(input: &str) -> Result<String, String> {
     // have nothing to preserve. Fail-closed: no snapshot, no overwrite
     // (recoverability is the feature; a silent truncate was the data-loss
     // path the roast flagged).
-    if path.exists() {
+    let previous_bytes: Option<usize> = if path.exists() {
         crate::transcript::snapshot_to_trash(&path).map_err(|e| {
             format!(
                 "write_file: pre-image snapshot failed, refusing to overwrite {}: {e}",
                 path.display()
             )
         })?;
-    }
+        fs::metadata(&path)
+            .ok()
+            .and_then(|m| usize::try_from(m.len()).ok())
+    } else {
+        None
+    };
     fs::write(&path, content)
         .map_err(|e| format!("write_file: write {} failed: {e}", path.display()))?;
+    super::log_file_write("write_file", &path, previous_bytes, content.len());
 
     let result = json!({
         "ok": true,
@@ -398,6 +427,39 @@ mod tests {
                 std::fs::read_to_string(&entries[0]).unwrap(),
                 "v1",
                 "pre-image must hold the truncated content"
+            );
+
+            match prev_ws {
+                Some(v) => std::env::set_var("CLAUDETTE_WORKSPACE", v),
+                None => std::env::remove_var("CLAUDETTE_WORKSPACE"),
+            }
+        });
+    }
+
+    #[test]
+    fn existing_write_target_distinguishes_create_from_overwrite() {
+        crate::with_temp_home(|_home| {
+            let prev_ws = std::env::var("CLAUDETTE_WORKSPACE").ok();
+            std::env::remove_var("CLAUDETTE_WORKSPACE");
+
+            // Nothing there yet → a create, no danger-tier escalation.
+            assert!(
+                existing_write_target("target.txt").is_none(),
+                "a path with no file must read as a create"
+            );
+
+            run_write_file(r#"{"path":"target.txt","content":"v1"}"#).unwrap();
+
+            // Same path, now occupied → an overwrite the gate must catch.
+            let found = existing_write_target("target.txt")
+                .expect("an existing file must read as an overwrite");
+            assert_eq!(std::fs::read_to_string(&found).unwrap(), "v1");
+
+            // A directory is not an overwrite target — write_file refuses it
+            // anyway and a preview must never read one as text.
+            assert!(
+                existing_write_target(".").is_none(),
+                "a directory must not read as an overwrite"
             );
 
             match prev_ws {

--- a/crates/claudette/src/tools/patch.rs
+++ b/crates/claudette/src/tools/patch.rs
@@ -132,6 +132,11 @@ fn run_apply_patch(input: &str) -> Result<String, String> {
             })?;
         }
         for (path, content) in &pending {
+            // Read the pre-image size BEFORE the rename — the target still
+            // holds the original bytes at this point.
+            let previous_bytes = fs::metadata(path)
+                .ok()
+                .and_then(|m| usize::try_from(m.len()).ok());
             let tmp = path.with_extension("claudette-apply.tmp");
             fs::write(&tmp, content)
                 .map_err(|e| format!("apply_patch: write tmp {} failed: {e}", tmp.display()))?;
@@ -139,6 +144,7 @@ fn run_apply_patch(input: &str) -> Result<String, String> {
                 let _ = fs::remove_file(&tmp);
                 format!("apply_patch: rename to {} failed: {e}", path.display())
             })?;
+            super::log_file_write("apply_patch", path, previous_bytes, content.len());
         }
     }
 

--- a/crates/claudette/src/tools/shell.rs
+++ b/crates/claudette/src/tools/shell.rs
@@ -493,6 +493,8 @@ fn run_edit_file(input: &str) -> Result<String, String> {
         )
     })?;
 
+    super::log_file_write("edit_file", &path, Some(content.len()), new_content.len());
+
     let mut result = json!({
         "ok": true,
         "path": path.display().to_string(),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,6 +103,11 @@ Four additional commands are **Telegram-only** (they have no effect in the REPL 
 | **WorkspaceWrite** | Auto-allowed | note_create, todo_add, web_search, github comment |
 | **DangerFullAccess** | Prompts `[y/N]` every time | bash, edit_file, git add/commit/push/checkout, cross-org PRs |
 
+`write_file` is `WorkspaceWrite` when it creates a file and `DangerFullAccess` when
+the target already exists — overwriting a file is an edit, so it prompts and shows a
+diff of what would be lost. Every completed file write also prints a `▸` line naming
+the file and its size change, so unattended runs leave a trail.
+
 The REPL prompter is interactive. The TUI shows a confirmation modal over the chat — `y` allows; `n`, `Esc`, or `Enter` denies (deny is the default); long inputs scroll with `↑`/`↓` and are never truncated. Telegram bot denies DangerFullAccess by default (no TTY to confirm with).
 
 ## Sessions and auto-compaction


### PR DESCRIPTION
Roast finding `EDIT-04`. Two halves of one problem: **the tool that can destroy the most announced the least.**

## 1. An overwrite is an edit, so gate it like one

`write_file` was registered `WorkspaceWrite`, so replacing an **existing** file was auto-allowed — no `[y/N]`, no preview — while every other edit tool (`edit_file`, `apply_diff`, `apply_patch`) sits at `DangerFullAccess`.

`PermissionPolicy::effective_required_mode` adds the one input-dependent rule: `write_file` onto a path that already exists reaches the danger tier. `diff_preview` gains a `write_file` arm that reads what is on disk and diffs it against the incoming content, headlined with the line/byte delta — a truncation is otherwise hundreds of `-` lines the reviewer has to count.

Deliberately lenient when the input can't be evaluated (unparseable JSON, no `path`, a path failing `validate_write_path`): in every one of those branches `run_write_file` returns `Err` before touching the disk, so there is provably nothing to guard.

Consequence worth knowing: in a non-interactive session with no prompter, a `write_file` overwrite is now **denied**. That is consistent — `edit_file` already behaves exactly that way there — and it closes the last route by which an existing file could be replaced with zero human contact.

## 2. Every file mutation now leaves a trail

`write_file`, `edit_file` and `apply_patch` printed **nothing** when they mutated a file; only `apply_diff` and the git tools emit a progress line. A live unattended run replaced a 710-line source file with a ~40-line fragment and left a **214-byte** log.

A shared `tools::log_file_write` emits one `▸` line per completed mutation, with a >50% loss called out in the warning colour — the signature of an output-budget cut mid-generation.

**Both halves are required.** Under `CLAUDETTE_AUTO_APPROVE=1` the gate returns `Allow` immediately and no prompt can ever fire, so in an unattended run the log line is the only defence.

## Shared resolver

The path resolution `write_file` uses is extracted to `resolve_write_target`, so the permission gate and the preview test **the same path the write uses**. A second copy would drift and gate the wrong file.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all-targets --no-deps -- -D warnings` clean.
- **1130 + 32 tests pass, 0 fail** (3 new).
- The two behavioural tests were re-run against reverted production code and **both failed**, so they are not vacuous. The third exercises the new helper directly.