### PR TITLE
fix(lint): satisfy two clippy lints new in Rust 1.98

### DIFF
--- a/crates/claudette/src/api.rs
+++ b/crates/claudette/src/api.rs
@@ -503,12 +503,10 @@ pub fn probe_ollama() -> Result<String, String> {
         );
     }
 
-    let skip_ollama_flag = std::env::var("CLAUDETTE_SKIP_OLLAMA_PROBE")
-        .ok()
-        .is_some_and(|v| !v.is_empty() && v != "0");
-    let skip_lm_studio_flag = std::env::var("CLAUDETTE_SKIP_LM_STUDIO_PROBE")
-        .ok()
-        .is_some_and(|v| !v.is_empty() && v != "0");
+    let skip_ollama_flag =
+        std::env::var("CLAUDETTE_SKIP_OLLAMA_PROBE").is_ok_and(|v| !v.is_empty() && v != "0");
+    let skip_lm_studio_flag =
+        std::env::var("CLAUDETTE_SKIP_LM_STUDIO_PROBE").is_ok_and(|v| !v.is_empty() && v != "0");
     if skip_ollama_flag || (openai_compat && skip_lm_studio_flag) {
         return Ok(url);
     }
@@ -694,8 +692,7 @@ impl OllamaApiClient {
         let text = resp.text().unwrap_or_default();
 
         let retry_disabled = std::env::var("CLAUDETTE_DISABLE_MODEL_RELOAD_RETRY")
-            .ok()
-            .is_some_and(|v| !v.is_empty() && v != "0");
+            .is_ok_and(|v| !v.is_empty() && v != "0");
 
         if retry_disabled || !is_model_reload_transient(status, &text) {
             return Err(RuntimeError::new(format!(

--- a/crates/claudette/src/egress.rs
+++ b/crates/claudette/src/egress.rs
@@ -139,9 +139,7 @@ pub const INTEGRATION_NET_TOOLS: &[&str] = &[];
 /// `CLAUDETTE_ALLOW_REMOTE_OLLAMA`, and the skip-probe flags.
 #[must_use]
 pub fn is_offline() -> bool {
-    std::env::var(OFFLINE_ENV)
-        .ok()
-        .is_some_and(|v| !v.is_empty() && v != "0")
+    std::env::var(OFFLINE_ENV).is_ok_and(|v| !v.is_empty() && v != "0")
 }
 
 /// The allow-list, as host strings, for display in `--doctor`. Order: loopback

--- a/crates/claudette/src/recall.rs
+++ b/crates/claudette/src/recall.rs
@@ -183,9 +183,8 @@ pub fn decode_vec_into(bytes: &[u8], dst: &mut Vec<f32>) -> Result<(), String> {
     }
     dst.clear();
     dst.reserve(bytes.len() / 4);
-    for chunk in bytes.chunks_exact(4) {
-        let arr: [u8; 4] = chunk.try_into().expect("chunks_exact yields 4-byte slices");
-        dst.push(f32::from_le_bytes(arr));
+    for arr in bytes.as_chunks::<4>().0 {
+        dst.push(f32::from_le_bytes(*arr));
     }
     Ok(())
 }

--- a/crates/claudette/src/tools.rs
+++ b/crates/claudette/src/tools.rs
@@ -1919,8 +1919,7 @@ mod tests {
         // closure-ish scope. Skip if cwd happens to be inside `ws` (rare
         // but possible if a test runner roots itself in the temp dir).
         let cwd_inside_ws = std::env::current_dir()
-            .ok()
-            .is_some_and(|c| normalize_path(&c).starts_with(normalize_path(&ws)));
+            .is_ok_and(|c| normalize_path(&c).starts_with(normalize_path(&ws)));
 
         let assert_result = if cwd_inside_ws {
             // The helper deliberately returns None when cwd is inside the

--- a/crates/claudette/src/tools/post_edit_check.rs
+++ b/crates/claudette/src/tools/post_edit_check.rs
@@ -58,8 +58,7 @@ pub(crate) struct CheckCmd {
 /// Unset or anything else → `false`. Default is OFF.
 pub(crate) fn enabled() -> bool {
     std::env::var(CHECK_ENV)
-        .ok()
-        .is_some_and(|v| matches!(v.to_ascii_lowercase().trim(), "1" | "true" | "yes" | "on"))
+        .is_ok_and(|v| matches!(v.to_ascii_lowercase().trim(), "1" | "true" | "yes" | "on"))
 }
 
 /// Returns the configured timeout in seconds, clamped to `1..=120`.
@@ -217,8 +216,7 @@ pub(crate) fn ruff_on_path() -> bool {
     std::process::Command::new("ruff")
         .arg("--version")
         .output()
-        .ok()
-        .is_some_and(|out| out.status.success())
+        .is_ok_and(|out| out.status.success())
 }
 
 /// Truncate raw output to the first `MAX_OUTPUT_LINES` lines, then cut at


### PR DESCRIPTION
Rust 1.98 promoted two lints to warn-by-default. Because CI runs clippy with `-D warnings`, every job went red on contact — **including PRs whose diffs cannot touch Rust at all**:

- #248 — an `editor/vscode` lockfile + `package.json` bump
- #247 — a `Swatinem/rust-cache` SHA bump

Neither branch changed a line of Rust, so this is toolchain drift, not a regression in either PR. Both stay blocked until this lands.

### `manual_is_variant_and` — 7 sites

`.ok().is_some_and(f)` on a `Result` is exactly `.is_ok_and(f)`; the rewrite is identity-preserving.

| File | Sites |
|---|---|
| `api.rs` | 3 |
| `post_edit_check.rs` | 2 |
| `egress.rs` | 1 |
| `tools.rs` | 1 (test-only) |

`is_ok_and` was **already** the idiom in `doctor.rs`, `env_config.rs`, `run/runtime_build.rs`, and `shell.rs`, so this makes the codebase consistent rather than introducing a new style.

### `chunks_exact_to_as_chunks` — 1 site

`recall.rs::decode_vec_into` already rejects any input whose length is not a multiple of 4, so the `chunks_exact(4)` remainder was always empty and the `try_into().expect("chunks_exact yields 4-byte slices")` could never fire. `as_chunks::<4>()` yields `&[u8; 4]` directly, so the fix also **removes an unreachable panic path** that still had to be read and trusted.

### MSRV

`as_chunks` is stable as of **1.88**, matching the declared `rust-version`. Verified rather than assumed:

```
cargo +1.88 check --workspace --all-targets   # clean
```

### Verification

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (local 1.95; the new lints only exist on 1.98, so CI is the real check here)
- `cargo test -p claudette --lib` — **1145 passed, 0 failed**, matching the baseline on `main`
- **Test power:** the `is_ok_and` rewrites are identity-equivalent by definition, but the `as_chunks` change carries real semantics, so I injected a fault (`from_le_bytes` → `from_be_bytes`) and confirmed 3 tests fail — `encode_decode_roundtrip`, `results_are_sorted_descending_by_score`, `store_roundtrip_indexes_and_queries` — then restored and re-ran green.