### PR TITLE
chore: land the pending REPL commit, backfill the changelog, repair stale doc links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ prior discussion; feature proposals work best as an issue first.
 Rust. Single binary, one local model (LM Studio or Ollama), four
 interfaces (REPL, one-shot, TUI, Telegram bot). It also carries a
 personal-assistant surface (notes, calendar, voice), but the coding
-agent is the core. See [`docs/comparison.md`](docs/comparison.md) for
+agent is the core. See [`docs/comparison.md`](../docs/comparison.md) for
 where Claudette sits relative to other agents.
 
 **What Claudette isn't going to become:** a hosted SaaS, a plugin
@@ -32,7 +32,7 @@ cargo build --release
 ```
 
 You'll need Ollama running locally for any end-to-end testing. See
-[`docs/hardware.md`](docs/hardware.md) for model requirements.
+[`docs/hardware.md`](../docs/hardware.md) for model requirements.
 
 ## Before you open a PR
 
@@ -89,7 +89,7 @@ existing history is the style guide.
    covering a known failure mode (missing parameter, invalid JSON,
    boundary condition).
 
-Document the group in [`docs/architecture.md`](docs/architecture.md)'s
+Document the group in [`docs/architecture.md`](../docs/architecture.md)'s
 "Tool groups" table so users can discover it.
 
 ## Adding a new tool group — permission tier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,31 @@ bumps are non-breaking bugfixes only.
 
 ## [Unreleased]
 
+### Security
+
+- **`--offline` no longer leaks the conversation to `$HTTP_PROXY`.**
+  `egress::is_allowed_host` vetted the host in the URL, but reqwest defaults to
+  `auto_sys_proxy: true` and hyper-util's proxy matcher has no loopback bypass,
+  so a loopback URL passed the guard and the socket still went to the system
+  proxy — carrying the whole system prompt and conversation with it, while the
+  "offline mode" banner was on screen. This also silently broke the *default*
+  posture: on any machine with a corporate proxy, traffic meant for the local
+  model backend was routed off-box. Proxy use is now decided per-request
+  alongside the host check rather than by reqwest's ambient default.
+
+- **Dev-dependency advisories cleared in the VS Code extension** (`fast-uri`,
+  `js-yaml`, `brace-expansion`, `linkify-it` and others in
+  `editor/vscode/package-lock.json`). Build-time only — the shipped Rust binary
+  never depended on them.
+
 ### Added
+
+- **A real line editor at the REPL prompt.** Input was a bare
+  `stdin().read_line`, so pressing Up printed `^[[A`. Adds history across
+  sessions in `~/.claudette/repl_history` (500 entries, consecutive duplicates
+  collapsed), cursor movement (arrows, Ctrl+A/E/B/F, Home/End), Ctrl+W
+  word-delete, Ctrl+U/Ctrl+K line-kill, and Ctrl+C to abandon a line without
+  losing the session.
 
 - **Multi-line prompts over a pipe.** A piped line reading exactly
   `<<<CLAUDETTE-PROMPT` opens a block that runs as **one turn** when a line
@@ -33,6 +57,78 @@ bumps are non-breaking bugfixes only.
   A run also warns at startup about files dense with chat-template control
   tokens (e.g. `api/harmony.rs`), which reliably provoke content-less batches —
   exclude them if the flake cost isn't worth the coverage.
+
+### Fixed
+
+- **`apply_diff` corrupted files while reporting `ok: true`.** Three distinct
+  bugs in the indentation logic that exists specifically to prevent whitespace
+  corruption: the replacement's indent was taken from the matched window's
+  first line, so a window starting on a blank line re-based the whole block to
+  column 0 (a Python method stopped being a method, YAML keys hoisted to
+  document root); the ambiguity guard rejected only a zero-length `before`, so
+  `"   "` or `"\n"` trimmed to `""` and matched any blank line; and an
+  already-correctly-indented `after` was rebased onto itself, rewriting the
+  interior of multi-line string literals and heredocs and changing a string's
+  runtime value. The rule is now **align or refuse** — an `after` already at the
+  window's indent is spliced verbatim, and an indent that cannot be related to
+  the block's anchor is an error rather than an invention.
+
+- **`/undo` was a no-op after `apply_diff`, `apply_patch` or `edit_file`.**
+  `snapshot_to_trash` had two production call sites; the three editors wrote to
+  a tmp file and renamed, leaving no pre-image, so `/undo` silently did nothing
+  and suggested `/undo one` — which then restored an unrelated older file.
+  All three now snapshot fail-closed: no pre-image, no write.
+
+- **`write_file` could overwrite an existing file with no prompt.** It was
+  registered `WorkspaceWrite`, so replacing an existing file was auto-allowed —
+  no `[y/N]`, no preview — while every other edit tool sits at
+  `DangerFullAccess`. Overwriting an existing file is an edit and is now gated
+  like one, with a diff preview showing what would be **lost** and the
+  line/byte delta. `write_file`, `edit_file` and `apply_patch` also now log
+  every file mutation instead of printing nothing.
+
+- **A post-edit check that timed out read as a pass.** `run_post_edit_check`
+  returned `Option<String>` and mapped both a timeout and a pass to `None`, so
+  on a slow or contended machine the check was killed at its 10s deadline and
+  the model saw a clean result for a file that was never verified. A check that
+  cannot evaluate its condition now says so.
+
+- **Content-less turns are diagnosed instead of guessed at.** A brain that
+  streams chain-of-thought in `delta.reasoning_content` spends it from the same
+  `num_predict` budget as the answer; when reasoning alone exhausted it, the
+  turn ended `finish_reason: "length"` with no content and the run aborted with
+  "assistant stream produced no content". The SSE parser read neither
+  `reasoning_content` nor `finish_reason`, so budget exhaustion and a genuinely
+  mute backend were indistinguishable. Now: the finish reason is read and
+  reported; an empty final turn *after* real work keeps the work already on
+  disk rather than discarding it; a cleanly-stopped silent turn is asked to
+  continue rather than retried byte-identically at a larger ceiling; and
+  because the runtime cannot tell "finished" from "abandoned mid-task", such a
+  turn is **flagged** rather than reported as a clean success.
+
+- **The tiered brain fallback no longer evicts the model you loaded.** A fresh
+  install has no `~/.claudette/models.toml`, so every new user got
+  `fallback_brain = qwen3.5:9b`; three consecutive tool errors were enough to
+  issue a request for a model the server does not have loaded, and LM Studio
+  JIT-loaded it — evicting the 13.6 GB model the user deliberately loaded. The
+  tiered design assumed Ollama on a small card and was never re-checked against
+  the LM Studio path.
+
+- **Unknown flags are rejected instead of sent to the model.** `parse_args`
+  pushed any unrecognised token into the prompt, so `claudette --setpu` printed
+  a chatty reply instead of an error — a typo in the first command the README
+  tells a new user to run looked like the tool working. Unknown flag-shaped
+  args now exit 2 with a Levenshtein "did you mean", after `--help`/`--version`
+  and before any subsystem. `--` ends flag parsing so a prompt may still start
+  with a dash.
+
+### Docs
+
+- **README leads with the Q56 benchmark** — 16 configs, 36 full runs, hidden
+  tests, no LLM judge — rather than with the agent.
+- **First-run drift corrected** in the paths a new user actually walks.
+- **Repo root tidied** so the README is reachable; `CODE_OF_CONDUCT.md`,
+  `CONTRIBUTING.md` and the issue/PR templates now live under `.github/`.
 
 ## [0.17.0] - 2026-07-19
 
@@ -2136,7 +2232,7 @@ behaviour or documents it more accurately.
 
 Claudette grew from a reactive chatbot into a proactive personal
 life agent. The sprint plan lives at
-[`docs/life_agent.md`](docs/life_agent.md); phases 1-4
+[`docs/life_agent.md`](docs/archive/life_agent.md); phases 1-4
 and 6 landed in v0.2.0, phase 5 (Gmail write) is deferred to a later
 release.
 
@@ -2256,14 +2352,14 @@ release.
 
 ### Docs
 
-- [`docs/life_agent.md`](docs/life_agent.md) — full
+- [`docs/life_agent.md`](docs/archive/life_agent.md) — full
   sprint plan with architecture decisions AD-1 through AD-6.
 - [`docs/google_setup.md`](docs/google_setup.md) — end-to-end Google
   Cloud Console setup covering both Calendar and Gmail scopes with
   separate `--auth-google` invocations.
 - [`docs/comparison.md`](docs/comparison.md) — honest positioning
   against opencode, Aider, OpenHands, Cline, Continue.
-- [`examples/`](examples/) — six scenario walkthroughs (quick tour,
+- [`examples/`](crates/claudette/examples/) — six scenario walkthroughs (quick tour,
   tool groups, Telegram setup, morning briefing, code generation,
   brain100 harness) with real transcript output from `qwen3.5:4b`
   runs on a 3060 Ti.
@@ -2272,13 +2368,13 @@ release.
 
 ### Community files
 
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — full contribution guide
+- [`CONTRIBUTING.md`](.github/CONTRIBUTING.md) — full contribution guide
   (setup, required checks, commit style, tool-adding how-to, permission
   tier guidance).
-- [`SECURITY.md`](SECURITY.md) — private vulnerability-reporting flow
+- [`SECURITY.md`](.github/SECURITY.md) — private vulnerability-reporting flow
   via GitHub security advisories; scope, threat model, response
   timeline.
-- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — short "be kind" rules
+- [`CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md) — short "be kind" rules
   of engagement for the project space.
 
 ### Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ bumps are non-breaking bugfixes only.
 
 ### Added
 
+- **Multi-line prompts over a pipe.** A piped line reading exactly
+  `<<<CLAUDETTE-PROMPT` opens a block that runs as **one turn** when a line
+  reading exactly `CLAUDETTE-PROMPT>>>` closes it. Without this, piped input is
+  one line per turn, so a prompt containing newlines silently became several
+  turns — with a blank line skipped and a line reading `exit` ending the
+  session — and there was no other way in (`Event::Paste` strips newlines and
+  only fires under raw mode, one-shot carries newlines on argv but has no
+  permission prompter, and no slash command reads a file into a turn). Line
+  endings inside a block are normalised to `\n`, blank lines are kept, an
+  unterminated block is an error rather than a partial prompt, and blocks are
+  kept out of `repl_history`. Interactive input is untouched. See
+  [docs/usage.md](docs/usage.md).
+
 - **`--research` scope control.** `CLAUDETTE_RESEARCH_EXCLUDE` skips
   comma-separated paths / directory names (bare names match at any depth; paths
   with a slash match that subtree), on top of a built-in `docs/archive` default

--- a/crates/claudette/examples/03-telegram-setup.md
+++ b/crates/claudette/examples/03-telegram-setup.md
@@ -6,7 +6,7 @@ local agent with voice in and voice out.
 
 ## Prerequisites
 
-- Claudette built and on `PATH` (see main [`README.md`](../README.md)).
+- Claudette built and on `PATH` (see main [`README.md`](../../../README.md)).
 - Ollama running locally with your chosen models pulled.
 - A Telegram account.
 
@@ -90,7 +90,7 @@ Bot:    You have 3 events scheduled this week:
 ```
 
 (This assumes you've already authorised the Calendar scope — see
-[`../docs/google_setup.md`](../docs/google_setup.md).)
+[`docs/google_setup.md`](../../../docs/google_setup.md).)
 
 ## 5. Restricting to specific chats
 

--- a/crates/claudette/examples/04-morning-briefing.md
+++ b/crates/claudette/examples/04-morning-briefing.md
@@ -9,7 +9,7 @@ anything urgent. Nothing to click; it arrives in Telegram.
 - Telegram bot set up and receiving messages (see
   [`03-telegram-setup.md`](03-telegram-setup.md)).
 - Google Calendar OAuth authorised (see
-  [`../docs/google_setup.md`](../docs/google_setup.md)).
+  [`docs/google_setup.md`](../../../docs/google_setup.md)).
 - Bot running persistently on a host that stays awake (your laptop
   won't fire briefings while its lid is closed).
 
@@ -101,7 +101,7 @@ Useful for testing the pipeline end-to-end before committing to the
 ## 6. Under the hood — the three-producer loop
 
 The scheduler is one piece of a single-consumer / two-producer `mpsc`
-pattern (see [`../docs/life_agent.md`](../docs/life_agent.md)
+pattern (see [`docs/archive/life_agent.md`](../../../docs/archive/life_agent.md)
 AD-1). Events go through one channel:
 
 - Telegram poller produces `Event::TgUpdate` (user messages).

--- a/crates/claudette/examples/05-brain-regression-harness.md
+++ b/crates/claudette/examples/05-brain-regression-harness.md
@@ -138,5 +138,5 @@ Brain100 pass rate is **not the same** as SWE-bench. The harness is
 pattern-matching on short-horizon tool-using prompts; SWE-bench is
 real task resolution on real repos. Claudette's 94% here doesn't
 translate to a 94% SWE-bench number (and we haven't run SWE-bench
-yet). See [`../docs/comparison.md`](../docs/comparison.md) for how
+yet). See [`docs/comparison.md`](../../../docs/comparison.md) for how
 Claudette positions against SWE-agent tooling.

--- a/crates/claudette/examples/README.md
+++ b/crates/claudette/examples/README.md
@@ -1,7 +1,7 @@
 # Examples
 
 Short, scenario-focused walkthroughs to complement the main
-[`README.md`](../README.md). Each file stands on its own — pick the
+[`README.md`](../../../README.md). Each file stands on its own — pick the
 one that matches what you want to do.
 
 Most examples include real output captured from Claudette running the
@@ -21,7 +21,7 @@ hardware, Ollama version, and model temperature.
 
 - All example commands assume Claudette is built and on `PATH`. If
   you haven't done that yet, follow the build steps in the main
-  [`README.md`](../README.md#quick-start).
+  [`README.md`](../../../README.md#quick-start).
 - Output blocks are tagged `▸` for tool invocations and `⚡` for the
   per-turn usage footer — both are exactly what Claudette prints.
 - Where a transcript shows a Telegram chat ID, it's always a

--- a/crates/claudette/src/run/line_editor.rs
+++ b/crates/claudette/src/run/line_editor.rs
@@ -314,13 +314,87 @@ pub(crate) fn action_for(key: KeyEvent) -> EditAction {
     }
 }
 
+/// Sentinels that let *piped* input carry a multi-line prompt as one turn.
+///
+/// The piped branch of [`LineEditor::read_line`] is one `read_line` per turn,
+/// which is right for a human at a keyboard and wrong for any program feeding
+/// Claudette a prompt containing newlines: line two becomes turn two, a blank
+/// line inside the prompt is skipped by the REPL loop, and a line reading
+/// `exit` ends the session. There was no other way in — `Event::Paste` strips
+/// newlines and only fires under raw mode, one-shot carries newlines on argv
+/// but has no permission prompter, and no slash command reads a file into a
+/// turn.
+///
+/// So: a piped line that is exactly [`MULTILINE_OPEN`] opens a block, and every
+/// line up to one that is exactly [`MULTILINE_CLOSE`] is joined with `\n` and
+/// returned as a single [`ReadOutcome::Line`]. Interactive input never sees
+/// this — raw mode reads key events, not lines.
+///
+/// Hyphenated deliberately: `main.rs`'s doc-drift guard scans `src/` for
+/// `CLAUDETTE_` followed by capitals, and an underscored sentinel reads to it
+/// as an undocumented env var. It is not one, and should not look like one.
+const MULTILINE_OPEN: &str = "<<<CLAUDETTE-PROMPT";
+const MULTILINE_CLOSE: &str = "CLAUDETTE-PROMPT>>>";
+
 /// What one `read_line` call produced.
+#[derive(Debug)]
 pub(crate) enum ReadOutcome {
     Line(String),
     /// Ctrl+C: prompt again without running a turn.
     Interrupted,
     /// Ctrl+D on an empty line, or EOF on piped input.
     Eof,
+}
+
+/// One turn's worth of piped input: a plain line, or a sentinel-delimited
+/// multi-line block joined with `\n`.
+///
+/// Line endings are normalised to `\n`. The block is prompt *content*, often a
+/// code body the model is asked to reproduce, and a CRLF that survives into it
+/// corrupts the answer without ever looking wrong.
+///
+/// An unterminated block is an error, never a partial prompt. A truncated pipe
+/// has to be loud here, because half a prompt still produces a fluent answer.
+fn read_piped_turn(input: &mut impl io::BufRead) -> io::Result<ReadOutcome> {
+    let mut first = String::new();
+    if input.read_line(&mut first)? == 0 {
+        return Ok(ReadOutcome::Eof);
+    }
+    if strip_eol(&first) != MULTILINE_OPEN {
+        return Ok(ReadOutcome::Line(first));
+    }
+
+    let mut block = String::new();
+    let mut empty = true;
+    loop {
+        let mut line = String::new();
+        if input.read_line(&mut line)? == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "multi-line prompt opened with `{MULTILINE_OPEN}` reached end \
+                     of input before its closing `{MULTILINE_CLOSE}`"
+                ),
+            ));
+        }
+        let body = strip_eol(&line);
+        if body == MULTILINE_CLOSE {
+            return Ok(ReadOutcome::Line(block));
+        }
+        // Tracked separately from `block.is_empty()` so a prompt that opens
+        // with a blank line keeps it.
+        if !empty {
+            block.push('\n');
+        }
+        empty = false;
+        block.push_str(body);
+    }
+}
+
+/// Strip one trailing line terminator, CRLF or LF, and nothing else.
+fn strip_eol(line: &str) -> &str {
+    line.strip_suffix('\n')
+        .map_or(line, |l| l.strip_suffix('\r').unwrap_or(l))
 }
 
 /// Owns the history list and its backing file.
@@ -350,7 +424,13 @@ impl LineEditor {
     /// holding Up doesn't walk through the same command repeatedly.
     pub(crate) fn push_history(&mut self, line: &str) {
         let line = line.trim();
-        if line.is_empty() || self.history.last().map(String::as_str) == Some(line) {
+        // A multi-line block (piped, sentinel-delimited) is deliberately not
+        // recalled: Up restores into a single-line buffer, and the history file
+        // is one entry per line, so storing it would corrupt both.
+        if line.is_empty()
+            || line.contains('\n')
+            || self.history.last().map(String::as_str) == Some(line)
+        {
             return;
         }
         self.history.push(line.to_string());
@@ -368,11 +448,8 @@ impl LineEditor {
     /// occupy no columns).
     pub(crate) fn read_line(&mut self, prompt: &str, prompt_width: u16) -> io::Result<ReadOutcome> {
         if !self.interactive {
-            let mut buf = String::new();
-            return match io::stdin().read_line(&mut buf)? {
-                0 => Ok(ReadOutcome::Eof),
-                _ => Ok(ReadOutcome::Line(buf)),
-            };
+            let stdin = io::stdin();
+            return read_piped_turn(&mut stdin.lock());
         }
         self.read_line_raw(prompt, prompt_width)
     }
@@ -720,5 +797,121 @@ mod tests {
         let path = std::env::temp_dir().join("claudette-nonexistent-history-file");
         let _ = std::fs::remove_file(&path);
         assert!(load_history(&path).is_empty());
+    }
+
+    // --- piped input: the multi-line prompt path ---
+
+    fn piped(input: &str) -> io::Result<ReadOutcome> {
+        read_piped_turn(&mut input.as_bytes())
+    }
+
+    fn line_of(outcome: ReadOutcome) -> String {
+        match outcome {
+            ReadOutcome::Line(l) => l,
+            ReadOutcome::Interrupted => panic!("expected a line, got Interrupted"),
+            ReadOutcome::Eof => panic!("expected a line, got Eof"),
+        }
+    }
+
+    #[test]
+    fn a_plain_piped_line_is_unchanged_by_the_sentinel_path() {
+        // Including its trailing newline: the REPL trims, and the old
+        // behaviour is what every existing piped caller was built against.
+        assert_eq!(line_of(piped("write a haiku\n").unwrap()), "write a haiku\n");
+    }
+
+    #[test]
+    fn empty_input_is_eof() {
+        assert!(matches!(piped("").unwrap(), ReadOutcome::Eof));
+    }
+
+    #[test]
+    fn a_sentinel_block_becomes_one_line_joined_with_newlines() {
+        let got = line_of(
+            piped(&format!(
+                "{MULTILINE_OPEN}\nfirst\nsecond\nthird\n{MULTILINE_CLOSE}\n"
+            ))
+            .unwrap(),
+        );
+        assert_eq!(got, "first\nsecond\nthird");
+    }
+
+    #[test]
+    fn crlf_in_a_block_is_normalised_to_lf() {
+        let got = line_of(
+            piped(&format!(
+                "{MULTILINE_OPEN}\r\nfirst\r\nsecond\r\n{MULTILINE_CLOSE}\r\n"
+            ))
+            .unwrap(),
+        );
+        assert_eq!(got, "first\nsecond", "no CR survives into prompt content");
+    }
+
+    #[test]
+    fn blank_lines_inside_a_block_are_content_including_a_leading_one() {
+        let got = line_of(
+            piped(&format!(
+                "{MULTILINE_OPEN}\n\nfirst\n\nsecond\n{MULTILINE_CLOSE}\n"
+            ))
+            .unwrap(),
+        );
+        // The REPL loop skips a blank *line*; inside a block it is a blank
+        // line of the prompt, which is the whole point.
+        assert_eq!(got, "\nfirst\n\nsecond");
+    }
+
+    #[test]
+    fn exit_inside_a_block_is_content_not_a_command() {
+        let got =
+            line_of(piped(&format!("{MULTILINE_OPEN}\nexit\nquit\n{MULTILINE_CLOSE}\n")).unwrap());
+        assert_eq!(got, "exit\nquit");
+    }
+
+    #[test]
+    fn the_reader_resumes_after_the_closing_sentinel() {
+        let input = format!("{MULTILINE_OPEN}\nblock\n{MULTILINE_CLOSE}\nnext turn\n");
+        let mut bytes = input.as_bytes();
+        assert_eq!(line_of(read_piped_turn(&mut bytes).unwrap()), "block");
+        assert_eq!(
+            line_of(read_piped_turn(&mut bytes).unwrap()),
+            "next turn\n",
+            "the turn after a block reads normally",
+        );
+    }
+
+    #[test]
+    fn an_unterminated_block_errors_rather_than_delivering_half_a_prompt() {
+        let err = piped(&format!("{MULTILINE_OPEN}\nfirst\nsecond\n")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains(MULTILINE_CLOSE),
+            "the error names the terminator that was missing: {err}",
+        );
+    }
+
+    #[test]
+    fn the_opener_must_match_exactly() {
+        // Trailing text, leading space, or a near-miss is an ordinary prompt.
+        for near in [
+            format!("{MULTILINE_OPEN} \n"),
+            format!(" {MULTILINE_OPEN}\n"),
+            format!("{MULTILINE_OPEN}x\n"),
+        ] {
+            let got = line_of(piped(&near).unwrap());
+            assert_eq!(got, near, "near-miss opener stays a plain line");
+        }
+    }
+
+    #[test]
+    fn history_refuses_a_multi_line_entry() {
+        let mut ed = LineEditor {
+            history: Vec::new(),
+            path: None,
+            interactive: false,
+        };
+        ed.push_history("first\nsecond");
+        assert!(ed.history.is_empty(), "a block would corrupt the history file");
+        ed.push_history("plain");
+        assert_eq!(ed.history, hist(&["plain"]));
     }
 }

--- a/crates/claudette/src/run/line_editor.rs
+++ b/crates/claudette/src/run/line_editor.rs
@@ -817,7 +817,10 @@ mod tests {
     fn a_plain_piped_line_is_unchanged_by_the_sentinel_path() {
         // Including its trailing newline: the REPL trims, and the old
         // behaviour is what every existing piped caller was built against.
-        assert_eq!(line_of(piped("write a haiku\n").unwrap()), "write a haiku\n");
+        assert_eq!(
+            line_of(piped("write a haiku\n").unwrap()),
+            "write a haiku\n"
+        );
     }
 
     #[test]
@@ -862,8 +865,12 @@ mod tests {
 
     #[test]
     fn exit_inside_a_block_is_content_not_a_command() {
-        let got =
-            line_of(piped(&format!("{MULTILINE_OPEN}\nexit\nquit\n{MULTILINE_CLOSE}\n")).unwrap());
+        let got = line_of(
+            piped(&format!(
+                "{MULTILINE_OPEN}\nexit\nquit\n{MULTILINE_CLOSE}\n"
+            ))
+            .unwrap(),
+        );
         assert_eq!(got, "exit\nquit");
     }
 
@@ -910,7 +917,10 @@ mod tests {
             interactive: false,
         };
         ed.push_history("first\nsecond");
-        assert!(ed.history.is_empty(), "a block would corrupt the history file");
+        assert!(
+            ed.history.is_empty(),
+            "a block would corrupt the history file"
+        );
         ed.push_history("plain");
         assert_eq!(ed.history, hist(&["plain"]));
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,6 +50,26 @@ When stdin or stderr isn't a terminal — piped input, CI, the eval battery —
 the editor steps aside and input is read plainly, so scripted use is
 unchanged.
 
+### Piping a multi-line prompt
+
+Piped input is one line per turn, which is a problem when the prompt itself
+contains newlines: line two would start a second turn, a blank line would be
+skipped, and a line reading `exit` would end the session. Wrap it in sentinels
+and the whole block arrives as a single turn:
+
+```bash
+{
+  echo '<<<CLAUDETTE-PROMPT'
+  cat task.md
+  echo 'CLAUDETTE-PROMPT>>>'
+} | claudette
+```
+
+Both sentinels must be alone on their line and match exactly; anything else is
+an ordinary prompt line. Line endings inside the block are normalised to `\n`,
+and blank lines are kept. A block that never closes is an error rather than a
+half-delivered prompt. The block is not added to `~/.claudette/repl_history`.
+
 ## Slash commands (REPL + TUI)
 
 ```


### PR DESCRIPTION
Repo-health pass, prompted by the repo starting to pick up outside traffic. Three commits, in the order they need reading.

### 1. `feat(repl): let piped input carry a multi-line prompt as one turn`

**This commit is @mrdushidush's, unpushed on local `main` since 2026-08-08.** It is carried here unchanged because branch protection makes a PR the only way it can land. Nothing about it was reviewed or altered.

### 2. `style(repl): rustfmt line_editor.rs`

That commit was never formatted, so `cargo fmt --all --check` fails on it — and `rustfmt` is a required check, so it could not have merged as it stood. Formatting only.

### 3. `docs: backfill the changelog since v0.17.0 and repair stale doc links`

**Changelog.** 38 of the 39 commits since `v0.17.0` never reached `CHANGELOG.md`. `[Unreleased]` listed one entry while `main` had, among others:

- the `--offline` proxy leak (`is_allowed_host` vetted the URL host, but reqwest's `auto_sys_proxy` still sent the socket to `$HTTP_PROXY`),
- three `apply_diff` bugs that corrupted files while reporting `ok: true`,
- `write_file` overwriting an existing file with no prompt and no preview,
- `/undo` silently doing nothing after `apply_diff` / `apply_patch` / `edit_file`,
- a post-edit check that read a 10s timeout as a pass,
- the empty-turn cluster.

Backfilled under Security / Added / Fixed / Docs, written from the commit bodies so each entry says what broke, not just what the subject line said.

**Links.** 16 relative links across tracked markdown pointed at files that had moved, and 404 on github.com today:

| file | was | now |
|---|---|---|
| `.github/CONTRIBUTING.md` | `docs/*.md` (×3) | `../docs/*.md` |
| `crates/claudette/examples/*.md` | `../README.md`, `../docs/*` (×6) | `../../../…` |
| `CHANGELOG.md` history | `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `examples/`, `docs/life_agent.md` | `.github/…`, `crates/claudette/examples/`, `docs/archive/…` |

`.github/CONTRIBUTING.md` is the one that matters most — it is what a would-be contributor opens first, and all three of its doc links were dead.

### Gate

Run locally on **1.98.1**, matching CI's `dtolnay/rust-toolchain@stable` (the local default toolchain had drifted to 1.95 and was quietly a weaker gate than CI):

- `cargo fmt --all --check` — pass
- `cargo clippy --all-targets --no-deps -- -D warnings` — pass
- `cargo clippy --all-targets --all-features --no-deps -- -D warnings` — pass
- `cargo test -p claudette --lib` — **1155 passed, 0 failed, 6 ignored**
- broken-link scan over all 65 tracked markdown files, code fences excluded — **0 broken**

No source behaviour changes: commit 1 is @mrdushidush's, commit 2 is whitespace, commit 3 is markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBTQNHWbko1wpeBrcmL3de