### PR TITLE
fix(check): a timed-out post-edit check must not read as a pass

### DIFF
--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -740,20 +740,35 @@ where
                                 let path = read_file_path(&input);
                                 if !path.is_empty() {
                                     let workspace = crate::missions::active_cwd();
-                                    if let Some(check) =
+                                    use crate::tools::post_edit_check::CheckOutcome;
+                                    let outcome =
                                         crate::tools::post_edit_check::run_post_edit_check(
                                             std::path::Path::new(&path),
                                             &workspace,
-                                        )
-                                    {
+                                        );
+                                    // Skipped/Passed append nothing. Failed and
+                                    // TimedOut both consume a round, so a
+                                    // persistently slow or broken check cannot
+                                    // spam every edit in the turn.
+                                    let note = match outcome {
+                                        CheckOutcome::Skipped | CheckOutcome::Passed => None,
+                                        CheckOutcome::Failed(check) => Some(format!(
+                                            "\n\n[post_edit_check] the edited file fails its check:\n{check}\nFix this before moving on."
+                                        )),
+                                        CheckOutcome::TimedOut(secs) => Some(
+                                            crate::tools::post_edit_check::timeout_notice(
+                                                &path, secs,
+                                            ),
+                                        ),
+                                    };
+                                    if let Some(note) = note {
                                         let rounds = {
                                             let n = check_fails.entry(path.clone()).or_insert(0);
                                             *n += 1;
                                             *n
                                         };
                                         if rounds <= crate::tools::post_edit_check::max_rounds() {
-                                            use std::fmt::Write as _;
-                                            let _ = write!(output, "\n\n[post_edit_check] the edited file fails its check:\n{check}\nFix this before moving on.");
+                                            output.push_str(&note);
                                         } else {
                                             output.push_str(
                                                 &crate::tools::post_edit_check::suppressed_notice(
@@ -3724,6 +3739,62 @@ mod tests {
 
         std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
         std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
+    }
+
+    // CHECK-01 at the call site. The unit tests cover the mapping; this covers
+    // the only thing the model actually sees. Without it the `TimedOut` arm can
+    // be reverted to `None` and the entire suite still passes — measured.
+    #[test]
+    fn post_edit_check_timeout_reaches_the_model_as_unverified() {
+        // A real timeout needs a real slow child. Python is the portable
+        // "sleep" this crate already leans on (see test_runner's
+        // run_command_drains_large_output_without_timeout), and we skip when
+        // it is absent because the assertion only means something if the
+        // subprocess really ran. No wall-clock bound is asserted: a loaded
+        // runner can only make the 1 s timeout fire harder, never softer.
+        let probe =
+            crate::test_runner::run_command_with_timeout("python", &["-c", "pass"], 10, None);
+        if !probe.success
+            && probe.exit_code.is_none()
+            && probe.stderr.starts_with("failed to spawn")
+        {
+            eprintln!("skipping: python not on PATH");
+            return;
+        }
+
+        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
+        std::env::set_var(crate::tools::post_edit_check::TIMEOUT_ENV, "1");
+        // CLAUDETTE_CHECK_CMD is split on whitespace, so the -c body must not
+        // contain any: __import__("time") avoids the usual `import time;`.
+        std::env::set_var(
+            crate::tools::post_edit_check::CMD_ENV,
+            "python -c __import__(\"time\").sleep(30) {file}",
+        );
+
+        let summary = run_write_file_turn(vec!["a.rs"]);
+        let output = tool_result_output(&summary, 0);
+
+        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
+        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
+        std::env::remove_var(crate::tools::post_edit_check::TIMEOUT_ENV);
+
+        assert!(
+            output.starts_with("ok"),
+            "the tool's own output stays first: {output}"
+        );
+        assert!(
+            output.contains("was NOT verified"),
+            "a timed-out check must say so rather than stay silent: {output}"
+        );
+        assert!(
+            output.contains("not a pass"),
+            "the note must not be readable as success: {output}"
+        );
+        assert!(
+            !output.contains("fails its check"),
+            "a timeout is not a failure either — it is unverified: {output}"
+        );
     }
 
     #[test]

--- a/crates/claudette/src/tools/post_edit_check.rs
+++ b/crates/claudette/src/tools/post_edit_check.rs
@@ -27,6 +27,23 @@ pub(crate) const MAX_OUTPUT_LINES: usize = 30;
 /// Maximum number of output characters to retain (after line cap).
 pub(crate) const MAX_OUTPUT_CHARS: usize = 2000;
 
+/// The outcome of a post-edit check.
+///
+/// A timeout is deliberately NOT folded into "clean". A check that never
+/// finished has verified nothing, and reporting silence there is exactly how a
+/// corrupt file slips through unnoticed (roast CHECK-01).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CheckOutcome {
+    /// Feature off, offline, or no check command matched this file type.
+    Skipped,
+    /// The check ran to completion and the file is clean.
+    Passed,
+    /// The check ran to completion and the file fails; truncated output.
+    Failed(String),
+    /// The check did not finish within this many seconds — file UNVERIFIED.
+    TimedOut(u64),
+}
+
 /// A check command with its program, arguments, and working directory.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CheckCmd {
@@ -67,6 +84,18 @@ pub(crate) fn max_rounds() -> u32 {
         .and_then(|v| v.trim().parse::<u32>().ok())
         .unwrap_or(2)
         .clamp(1, 10)
+}
+
+/// Notice body for a check that never completed.
+///
+/// Says UNVERIFIED rather than staying silent: silence is indistinguishable
+/// from a pass, which is the whole of roast CHECK-01.
+pub(crate) fn timeout_notice(path: &str, secs: u64) -> String {
+    format!(
+        "\n\n[post_edit_check] {path} was NOT verified — its check did not \
+         finish within {secs}s. This is not a pass. Re-run the check yourself, \
+         or raise CLAUDETTE_CHECK_TIMEOUT_SECS, before relying on this edit."
+    )
 }
 
 /// Suppressed-notice body when the per-file round cap is exceeded.
@@ -231,40 +260,50 @@ pub(crate) fn command_for(file: &Path, workspace: &Path) -> Option<CheckCmd> {
     builtin_cmd(file, workspace, ruff_on_path())
 }
 
-/// Run a post-edit check on `file` in `workspace`.
+/// Map a finished command run onto a `CheckOutcome`.
 ///
-/// Returns `None` unless enabled; also returns `None` under offline mode or
-/// when no command can be determined. On success (exit 0) or timeout → `None`.
-/// Otherwise returns truncated failure output.
-pub(crate) fn run_post_edit_check(file: &Path, workspace: &Path) -> Option<String> {
-    if !enabled() {
-        return None;
-    }
-
-    if crate::egress::is_offline() {
-        return None;
-    }
-
-    let cmd = command_for(file, workspace)?;
-
-    let args: Vec<&str> = cmd.args.iter().map(String::as_str).collect();
-    let result = crate::test_runner::run_command_with_timeout(
-        &cmd.program,
-        &args,
-        timeout_secs(),
-        Some(&cmd.cwd),
-    );
-
+/// Split out of `run_post_edit_check` so the timeout-vs-pass distinction is
+/// unit-testable without spawning a genuinely slow process (roast CHECK-01).
+pub(crate) fn outcome_from_run(
+    result: &crate::test_runner::CommandResult,
+    secs: u64,
+) -> CheckOutcome {
     if result.timed_out {
-        return None;
+        return CheckOutcome::TimedOut(secs);
     }
 
     if result.success {
-        return None;
+        return CheckOutcome::Passed;
     }
 
     let output = format!("{}\n{}", result.stdout, result.stderr);
-    Some(truncate_output(&output))
+    CheckOutcome::Failed(truncate_output(&output))
+}
+
+/// Run a post-edit check on `file` in `workspace`.
+///
+/// `Skipped` unless enabled, and also when offline or when no command can be
+/// determined. Otherwise the command runs and the outcome distinguishes
+/// `Passed`, `Failed` and `TimedOut` — a timeout is NOT a pass (roast CHECK-01).
+pub(crate) fn run_post_edit_check(file: &Path, workspace: &Path) -> CheckOutcome {
+    if !enabled() {
+        return CheckOutcome::Skipped;
+    }
+
+    if crate::egress::is_offline() {
+        return CheckOutcome::Skipped;
+    }
+
+    let Some(cmd) = command_for(file, workspace) else {
+        return CheckOutcome::Skipped;
+    };
+
+    let args: Vec<&str> = cmd.args.iter().map(String::as_str).collect();
+    let secs = timeout_secs();
+    let result =
+        crate::test_runner::run_command_with_timeout(&cmd.program, &args, secs, Some(&cmd.cwd));
+
+    outcome_from_run(&result, secs)
 }
 
 /// Serializes every test that mutates the post-edit-check env knobs — the
@@ -450,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    fn run_post_edit_check_disabled_returns_none() {
+    fn run_post_edit_check_disabled_returns_skipped() {
         let _lock = ENV_LOCK.lock().unwrap();
         // Ensure CHECK_ENV is unset so enabled() → false.
         unset_env(CHECK_ENV);
@@ -459,9 +498,10 @@ mod tests {
         set_env(CMD_ENV, "/nonexistent_program_xyz");
 
         let result = run_post_edit_check(Path::new("test.rs"), Path::new("/ws"));
-        assert!(
-            result.is_none(),
-            "should return None when disabled; got {:?}",
+        assert_eq!(
+            result,
+            CheckOutcome::Skipped,
+            "should return Skipped when disabled; got {:?}",
             result
         );
 
@@ -476,9 +516,10 @@ mod tests {
         std::env::set_var(crate::egress::OFFLINE_ENV, "1");
 
         let result = run_post_edit_check(Path::new("test.rs"), Path::new("/ws"));
-        assert!(
-            result.is_none(),
-            "should return None under offline; got {:?}",
+        assert_eq!(
+            result,
+            CheckOutcome::Skipped,
+            "should return Skipped under offline; got {:?}",
             result
         );
 
@@ -506,6 +547,64 @@ mod tests {
         assert_eq!(max_rounds(), 2); // fallback default.
 
         unset_env(MAX_ROUNDS_ENV);
+    }
+
+    fn fake_run(success: bool, timed_out: bool, stdout: &str) -> crate::test_runner::CommandResult {
+        crate::test_runner::CommandResult {
+            success,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+            timed_out,
+            exit_code: if success { Some(0) } else { Some(1) },
+        }
+    }
+
+    // CHECK-01: the whole point. A timeout and a pass used to be the same
+    // value, so a check that never ran reported the file clean.
+
+    #[test]
+    fn timed_out_run_is_not_reported_as_clean() {
+        let out = outcome_from_run(&fake_run(false, true, ""), 10);
+        assert_eq!(
+            out,
+            CheckOutcome::TimedOut(10),
+            "a timeout must be its own outcome, never Passed/Skipped"
+        );
+        assert_ne!(out, CheckOutcome::Passed, "a timeout is NOT a pass");
+    }
+
+    #[test]
+    fn successful_run_is_passed() {
+        assert_eq!(
+            outcome_from_run(&fake_run(true, false, ""), 10),
+            CheckOutcome::Passed
+        );
+    }
+
+    #[test]
+    fn failed_run_carries_its_output() {
+        let out = outcome_from_run(&fake_run(false, false, "E0308 mismatched types"), 10);
+        match out {
+            CheckOutcome::Failed(text) => {
+                assert!(
+                    text.contains("E0308"),
+                    "failure output must survive: {text}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn timeout_notice_says_unverified_and_names_the_file() {
+        let notice = timeout_notice("src/main.rs", 10);
+        assert!(notice.contains("src/main.rs"));
+        assert!(notice.contains("NOT verified"));
+        assert!(notice.contains("10s"));
+        assert!(
+            notice.contains("not a pass"),
+            "the notice must not be readable as success: {notice}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Roast finding `CHECK-01`. `post_edit_check.rs` returned `Option<String>`, and a **timed-out check and a passing check were the same value**:

```rust
if result.timed_out { return None; }   // "I never finished checking"
if result.success   { return None; }   // "the file is fine"
```

Default timeout is 10s. On a slow or contended machine the check gets killed, nothing is appended to the tool result, and **the model sees a clean result for a file that was never verified.**

This is the roast's own cross-cutting theme — *a guard that cannot evaluate its condition returns the reassuring answer* — reproduced inside the safety net built for it. It matters more than most because `CLAUDETTE_POST_EDIT_CHECK=1` is enabled on every co-dev run specifically to catch corrupt edits in-turn.

## What changed

- `run_post_edit_check` now returns an explicit `CheckOutcome` — `Skipped` / `Passed` / `Failed(String)` / `TimedOut(u64)`.
- A timeout gets its own notice: names the file, says **NOT verified**, says **this is not a pass**, and points at `CLAUDETTE_CHECK_TIMEOUT_SECS`.
- A timeout consumes a round like a failure does, so a persistently slow check can't spam every edit in the turn.
- The mapping is split into a pure `outcome_from_run` so timeout-vs-pass is unit-testable without spawning a genuinely slow process.

No new env var — `CLAUDETTE_CHECK_TIMEOUT_SECS` already exists and is documented.

## Tests

Five new (1141 lib + 32 bin, 0 fail), each checked for actual power by reverting the production change in isolation:

| Test | Reverted-code behaviour |
|---|---|
| `timed_out_run_is_not_reported_as_clean` | **FAILS** — `left: Passed, right: TimedOut(10)` |
| `post_edit_check_timeout_reaches_the_model_as_unverified` | **FAILS** — tool result is just `ok` |
| `successful_run_is_passed` | passes either way (labelled regression guard) |
| `failed_run_carries_its_output` | passes either way (labelled regression guard) |
| `timeout_notice_says_unverified_and_names_the_file` | passes either way (content guard — the notice must never read as success) |

The call-site test is the one that matters: **before it existed, the `TimedOut` arm could be reverted to `None` and all 1140 tests still passed.** It drives a real 1s timeout through the actual tool result, follows the crate's existing python-with-skip precedent (`test_runner::run_command_drains_large_output_without_timeout`), and asserts no wall-clock bound — a loaded runner can only make the 1s timeout fire harder, never softer.

Gate: `cargo fmt --all --check` clean, `clippy --all-targets --no-deps -D warnings` clean, `cargo test --lib --bins` 1141 + 32 pass / 0 fail.
