### PR TITLE
fix(edit): take apply_diff's indent from the first non-blank line

### DIFF
--- a/crates/claudette/src/tools/fuzzy_apply.rs
+++ b/crates/claudette/src/tools/fuzzy_apply.rs
@@ -164,7 +164,9 @@ fn run_apply_diff(input: &str) -> Result<String, String> {
                      ambiguous. Add more surrounding lines so the block is unique."
                 ),
                 FuzzyError::EmptyBefore => {
-                    "apply_diff: 'before' is empty (nothing to find)".to_string()
+                    "apply_diff: 'before' is blank (nothing to find) — it must \
+                     contain at least one non-whitespace character"
+                        .to_string()
                 }
             };
             eprintln!(
@@ -283,7 +285,14 @@ fn reindent_to(block: &str, target_indent: &str) -> String {
 /// when more than one matches, so a genuinely ambiguous edit is rejected
 /// rather than silently applied to the first hit (roast RC-E C3).
 fn fuzzy_replace(content: &str, before: &str, after: &str) -> Result<String, FuzzyError> {
-    if before.is_empty() {
+    // Blank, not just empty: Pass 2 compares TRIMMED lines, so a `before` of
+    // "   " or "\n" trims to "" and matches ANY blank line in the file. With
+    // exactly one blank line the ambiguity check never fires and the block is
+    // injected at an arbitrary position, reported `ok:true` (roast EDIT-05).
+    // This one guard is sufficient: if `before.trim()` is non-empty then at
+    // least one of its lines has a non-empty trim, so no Pass-2 window can be
+    // made entirely of blank lines.
+    if before.trim().is_empty() {
         return Err(FuzzyError::EmptyBefore);
     }
 
@@ -360,7 +369,15 @@ fn fuzzy_replace(content: &str, before: &str, after: &str) -> Result<String, Fuz
     // splicing it verbatim corrupts whitespace-significant languages. Then
     // re-encode to the window's EOL style so a CRLF file keeps CRLF inside the
     // replaced region (roast RC-E H1).
-    let file_indent = leading_ws(content_lines[i]);
+    // Derive the indent from the first NON-BLANK line of the matched window.
+    // `leading_ws("\n")` is "", so a window that starts on a blank line used to
+    // re-base the whole replacement to column 0 — silently lifting it out of its
+    // scope (a Python method stopped being a method; YAML keys hoisted to
+    // document root), reported `ok:true` (roast EDIT-01).
+    let file_indent = content_lines[i..i + m]
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .map_or("", |l| leading_ws(l));
     let reindented = reindent_to(after, file_indent);
     let window_crlf = content_lines[i..i + m].iter().any(|l| l.ends_with("\r\n"));
     let mut after_norm = normalize_eol(&reindented, window_crlf);
@@ -563,6 +580,84 @@ mod tests {
     fn empty_before_errors() {
         let err = fuzzy_replace("anything", "", "x").unwrap_err();
         assert_eq!(err, FuzzyError::EmptyBefore);
+    }
+
+    // EDIT-01: a matched window whose FIRST line is blank must take its indent
+    // from the first non-blank line, not from the blank one.
+    //
+    // Every `before` below carries a DELIBERATELY WRONG indent so the Pass 1
+    // exact-match path cannot fire. That matters: Pass 1 returns early, and the
+    // bug being tested lives in Pass 2. A `before` copied verbatim out of
+    // `content` would make these tests vacuous.
+
+    #[test]
+    fn blank_first_line_window_keeps_python_method_nested() {
+        let content = "class Foo:\n\n    def bar(self):\n        pass\n";
+        let before = "\n  def bar(self):\n";
+        let after = "\n  def bar(self):\n      return 42\n";
+        let got = fuzzy_replace(content, before, after).unwrap();
+        assert!(
+            got.contains("\n    def bar(self):\n"),
+            "method must stay nested under the class: {got:?}"
+        );
+        assert!(
+            !got.contains("\ndef bar(self):"),
+            "method must not dedent to column 0: {got:?}"
+        );
+    }
+
+    #[test]
+    fn blank_first_line_window_keeps_yaml_keys_nested() {
+        let content = "server:\n\n  host: localhost\n  port: 8080\n";
+        let before = "\nhost: localhost\nport: 8080\n";
+        let after = "\nhost: 127.0.0.1\nport: 9090\n";
+        let got = fuzzy_replace(content, before, after).unwrap();
+        assert!(
+            got.contains("\n  host: 127.0.0.1\n"),
+            "keys must stay under `server:`: {got:?}"
+        );
+        assert!(
+            !got.contains("\nhost: 127.0.0.1"),
+            "keys must not hoist to document root: {got:?}"
+        );
+    }
+
+    #[test]
+    fn nonblank_first_line_window_is_unchanged_by_the_fix() {
+        // Regression guard only: this window's first line is non-blank, so the
+        // new code must pick exactly the indent the old code did.
+        let content = "def f():\n    x = 1\n    y = 2\n";
+        let before = "  x = 1\n  y = 2\n";
+        let after = "  x = 10\n  y = 20\n";
+        let got = fuzzy_replace(content, before, after).unwrap();
+        assert_eq!(got, "def f():\n    x = 10\n    y = 20\n");
+    }
+
+    // EDIT-05: a `before` made only of whitespace is a wildcard against any
+    // blank line. It must be refused, not applied.
+
+    #[test]
+    fn whitespace_only_before_is_refused() {
+        let err = fuzzy_replace("alpha\n\nbeta\n", "   ", "INJECTED\n").unwrap_err();
+        assert_eq!(err, FuzzyError::EmptyBefore);
+    }
+
+    #[test]
+    fn newline_only_before_is_refused() {
+        let err = fuzzy_replace("alpha\n\nbeta\n", "\n", "INJECTED\n").unwrap_err();
+        assert_eq!(err, FuzzyError::EmptyBefore);
+    }
+
+    #[test]
+    fn before_that_merely_starts_blank_is_still_accepted() {
+        // The EDIT-05 guard must not over-reject: a leading blank line is fine
+        // as long as the block carries real content somewhere.
+        let content = "alpha\n\n  beta\n";
+        let got = fuzzy_replace(content, "\nbeta\n", "\nGAMMA\n").unwrap();
+        assert!(
+            got.contains("GAMMA"),
+            "real block must still apply: {got:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Roast findings `EDIT-01` and `EDIT-05`. Both are ways `apply_diff` corrupted a file and reported `ok:true` — the primary edit path, and the tool the system prompt explicitly steers the model toward (`prompt.rs:102-107`).

## 1. `EDIT-01` — the indent came from a blank line

Pass 2 matches on **trimmed** lines, so the model's `after` carries whatever indentation it guessed. `reindent_to` re-bases that block onto the file's actual indent — and it took that indent from the matched window's **first** line:

```rust
let file_indent = leading_ws(content_lines[i]);
```

`leading_ws("\n")` is `""`. A window whose first line is blank therefore re-based the entire replacement to **column 0**. Reproduced against the shipped rlib: a Python method stopped being a method, and YAML `host`/`port` were hoisted out of `server:` to document root. Both reported `ok:true` with nothing in the tool result to suggest anything had moved.

The indent now comes from the first **non-blank** line of the window. The irony was that this whole code path exists *because* splicing verbatim corrupts whitespace-significant languages — the fix restores the intent the comment already claimed.

## 2. `EDIT-05` — a whitespace-only `before` was a wildcard

The guard rejected only a zero-length `before`. But Pass 2 compares trimmed lines, so `before = "   "` trims to `""` and matched **any** blank line in the file. With exactly one blank line the ambiguity check at the end of the pass never fired, and the block was injected at an arbitrary position:

```
"alpha\n\nbeta\n" + before="   "  →  "alpha\nINJECTED\nbeta\n"   // ok:true
```

`before = "\n"` behaved identically. The guard is now `before.trim().is_empty()`, and the user-facing message says "blank" rather than "empty" to match.

The finding proposed a second guard — reject any Pass-2 window whose trimmed `before` lines are all empty — but it is subsumed: if `before.trim()` is non-empty then at least one of its lines has a non-empty trim, so no such window can exist. One guard is enough, and there is a comment saying why so it doesn't get re-added.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --all-targets --no-deps -- -D warnings` clean.
- **1136 + 32 tests pass, 0 fail** (6 new).
- **Test-power check:** the production change was reverted on its own and the suite re-run. **4 of the 6 new tests failed**, so they are not vacuous. The other two are labelled guards that are *supposed* to pass either way — one pins that a non-blank first line still picks the indent the old code did, one pins that a `before` merely *starting* with a blank line is not over-rejected.
- Every fixture gives `before` a deliberately **wrong** indent. This matters more than it looks: Pass 1 is an exact byte-match that returns early, so a `before` copied verbatim out of `content` never reaches the Pass 2 code under test. Earlier candidate fixtures for this fix did exactly that and passed against the unfixed code.

## Not in scope

`EDIT-02` (`reindent_to` rewriting the contents of multi-line string literals) is left for its own PR. Its proposed fix — never synthesize indentation the caller didn't send — is in real tension with the Dogfood 9/10 behaviour `reindent_to` was built for, and deserves to be decided on its own rather than smuggled in behind a five-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
