### PR TITLE
fix(tests): stop one panicking test from poisoning the env lock for the rest

### DIFF
--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -367,7 +367,9 @@ mod tests {
 
     #[test]
     fn is_offline_reads_truthy_env() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
 
         std::env::remove_var(OFFLINE_ENV);
@@ -388,7 +390,9 @@ mod tests {
 
     #[test]
     fn loopback_hosts_always_allowed() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
 
@@ -405,7 +409,9 @@ mod tests {
 
     #[test]
     fn cloud_hosts_denied() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
 
@@ -427,7 +433,9 @@ mod tests {
 
     #[test]
     fn configured_lan_backend_allowed_other_cloud_still_denied() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         // A remote-but-LAN backend the user opted into — "your hardware".
         std::env::set_var("OLLAMA_HOST", "http://192.168.1.50:11434");
@@ -452,7 +460,9 @@ mod tests {
 
     #[test]
     fn guard_is_noop_when_offline_off() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         std::env::remove_var(OFFLINE_ENV);
         // Even an obvious cloud host passes when offline mode is off.
@@ -462,7 +472,9 @@ mod tests {
 
     #[test]
     fn guard_blocks_cloud_and_allows_backend_when_offline_on() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
         std::env::set_var(OFFLINE_ENV, "1");
@@ -492,7 +504,9 @@ mod tests {
 
     #[test]
     fn allow_list_includes_loopback_and_lan_backend() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
 
         std::env::set_var("OLLAMA_HOST", "http://localhost:11434");
@@ -512,7 +526,9 @@ mod tests {
 
     #[test]
     fn proxy_vars_set_detects_both_spellings() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         EnvGuard::clear_proxies();
 
@@ -555,7 +571,9 @@ mod tests {
 
     #[test]
     fn preflight_is_noop_when_offline_off() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         EnvGuard::clear_proxies();
 
@@ -570,7 +588,9 @@ mod tests {
 
     #[test]
     fn preflight_refuses_offline_with_proxy() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let _g = EnvGuard::capture();
         EnvGuard::clear_proxies();
 

--- a/crates/claudette/src/run.rs
+++ b/crates/claudette/src/run.rs
@@ -395,7 +395,9 @@ mod tests {
 
     #[test]
     fn default_session_path_honors_env_var() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let path = temp_session_file("env-var");
         let prev = std::env::var("CLAUDETTE_SESSION").ok();
         std::env::set_var("CLAUDETTE_SESSION", &path);
@@ -446,7 +448,9 @@ mod tests {
 
     #[test]
     fn maybe_compact_session_no_op_when_under_threshold() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_COMPACT_THRESHOLD").ok();
         std::env::set_var("CLAUDETTE_COMPACT_THRESHOLD", "1000000");
 
@@ -477,7 +481,9 @@ mod tests {
 
     #[test]
     fn maybe_compact_session_fires_when_over_threshold() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_COMPACT_THRESHOLD").ok();
         // Threshold of 10 tokens — every realistic session crosses this.
         std::env::set_var("CLAUDETTE_COMPACT_THRESHOLD", "10");

--- a/crates/claudette/src/run/compaction_policy.rs
+++ b/crates/claudette/src/run/compaction_policy.rs
@@ -202,7 +202,9 @@ mod tests {
 
     #[test]
     fn compact_threshold_default_when_env_var_unset() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_COMPACT_THRESHOLD").ok();
         std::env::remove_var("CLAUDETTE_COMPACT_THRESHOLD");
 
@@ -218,7 +220,9 @@ mod tests {
 
     #[test]
     fn compact_threshold_honors_env_var() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_COMPACT_THRESHOLD").ok();
         std::env::set_var("CLAUDETTE_COMPACT_THRESHOLD", "12345");
 
@@ -232,7 +236,9 @@ mod tests {
 
     #[test]
     fn compact_threshold_falls_back_on_garbage() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_COMPACT_THRESHOLD").ok();
         std::env::set_var("CLAUDETTE_COMPACT_THRESHOLD", "not-a-number");
 
@@ -326,7 +332,9 @@ mod tests {
 
     #[test]
     fn soft_compact_threshold_returns_none_when_unset() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_SOFT_COMPACT_THRESHOLD").ok();
         std::env::remove_var("CLAUDETTE_SOFT_COMPACT_THRESHOLD");
 
@@ -339,7 +347,9 @@ mod tests {
 
     #[test]
     fn soft_compact_threshold_returns_some_when_set() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_SOFT_COMPACT_THRESHOLD").ok();
         std::env::set_var("CLAUDETTE_SOFT_COMPACT_THRESHOLD", "200000");
 
@@ -355,7 +365,9 @@ mod tests {
     fn soft_compact_threshold_treats_zero_as_unset() {
         // 0 is a magic "disabled" value — explicit opt-out via env without
         // having to unset.
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_SOFT_COMPACT_THRESHOLD").ok();
         std::env::set_var("CLAUDETTE_SOFT_COMPACT_THRESHOLD", "0");
 

--- a/crates/claudette/src/run/forge_run.rs
+++ b/crates/claudette/src/run/forge_run.rs
@@ -1729,7 +1729,9 @@ mod tests {
 
     #[test]
     fn human_review_disabled_under_auto_approve() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_aa = std::env::var("CLAUDETTE_FORGE_AUTO_APPROVE").ok();
         let prev_nr = std::env::var("CLAUDETTE_FORGE_NO_REVIEW").ok();
         std::env::set_var("CLAUDETTE_FORGE_AUTO_APPROVE", "1");
@@ -1742,7 +1744,9 @@ mod tests {
 
     #[test]
     fn human_review_on_by_default_and_opt_out_works() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev_aa = std::env::var("CLAUDETTE_FORGE_AUTO_APPROVE").ok();
         let prev_nr = std::env::var("CLAUDETTE_FORGE_NO_REVIEW").ok();
         std::env::remove_var("CLAUDETTE_FORGE_AUTO_APPROVE");
@@ -1759,7 +1763,9 @@ mod tests {
 
     #[test]
     fn build_check_on_by_default_and_opt_out_works() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_FORGE_NO_BUILD_CHECK").ok();
         std::env::remove_var("CLAUDETTE_FORGE_NO_BUILD_CHECK");
         assert!(forge_build_check_enabled());
@@ -1770,7 +1776,9 @@ mod tests {
 
     #[test]
     fn test_timeout_defaults_and_clamps() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var("CLAUDETTE_FORGE_TEST_TIMEOUT_SECS").ok();
         std::env::remove_var("CLAUDETTE_FORGE_TEST_TIMEOUT_SECS");
         assert_eq!(forge_test_timeout_secs(), 180);

--- a/crates/claudette/src/runtime/context_evict.rs
+++ b/crates/claudette/src/runtime/context_evict.rs
@@ -176,7 +176,9 @@ mod tests {
 
     #[test]
     fn trigger_percent_parses() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         // Unset → None
         std::env::remove_var(EVICT_ENV);

--- a/crates/claudette/src/runtime/conversation.rs
+++ b/crates/claudette/src/runtime/conversation.rs
@@ -3699,7 +3699,7 @@ mod tests {
 
     #[test]
     fn post_edit_check_off_leaves_tool_result_untouched() {
-        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        let _guard = crate::tools::post_edit_check::CheckEnvGuard::acquire();
         std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
         // A command that WOULD fail if the feature ran while disabled.
         std::env::set_var(
@@ -3713,13 +3713,11 @@ mod tests {
             output, "ok",
             "knob off must leave the result byte-identical"
         );
-
-        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
     }
 
     #[test]
     fn post_edit_check_appends_failure_output() {
-        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        let _guard = crate::tools::post_edit_check::CheckEnvGuard::acquire();
         std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
         std::env::set_var(
             crate::tools::post_edit_check::CMD_ENV,
@@ -3736,9 +3734,6 @@ mod tests {
             output.contains("[post_edit_check] the edited file fails its check:"),
             "check failure must be appended: {output}"
         );
-
-        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
-        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
     }
 
     // CHECK-01 at the call site. The unit tests cover the mapping; this covers
@@ -3762,7 +3757,7 @@ mod tests {
             return;
         }
 
-        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        let _guard = crate::tools::post_edit_check::CheckEnvGuard::acquire();
         std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
         std::env::set_var(crate::tools::post_edit_check::TIMEOUT_ENV, "1");
         // CLAUDETTE_CHECK_CMD is split on whitespace, so the -c body must not
@@ -3774,10 +3769,6 @@ mod tests {
 
         let summary = run_write_file_turn(vec!["a.rs"]);
         let output = tool_result_output(&summary, 0);
-
-        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
-        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
-        std::env::remove_var(crate::tools::post_edit_check::TIMEOUT_ENV);
 
         assert!(
             output.starts_with("ok"),
@@ -3799,7 +3790,7 @@ mod tests {
 
     #[test]
     fn post_edit_check_caps_rounds_per_file() {
-        let _lock = crate::tools::post_edit_check::ENV_LOCK.lock().unwrap();
+        let _guard = crate::tools::post_edit_check::CheckEnvGuard::acquire();
         std::env::set_var(crate::tools::post_edit_check::CHECK_ENV, "1");
         std::env::set_var(
             crate::tools::post_edit_check::CMD_ENV,
@@ -3820,10 +3811,6 @@ mod tests {
             second.contains("still fails its check (output suppressed"),
             "round 2 gets the suppression notice: {second}"
         );
-
-        std::env::remove_var(crate::tools::post_edit_check::CHECK_ENV);
-        std::env::remove_var(crate::tools::post_edit_check::CMD_ENV);
-        std::env::remove_var(crate::tools::post_edit_check::MAX_ROUNDS_ENV);
     }
 
     // ── W5b: apply_context_eviction Cow wrapper ─────────────────────────────

--- a/crates/claudette/src/tools/post_edit_check.rs
+++ b/crates/claudette/src/tools/post_edit_check.rs
@@ -313,6 +313,58 @@ pub(crate) fn run_post_edit_check(file: &Path, workspace: &Path) -> CheckOutcome
 #[cfg(test)]
 pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Holds `ENV_LOCK` and restores every env var these tests touch on drop.
+///
+/// Manual `remove_var` calls placed after a test's assertions never run when an
+/// assertion fails, so a failing test used to leak `CLAUDETTE_POST_EDIT_CHECK=1`
+/// into every later test in the binary (roast CI-03). `Drop` runs during unwind,
+/// so this restores state even on panic.
+#[cfg(test)]
+pub(crate) struct CheckEnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+#[cfg(test)]
+impl CheckEnvGuard {
+    pub(crate) fn acquire() -> Self {
+        let guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // OFFLINE_ENV belongs here even though it is not a post-edit-check
+        // knob: run_post_edit_check_skips_under_offline sets it, and a guard
+        // that restores everything *except* it would leak CLAUDETTE_OFFLINE=1
+        // into every later test in the binary — which is the exact class of bug
+        // this guard exists to prevent.
+        let saved = [
+            CHECK_ENV,
+            CMD_ENV,
+            TIMEOUT_ENV,
+            MAX_ROUNDS_ENV,
+            crate::egress::OFFLINE_ENV,
+        ]
+        .into_iter()
+        .map(|k| (k, std::env::var(k).ok()))
+        .collect();
+        Self {
+            _lock: guard,
+            saved,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for CheckEnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,7 +380,7 @@ mod tests {
 
     #[test]
     fn enabled_defaults_off_and_parses_truthy() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = CheckEnvGuard::acquire();
         // Unset → false.
         unset_env(CHECK_ENV);
         assert!(!enabled());
@@ -350,13 +402,11 @@ mod tests {
         assert!(!enabled());
         set_env(CHECK_ENV, "");
         assert!(!enabled());
-
-        unset_env(CHECK_ENV);
     }
 
     #[test]
     fn timeout_defaults_and_clamps() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = CheckEnvGuard::acquire();
         // Unset → 10.
         unset_env(TIMEOUT_ENV);
         assert_eq!(timeout_secs(), 10);
@@ -490,7 +540,7 @@ mod tests {
 
     #[test]
     fn run_post_edit_check_disabled_returns_skipped() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = CheckEnvGuard::acquire();
         // Ensure CHECK_ENV is unset so enabled() → false.
         unset_env(CHECK_ENV);
         // Point CMD_ENV at a nonexistent program — if the function were to
@@ -504,13 +554,11 @@ mod tests {
             "should return Skipped when disabled; got {:?}",
             result
         );
-
-        unset_env(CMD_ENV);
     }
 
     #[test]
     fn run_post_edit_check_skips_under_offline() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = CheckEnvGuard::acquire();
         set_env(CHECK_ENV, "1");
         // Simulate offline mode.
         std::env::set_var(crate::egress::OFFLINE_ENV, "1");
@@ -522,14 +570,11 @@ mod tests {
             "should return Skipped under offline; got {:?}",
             result
         );
-
-        unset_env(CHECK_ENV);
-        std::env::remove_var(crate::egress::OFFLINE_ENV);
     }
 
     #[test]
     fn max_rounds_defaults_and_clamps() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = CheckEnvGuard::acquire();
         // Unset → 2.
         unset_env(MAX_ROUNDS_ENV);
         assert_eq!(max_rounds(), 2);
@@ -545,8 +590,6 @@ mod tests {
 
         set_env(MAX_ROUNDS_ENV, "garbage");
         assert_eq!(max_rounds(), 2); // fallback default.
-
-        unset_env(MAX_ROUNDS_ENV);
     }
 
     fn fake_run(success: bool, timed_out: bool, stdout: &str) -> crate::test_runner::CommandResult {

--- a/crates/claudette/tests/offline_egress.rs
+++ b/crates/claudette/tests/offline_egress.rs
@@ -83,7 +83,9 @@ fn offline_probe_input(tool: &str) -> &'static str {
 
 #[test]
 fn every_net_tool_refuses_under_offline() {
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _env = OfflineEnv::set();
 
     for tool in all_net_tools() {
@@ -99,7 +101,9 @@ fn every_net_tool_refuses_under_offline() {
 
 #[test]
 fn backend_and_loopback_stay_allowed_under_offline() {
-    let _lock = ENV_LOCK.lock().unwrap();
+    let _lock = ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _env = OfflineEnv::set();
 
     // The backend / recall-embeddings path is on the allow-list — offline mode


### PR DESCRIPTION
Roast finding `CI-03`. Several modules keep a `static ENV_LOCK: Mutex<()>` so tests that mutate process env vars run one at a time, and every holder wrote `ENV_LOCK.lock().unwrap()`.

A test that panicked **while holding** the lock poisoned it, so every later holder died with `PoisonError` instead of running. On a recent CI run **one real failure became nine**, and the eight collateral ones buried the cause.

Poisoning is meaningless here — the guarded data is `()`, so there is no state to corrupt. The lock is simply re-acquired.

## What changed

**35 sites across 8 files.** 26 take the direct `unwrap_or_else(std::sync::PoisonError::into_inner)` replacement — the pattern `main.rs` already uses for its own env lock, added earlier to fix a flaky `parse_args_telegram_with_chat`. The other 9 (the post-edit-check tests) move to a new RAII `CheckEnvGuard`.

The guard also fixes the **second half** of CI-03: those tests cleaned up by calling `remove_var` *after* their assertions, so a failing assertion never cleaned up and leaked `CLAUDETTE_POST_EDIT_CHECK=1` plus a bogus check command into every later test in the binary. `Drop` runs during unwind, so the guard restores state even on panic.

The guard saves `OFFLINE_ENV` alongside the four post-edit-check knobs. It isn't a post-edit-check knob, but `run_post_edit_check_skips_under_offline` sets it, and a guard restoring everything *except* it leaks `CLAUDETTE_OFFLINE=1` into every later test — the exact class of bug the guard exists to prevent. (That was a real defect caught in review: 8 tests in `shell` and `web_search` failed as "offline-blocked" until `OFFLINE_ENV` was added.)

## Verification

The sweep is mechanical, so the interesting question is whether it's load-bearing. Injected a `panic!` into a guarded test while it held the lock:

| Tree | Result |
|---|---|
| All 35 sites fixed | **1 failure** (the injected one), 23 pass, **no `PoisonError`**, no env leak |
| One site reverted to `.lock().unwrap()` | **2 failures** — the injected one **plus a `PoisonError` cascade** |

That second row is the regression this card prevents, reproduced on demand.

Gate: `cargo fmt --all --check` clean, `clippy --all-targets --no-deps -D warnings` clean, `cargo test --lib --bins` **1141 + 32 pass / 0 fail**, `cargo test --test offline_egress` 3/3.
