### PR TITLE
fix(api): a broken stream must not discard the turn the user already read

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -931,14 +931,30 @@ impl OllamaApiClient {
         let mut input_tokens: u32 = 0;
         let mut output_tokens: u32 = 0;
 
+        // A mid-stream read/parse failure must NOT `?` out of this loop: the
+        // text callback has already fired for every delta above it, so the user
+        // has read the answer. Record the cause, stop reading, and keep what
+        // accumulated. (roast API-01)
+        let mut stream_error: Option<String> = None;
+
         for line in reader.lines() {
-            let line =
-                line.map_err(|e| RuntimeError::new(format!("Ollama stream read failed: {e}")))?;
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    stream_error = Some(format!("Ollama stream read failed: {e}"));
+                    break;
+                }
+            };
             if line.trim().is_empty() {
                 continue;
             }
-            let chunk: Value = serde_json::from_str(&line)
-                .map_err(|e| RuntimeError::new(format!("Ollama stream parse failed: {e}")))?;
+            let chunk: Value = match serde_json::from_str(&line) {
+                Ok(c) => c,
+                Err(e) => {
+                    stream_error = Some(format!("Ollama stream parse failed: {e}"));
+                    break;
+                }
+            };
 
             if let Some(err) = chunk.get("error").and_then(Value::as_str) {
                 return Err(RuntimeError::new(format!("Ollama error: {err}")));
@@ -1006,6 +1022,18 @@ impl OllamaApiClient {
                 .and_then(Value::as_str)
                 .map_or_else(|| format!("call_{idx}"), String::from);
             events.push(AssistantEvent::ToolUse { id, name, input });
+        }
+        // Only a stream that produced NOTHING is a hard error. Otherwise carry
+        // the truncation cause so the turn is recorded as partial rather than
+        // silently passing as complete.
+        if let Some(err) = stream_error {
+            if events.is_empty() {
+                return Err(RuntimeError::new(err));
+            }
+            events.push(AssistantEvent::StreamMeta {
+                finish_reason: Some(format!("stream_error: {err}")),
+                reasoning_chars: 0,
+            });
         }
         events.push(AssistantEvent::Usage(TokenUsage {
             input_tokens,
@@ -1075,9 +1103,18 @@ impl OllamaApiClient {
         let mut finish_reason: Option<String> = None;
         let mut reasoning_chars: usize = 0;
 
+        // Same rule as the Ollama reader: never `?` away a turn the user has
+        // already read off the screen. (roast API-01)
+        let mut stream_error: Option<String> = None;
+
         for line in reader.lines() {
-            let line =
-                line.map_err(|e| RuntimeError::new(format!("SSE stream read failed: {e}")))?;
+            let line = match line {
+                Ok(l) => l,
+                Err(e) => {
+                    stream_error = Some(format!("SSE stream read failed: {e}"));
+                    break;
+                }
+            };
             let line = line.trim();
             if line.is_empty() {
                 continue;
@@ -1092,8 +1129,13 @@ impl OllamaApiClient {
                 break;
             }
 
-            let chunk: Value = serde_json::from_str(payload)
-                .map_err(|e| RuntimeError::new(format!("SSE stream parse failed: {e}")))?;
+            let chunk: Value = match serde_json::from_str(payload) {
+                Ok(c) => c,
+                Err(e) => {
+                    stream_error = Some(format!("SSE stream parse failed: {e}"));
+                    break;
+                }
+            };
 
             // Errors can arrive mid-stream as a `data:` chunk; surface them the
             // same way `parse_openai_response` does.
@@ -1224,8 +1266,20 @@ impl OllamaApiClient {
             };
             events.push(AssistantEvent::ToolUse { id, name, input });
         }
+        // A stream that broke mid-flight and produced nothing at all is still a
+        // hard error; one that produced text or tool calls is a PARTIAL turn,
+        // and the cause replaces `finish_reason` so it reaches the same
+        // diagnosis path the empty-turn work built.
+        if let Some(err) = &stream_error {
+            if events.is_empty() {
+                return Err(RuntimeError::new(err.clone()));
+            }
+        }
         events.push(AssistantEvent::StreamMeta {
-            finish_reason,
+            finish_reason: match stream_error {
+                Some(err) => Some(format!("stream_error: {err}")),
+                None => finish_reason,
+            },
             reasoning_chars,
         });
         events.push(AssistantEvent::Usage(TokenUsage {
@@ -2267,6 +2321,40 @@ mod tests {
     }
 
     #[test]
+    fn stream_keeps_a_partial_turn_when_a_line_is_malformed() {
+        // Roast API-01: the reader used to `?` out on a parse failure, throwing
+        // away `accumulated_text` — but the text callback has ALREADY fired, so
+        // the user has read the answer. Keep it, and say why it stopped.
+        let client = OllamaApiClient::new("test", json!([]));
+        let stream = fake_stream(&[
+            r#"{"message":{"role":"assistant","content":"Hello"},"done":false}"#,
+            "{not json at all",
+        ]);
+        let events = client.consume_stream_lines(stream).unwrap();
+        match &events[0] {
+            AssistantEvent::TextDelta(t) => assert_eq!(t, "Hello"),
+            other => panic!("expected the text to survive, got {other:?}"),
+        }
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AssistantEvent::StreamMeta { finish_reason: Some(r), .. }
+                    if r.starts_with("stream_error:")
+            )),
+            "truncation cause must be reported, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn stream_with_nothing_accumulated_is_still_an_error() {
+        // The other half of the rule: if the stream produced NOTHING, there is
+        // no turn to preserve and the failure must stay hard.
+        let client = OllamaApiClient::new("test", json!([]));
+        let stream = fake_stream(&["{not json at all"]);
+        assert!(client.consume_stream_lines(stream).is_err());
+    }
+
+    #[test]
     fn stream_text_only_single_chunk() {
         let client = OllamaApiClient::new("test", json!([]));
         let stream = fake_stream(&[
@@ -2446,6 +2534,35 @@ mod tests {
 
     fn fake_sse(lines: &[&str]) -> Cursor<Vec<u8>> {
         Cursor::new(lines.join("\n").into_bytes())
+    }
+
+    #[test]
+    fn sse_keeps_a_partial_turn_when_a_frame_is_malformed() {
+        // Roast API-01, compat side. A proxy closing the body mid-frame, a model
+        // swap, LM Studio being killed — the user sees a complete answer and the
+        // session used to record nothing at all.
+        let client = OllamaApiClient::new("test", json!([]));
+        let stream = fake_sse(&[
+            r#"data: {"choices":[{"delta":{"content":"hi"}}]}"#,
+            r"data: {broken",
+        ]);
+        let events = client.consume_sse_lines(stream).unwrap();
+        assert!(matches!(&events[0], AssistantEvent::TextDelta(t) if t == "hi"));
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AssistantEvent::StreamMeta { finish_reason: Some(r), .. }
+                    if r.starts_with("stream_error:")
+            )),
+            "truncation cause must be reported, got {events:?}"
+        );
+    }
+
+    #[test]
+    fn sse_with_nothing_accumulated_is_still_an_error() {
+        let client = OllamaApiClient::new("test", json!([]));
+        let stream = fake_sse(&[r"data: {broken"]);
+        assert!(client.consume_sse_lines(stream).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Roast 2026-08-02, card **API-01** (CRITICAL).

Both stream readers used `?` on a read or parse failure, discarding `accumulated_text` and the entire tool-call map. By that point `text_callback` has **already fired for every delta** — in the REPL the answer is written to stdout and flushed, so **the user has read it**.

LM Studio being killed, a model swap, or a proxy closing the body mid-frame therefore produced a complete, correct-looking answer that the session recorded as **nothing at all**. If the failure landed after a tool-call delta, a `write_file` the model had already decided on was dropped silently.

### The fix

Both readers record the cause and `break` instead of returning. What accumulated is kept, and the cause rides on `StreamMeta.finish_reason` as `stream_error: …`, so a truncated turn reaches the **same diagnosis path the empty-turn work (#225) built** rather than passing as complete.

A stream that produced nothing at all is **still a hard error** — there is no turn to preserve.

### Scope

Applies to **read and parse** failures on both transports. The explicit backend-error arms (`chunk.error` on Ollama, `/error/message` on compat) still return `Err` — those are clean semantic errors that normally arrive before any content, and changing them would turn a real backend failure into a successful turn. Worth a follow-up if we ever see one land mid-content.

### Coverage

Four new tests, two per transport: the partial turn survives with its cause reported, and an empty stream still errors.

Power verified by reverting **each transport's production hunk on its own** — each time the matching partial-turn test fails at its `.unwrap()`, because the reader is back to `?`-ing the turn away.

### Gate

`cargo fmt --all` clean · `cargo clippy --all-targets --no-deps -- -D warnings` rc 0 · `cargo test -p claudette --lib` **1149 passed / 0 failed** (baseline 1145 + 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
