### PR TITLE
fix(deps): patch 7 dev-dependency advisories in the vscode extension lockfile

### DIFF
--- a/editor/vscode/package-lock.json
+++ b/editor/vscode/package-lock.json
@@ -1298,9 +1298,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1919,9 +1919,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -4028,9 +4028,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Closes all 6 open Dependabot alerts (#14–#18, #20), plus one advisory Dependabot has not opened an alert for yet.

All three packages are **dev-only transitive dependencies of `@vscode/vsce`**. The extension declares no runtime `dependencies`, so none of this ships to users — the exposure is the packaging toolchain only.

| Package | Via | Was | Now | Severity |
|---|---|---|---|---|
| `fast-uri` | `ajv@^3.0.1` | 3.1.4 | 3.1.5 | high |
| `undici` | `cheerio@^7.19.0` | 7.28.0 | 7.29.0 | 1 high + 4 medium |
| `brace-expansion` | `minimatch@^5.0.5` | 5.0.8 | 5.0.9 | high ([GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)) |

Every parent range already permitted the patched version, so this is a **lockfile-only** change — no `package.json` edit, no dependency-tree churn, and all three stay `dev: true`.

### Supersedes

- #236 (`fast-uri` 3.1.4 → 3.1.5)
- #235 (`undici` 7.28.0 → 7.29.0)

Both touch the same lines of `editor/vscode/package-lock.json`, so landing them separately would force a rebase on whichever merged second. This does both in one commit and adds `brace-expansion`, which would otherwise arrive as a third PR once the advisory is picked up.

### Verification

- `npm audit` → **found 0 vulnerabilities** (was 7)
- `npm ci` installs clean from the lockfile; installed versions match the lock exactly
- `npm run lint` (`tsc --noEmit`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
